### PR TITLE
Migrate manifest v2 to v3 - WIP: loading gapi is failing

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -1,12 +1,12 @@
 {
   "key": "fdnekjijeofacghkammknogmiapepano",
   "version": "7.4.0",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "short_name": "Bypass Links",
   "name": "Bypass Links",
   "author": "Amit Singh",
   "description": "Bypass links from various sites to required links.",
-  "browser_action": {
+  "action": {
     "default_icon": "bypass_link_on_128.png",
     "default_popup": "index.html",
     "default_title": "Bypass Links"
@@ -14,10 +14,12 @@
   "icons": {
     "128": "bypass_link_on_128.png"
   },
-  "permissions": ["storage", "tabs", "history", "<all_urls>"],
+  "permissions": ["storage", "tabs", "history"],
+  "host_permissions": ["<all_urls>"],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js"
   },
-  "content_security_policy": "script-src 'self' https://apis.google.com/ 'unsafe-eval'; object-src 'self'"
+  "content_security_policy": {
+    "extension_pages": "script-src 'self' ; object-src 'self'"
+  }
 }

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -37,7 +37,7 @@ const onStorageChange = (changedObj, storageType) => {
     const icon = isExtensionActive(extState.newValue)
       ? "bypass_link_on_128.png"
       : "bypass_link_off_128.png";
-    chrome.browserAction.setIcon({ path: icon });
+    chrome.action.setIcon({ path: icon });
   }
 };
 

--- a/src/utils/background.js
+++ b/src/utils/background.js
@@ -1,10 +1,10 @@
 import tabs from "ChromeApi/tabs";
 
 export const bypassSingleLinkOnPage = (selectorFn, tabId) => {
-  chrome.tabs.executeScript(
+  chrome.scripting.executeScript(
     tabId,
     {
-      code: `(${selectorFn})()`,
+      function: selectorFn,
       runAt: "document_end",
     },
     ([result] = []) => {

--- a/src/utils/bypass/bypassMedium.js
+++ b/src/utils/bypass/bypassMedium.js
@@ -20,10 +20,10 @@ export const bypassMedium = async (url, tabId) => {
     return;
   }
 
-  chrome.tabs.executeScript(
+  chrome.scripting.executeScript(
     tabId,
     {
-      code: `(${shouldBypass})()`,
+      function: shouldBypass,
       runAt: "document_end",
     },
     ([result] = []) => {

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -27,7 +27,7 @@ const commonConfig = {
     modules: [path.resolve(__dirname, "src"), "node_modules"],
   },
   stats: isProduction ? "normal" : "errors-warnings",
-  devtool: isProduction ? undefined : "eval-cheap-module-source-map",
+  devtool: isProduction ? undefined : "inline-source-map",
   performance: {
     hints: false,
   },


### PR DESCRIPTION
* On login, firebase loads [gapi](https://apis.google.com/js/api.js) for OAuth(I guess) and this is getting blocked due to [not able to run remote scripts](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-overview/#remotely-hosted-code).
* I suspect that if we resolve above, even then maybe firebase realtime db requests might fail.
* One more thing to consider is that login popup opens in an iframe(not sure) and this is prohibited(I guess) in manifest v3.