### PR TITLE
fix: adjust xo config for new xo version

### DIFF
--- a/xo.config.ts
+++ b/xo.config.ts
@@ -1,7 +1,8 @@
 import { type FlatXoConfig } from 'xo';
+import nextPlugin from '@next/eslint-plugin-next';
 // https://github.com/vercel/next.js/pull/78109
 // @ts-expect-error TODO: types will ship later
-import { flatConfig } from '@next/eslint-plugin-next';
+const { flatConfig } = nextPlugin;
 
 const xoConfig: FlatXoConfig = [
   {
@@ -60,6 +61,7 @@ const xoConfig: FlatXoConfig = [
     },
   },
   {
+    files: ['**/*.{ts,tsx}'],
     rules: {
       '@typescript-eslint/no-confusing-void-expression': [
         'error',


### PR DESCRIPTION
## Summary
- import `@next/eslint-plugin-next` via default export for xo v1.2
- restrict type-aware lint rules to TypeScript sources

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Error while loading rule '@typescript-eslint/no-confusing-void-expression' ...)*

------
https://chatgpt.com/codex/tasks/task_b_689f7b5b4e948328b506bc22c24888f4