### PR TITLE
test: re-enable LastVisitedButton tests with serial execution

### DIFF
--- a/apps/extension/tests/specs/last-visited-button.spec.ts
+++ b/apps/extension/tests/specs/last-visited-button.spec.ts
@@ -8,7 +8,7 @@ import { TEST_TIMEOUTS } from '../constants';
  * a website/domain. These tests run sequentially with shared browser context.
  */
 
-test.describe.skip('LastVisitedButton', () => {
+test.describe.serial('LastVisitedButton', () => {
   test('should update timestamp and show tooltip after clicking Visited button', async ({
     homePage,
   }) => {


### PR DESCRIPTION
## Summary
- Re-enabled the LastVisitedButton test suite by changing from `.skip` to `.serial`
- Tests will now run sequentially with shared browser context as designed

## Test plan
- [ ] LastVisitedButton tests run successfully with serial execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/amitsingh-007/bypass-links/pull/3813">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Re-enabled the `LastVisitedButton` test suite by changing from `.skip` to `.serial`, allowing tests to run sequentially with shared browser context as originally designed.

- Changed `test.describe.skip` to `test.describe.serial` on line 11
- Consistent with other test files in the codebase that use serial execution (e.g., `bookmarks.spec.ts`, `persons.spec.ts`, `quick-bookmark-button.spec.ts`)
- Tests were previously skipped in commit fdede490, and this PR re-enables them

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple one-line modification that re-enables a test suite using serial execution, which is a well-established pattern in this codebase. The `.serial` modifier ensures tests run sequentially rather than in parallel, which is appropriate for tests with shared state. No logic changes or potential runtime errors introduced.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->