### PR TITLE
test: add E2E test for extension latest version API

### DIFF
--- a/apps/extension/tests/specs/version-api.spec.ts
+++ b/apps/extension/tests/specs/version-api.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '../fixtures/auth-fixture';
+import { TEST_TIMEOUTS } from '../constants';
+
+test('should call extension.latest API and return expected response structure', async ({
+  page,
+  extensionId,
+  login: _login,
+}) => {
+  const apiPromise = page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/trpc/extension.latest') &&
+      response.status() === 200,
+    { timeout: TEST_TIMEOUTS.PAGE_OPEN }
+  );
+
+  await page.goto(`chrome-extension://${extensionId}/index.html`);
+  const apiResponse = await apiPromise;
+
+  const responseJson = await apiResponse.json();
+  const responseData = responseJson[0]?.result?.data;
+
+  expect(responseData).toBeDefined();
+  expect(responseData.chrome).toBeTruthy();
+
+  const { chrome: chromeData } = responseData;
+  expect(chromeData.version).toBeTruthy();
+  expect(chromeData.downloadLink).toBeTruthy();
+  expect(chromeData.date).toBeTruthy();
+});


### PR DESCRIPTION
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/amitsingh-007/bypass-links/pull/3821">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

 

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added E2E test to verify the `extension.latest` API endpoint returns the expected response structure with Chrome extension version information.

- Test validates API call to `/api/trpc/extension.latest` and checks for `chrome.version`, `chrome.downloadLink`, and `chrome.date` fields
- Test may fail intermittently due to conditional API call logic that checks if more than 1 hour has passed since last update check

<details><summary><h3>Confidence Score: 3/5</h3></summary>

- This PR is moderately safe to merge with potential test flakiness
- The test implementation is structurally sound but has a conditional dependency that could cause intermittent failures. The API call only executes when specific conditions are met (user signed in and more than 1 hour since last check), which may not be guaranteed in the test environment.
- Pay attention to `apps/extension/tests/specs/version-api.spec.ts` - the test may need adjustments to ensure the API is always called
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->