### PR TITLE
fix(persons): hide edit bookmark buttons in readonly web app

### DIFF
--- a/apps/extension/src/PersonsPanel/components/PersonsPanel.tsx
+++ b/apps/extension/src/PersonsPanel/components/PersonsPanel.tsx
@@ -134,7 +134,7 @@ function PersonsPanel() {
           <Persons
             scrollButton
             persons={filteredAndOrderedPersons}
-            bookmarkListProps={{ fullscreen: true }}
+            bookmarkListProps={{ fullscreen: true, showEditButton: true }}
             renderPerson={(person) => (
               <PersonVirtualCell
                 person={person}

--- a/apps/web/src/app/persons-panel/page.tsx
+++ b/apps/web/src/app/persons-panel/page.tsx
@@ -83,7 +83,7 @@ function PersonsPage() {
         {filteredAndOrderedPersons.length > 0 ? (
           <Persons
             persons={filteredAndOrderedPersons}
-            bookmarkListProps={{ fullscreen: false }}
+            bookmarkListProps={{ fullscreen: false, showEditButton: false }}
             renderPerson={(person) => <PersonVirtualCell person={person} />}
             onLinkOpen={onLinkOpen}
           />

--- a/apps/web/tests/page-object-models/persons-panel.ts
+++ b/apps/web/tests/page-object-models/persons-panel.ts
@@ -149,6 +149,15 @@ export class PersonsPanel {
     return this.page.getByPlaceholder('Search');
   }
 
+  getEditButtons(): Locator {
+    return this.getModal().getByTitle('Edit Bookmark');
+  }
+
+  async verifyEditButtonsHidden() {
+    const editButtons = this.getEditButtons();
+    await expect(editButtons).not.toBeVisible();
+  }
+
   private getModal(): Locator {
     return this.page.getByTestId('bookmarks-list-modal');
   }

--- a/apps/web/tests/specs/persons.spec.ts
+++ b/apps/web/tests/specs/persons.spec.ts
@@ -187,4 +187,14 @@ test.describe('Persons Panel', () => {
     const personNamesRestored = await panel.getPersonNames();
     expect(personNamesRestored).toEqual(personNamesBefore);
   });
+
+  test('should hide edit bookmark buttons in readonly web app', async ({
+    authenticatedPage,
+  }) => {
+    const panel = new PersonsPanel(authenticatedPage);
+
+    await panel.openPersonCard(TEST_PERSONS.JOHN_NATHAN);
+    await panel.verifyEditButtonsHidden();
+    await panel.closeModal();
+  });
 });

--- a/packages/shared/src/components/Persons/components/BookmarksList.tsx
+++ b/packages/shared/src/components/Persons/components/BookmarksList.tsx
@@ -32,6 +32,7 @@ interface Props {
   imageUrl: string;
   onLinkOpen: (url: string) => void;
   fullscreen: boolean;
+  showEditButton?: boolean;
 }
 
 function BookmarksList({
@@ -39,6 +40,7 @@ function BookmarksList({
   imageUrl,
   onLinkOpen,
   fullscreen,
+  showEditButton,
 }: Props) {
   const { location } = useContext(DynamicContext);
   const { getBookmarkFromHash, getFolderFromHash, getDefaultOrRootFolderUrls } =
@@ -142,15 +144,17 @@ function BookmarksList({
               styles.bookmarkContainer
             )}
           >
-            <ActionIcon
-              size="2rem"
-              title="Edit Bookmark"
-              color="red"
-              radius="xl"
-              onClick={() => handleBookmarkEdit(bookmark)}
-            >
-              <AiFillEdit size="1.125rem" />
-            </ActionIcon>
+            {showEditButton !== false && (
+              <ActionIcon
+                size="2rem"
+                title="Edit Bookmark"
+                color="red"
+                radius="xl"
+                onClick={() => handleBookmarkEdit(bookmark)}
+              >
+                <AiFillEdit size="1.125rem" />
+              </ActionIcon>
+            )}
             <Box className={styles.bookmarkWrapper}>
               <Bookmark
                 id={bookmark.id}

--- a/packages/shared/src/components/Persons/components/Persons.tsx
+++ b/packages/shared/src/components/Persons/components/Persons.tsx
@@ -22,7 +22,7 @@ interface Props {
   persons: IPerson[];
   onLinkOpen: (url: string) => void;
   scrollButton?: boolean;
-  bookmarkListProps: { fullscreen: boolean };
+  bookmarkListProps: { fullscreen: boolean; showEditButton?: boolean };
   renderPerson: (person: IPerson) => ReactNode;
 }
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,14 +6,13 @@ process.loadEnvFile(path.join(process.cwd(), '.env'));
 
 const ciBaseUrl = process.env.PLAYWRIGHT_TEST_BASE_URL;
 const isCI = Boolean(ciBaseUrl);
-const isVM = process.env.IS_VM === 'true'; // Manually set in .env for VM environments
 
 const config = defineConfig({
   globalTimeout: 30 * 60 * 1000,
   expect: { timeout: 5000 },
   forbidOnly: isCI,
   retries: isCI ? 2 : 1,
-  fullyParallel: !isVM,
+  fullyParallel: true,
   reporter: isCI ? [['github']] : [['list'], ['html', { open: 'never' }]],
   use: {
     navigationTimeout: 30 * 1000,


### PR DESCRIPTION
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/amitsingh-007/bypass-links/pull/3877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

 

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a `showEditButton` flag to the shared `BookmarksList`/`Persons` components to allow hiding the “Edit Bookmark” action in readonly contexts.
- Updates the web persons-panel page to disable the edit button, while keeping it enabled for the extension persons panel.
- Adds a Playwright page object helper + spec asserting edit buttons are hidden in the readonly web app.
- Adjusts Playwright runner configuration to run fully in parallel.

<details><summary><h3>Confidence Score: 3/5</h3></summary>

- Mostly safe to merge, but a couple of changes can cause test instability or environment-specific failures.
- The functional change (hiding edit buttons via a prop) is localized and low risk, but the Playwright config change forces full parallelism globally and the new test assertion can be flaky when the locator matches 0 elements. Addressing these should make the PR safer.
- playwright.config.ts; apps/web/tests/page-object-models/persons-panel.ts
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->