### PR TITLE
Fix Playwright service worker attachment failures in CI

### DIFF
--- a/apps/extension/tests/auth.setup.ts
+++ b/apps/extension/tests/auth.setup.ts
@@ -11,6 +11,7 @@ import {
   EXTENSION_STORAGE_PATH,
 } from './auth-constants';
 import { getExtensionPath } from './utils/extension-path';
+import { createSharedBackgroundSW } from './fixtures/base-fixture';
 import type { IAuthResponse } from '@/interfaces/firebase';
 import { getExpiresAtMs } from '@/store/firebase/utils';
 
@@ -63,10 +64,7 @@ setup('authenticate and cache extension storage', async () => {
     }
   );
 
-  let [background] = browserContext.serviceWorkers();
-  background ||= await browserContext.waitForEvent('serviceworker', {
-    timeout: 20_000,
-  });
+  const background = await createSharedBackgroundSW(browserContext);
   const extensionId = background.url().split('/')[2];
 
   await browserContext.addInitScript(

--- a/apps/extension/tests/fixtures/extension-fixture.ts
+++ b/apps/extension/tests/fixtures/extension-fixture.ts
@@ -9,6 +9,7 @@ import {
   type BrowserContext,
 } from '@playwright/test';
 import { getExtensionPath } from '../utils/extension-path';
+import { createSharedBackgroundSW } from './base-fixture';
 
 export const test = base.extend<{
   context: BrowserContext;
@@ -34,8 +35,7 @@ export const test = base.extend<{
     await fs.promises.rm(userDataDir, { recursive: true, force: true });
   },
   async backgroundSW({ context }, use) {
-    let [background] = context.serviceWorkers();
-    background ||= await context.waitForEvent('serviceworker');
+    const background = await createSharedBackgroundSW(context);
     await use(background);
   },
 });

--- a/apps/extension/tests/fixtures/home-popup-fixture.ts
+++ b/apps/extension/tests/fixtures/home-popup-fixture.ts
@@ -91,8 +91,9 @@ export const test = base.extend<
       await createUnauthContext(extensionPath);
 
     // Get extension ID from the new context
-    let [background] = unauthContext.serviceWorkers();
-    background ||= await unauthContext.waitForEvent('serviceworker');
+    // Import the robust service worker getter from base-fixture
+    const { createSharedBackgroundSW } = await import('./base-fixture');
+    const background = await createSharedBackgroundSW(unauthContext);
     const extensionId = background.url().split('/')[2];
 
     // Create a new page without authentication

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
<!-- greptile_comment -->

 

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the Playwright extension test fixtures to attach to the MV3 background service worker more reliably in CI by adding a retry/backoff helper (`getBackgroundServiceWorkerWithRetry`) and using it across auth setup and fixtures. Also updates `apps/web/next-env.d.ts` to reference the non-`dev` generated routes type location.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is mostly safe to merge, with a couple of small correctness/cleanliness issues to address in the test fixtures.
- The retry/backoff approach is self-contained and consistently applied, but there is duplicated dynamic importing in one fixture and an unreachable branch that suggests a mismatch between helper semantics and call-site expectations.
- apps/extension/tests/fixtures/home-popup-fixture.ts, apps/extension/tests/fixtures/base-fixture.ts
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->