### PR TITLE
Fix/mantine shadcn ci tests

### DIFF
--- a/packages/shared/src/components/Persons/components/Persons.tsx
+++ b/packages/shared/src/components/Persons/components/Persons.tsx
@@ -1,7 +1,14 @@
 import { ScrollArea } from '@bypass/ui';
 import { useSize } from 'ahooks';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { type ReactNode, useContext, useEffect, useRef, useState } from 'react';
+import {
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import usePlatform from '../../../hooks/usePlatform';
 import DynamicContext from '../../../provider/DynamicContext';
 import { deserializeQueryStringToObject } from '../../../utils/url';
@@ -107,10 +114,12 @@ function Persons(props: Props) {
   const [personToOpen, setPersonToOpen] = useState<IPerson>();
   const [personToOpenImage, setPersonToOpenImage] = useState('');
   const containerRef = useRef<HTMLDivElement>(null);
-  const scrollAreaRef = useRef<HTMLDivElement>(null);
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(
     null
   );
+  const handleViewportRef = useCallback((node: HTMLDivElement | null) => {
+    setScrollElement(node);
+  }, []);
   const size = useSize(containerRef);
   const bodyWidth = size?.width ?? 0;
   const { location } = useContext(DynamicContext);
@@ -128,15 +137,10 @@ function Persons(props: Props) {
     }
   }, [queryString, persons, resolvePersonImageFromUid]);
 
-  useEffect(() => {
-    if (!scrollElement) {
-      setScrollElement(scrollAreaRef.current);
-    }
-  }, [scrollElement]);
   return (
     <ScrollArea
       ref={containerRef}
-      viewportRef={scrollAreaRef}
+      viewportRef={handleViewportRef}
       className="size-full"
     >
       {bodyWidth > 0 && (


### PR DESCRIPTION
#### Check if the Pull Request fulfils these requirements

- [ ] Does the extension require a version change?

<!-- greptile_comment -->

 

<h3>Greptile Summary</h3>

This PR attempts to fix CI test failures by refactoring the `Persons` component's ref handling pattern. The main change switches from using a simple `useRef` with `RefObject` to a callback ref pattern with state management.

**Key changes:**
- Replaced `scrollAreaRef` ref object with `scrollElement` state and `handleViewportRef` callback
- Renamed `width` to `bodyWidth` for clarity
- Changed `InnerProps` interface to accept `scrollElement` instead of `bodyRef`

**Issues identified:**
- The new callback ref + state pattern adds unnecessary complexity compared to the simpler ref pattern used consistently in `BookmarksPanel.tsx:47` and `bookmark-panel/page.tsx:40`
- The `ScrollArea` component already properly handles ref forwarding via `useImperativeHandle`, making the state-based approach redundant
- No explanation in the PR description of why this specific change was needed to fix CI tests

The previous pattern (`useRef` + passing `ref.current` to `getScrollElement`) is the established convention in this codebase and should work correctly.

<details><summary><h3>Confidence Score: 3/5</h3></summary>

- This PR is safe to merge but introduces unnecessary complexity that deviates from established patterns
- The changes are functionally correct and won't break anything, but they add complexity (callback ref + state) where the simpler ref pattern used elsewhere in the codebase would suffice. The PR title mentions fixing CI tests, but there's no clear explanation of how these specific changes address test failures. The code works but doesn't follow the repository's established conventions.
- packages/shared/src/components/Persons/components/Persons.tsx could be simplified to follow the existing ref pattern used in BookmarksPanel components
</details>


<sub>Last reviewed commit: eaf514e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->