### PR TITLE
Bump extension to 24.6.0 and update forum links

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bypass/extension",
   "type": "module",
-  "version": "24.5.0",
+  "version": "24.6.0",
   "private": true,
   "description": "Bypass links from various sites to required links, with added functionality of Bookmarks Manager, Tagging Panel.",
   "scripts": {

--- a/apps/extension/src/entrypoints/background/misc/forumPageLinks.ts
+++ b/apps/extension/src/entrypoints/background/misc/forumPageLinks.ts
@@ -11,22 +11,20 @@ const getForum_1_2_LinksFunc = () => {
 };
 
 const getForum_1_2_WatchedThreadsLinksFunc = () => {
-  const unreadRows = document.querySelectorAll(
-    '.structItemContainer > .structItem.is-unread > .structItem-cell--main'
+  const allPosts = document.querySelectorAll(
+    '.structItemContainer .structItem-cell--main'
   );
-  return [...unreadRows].map((row) => {
-    const topicLink = row.querySelector<HTMLAnchorElement>(
-      '.structItem-title > a:not(.labelLink), [data-preview-url]'
-    )?.href;
-    if (topicLink) {
-      return topicLink;
-    }
+  return [...allPosts].map((row) => {
     const lastPageLink = row.querySelector<HTMLAnchorElement>(
       '.structItem-pageJump > a:last-child'
     )?.href;
-    return lastPageLink?.endsWith('/unread')
-      ? `${lastPageLink}?new=1`
-      : lastPageLink;
+    if (lastPageLink) {
+      return lastPageLink;
+    }
+
+    return row.querySelector<HTMLAnchorElement>(
+      '.structItem-title > [data-preview-url]'
+    )?.href;
   });
 };
 


### PR DESCRIPTION
#### Check if the Pull Request fulfils these requirements

- [x] Does the extension require a version change?

<!-- greptile_comment -->

 

<h3>Greptile Summary</h3>

This PR bumps the extension version from `24.5.0` to `24.6.0` and updates the watched-threads link-collection logic in `forumPageLinks.ts` to match apparent changes in the forum's DOM structure.

- **Version bump** in `apps/extension/package.json`: `24.5.0` → `24.6.0`
- **`getForum_1_2_WatchedThreadsLinksFunc` refactored**: The query selector is broadened from only unread items (`.structItem.is-unread`) to **all** watched-thread rows (`.structItemContainer .structItem-cell--main`), the link-priority order is swapped (last-page jump link now takes priority over the topic link), the `?new=1` query-string suffix is removed, and the fallback topic-link selector is narrowed to `[data-preview-url]` direct children of `.structItem-title` only.

The code is clean, `undefined` values are safely filtered at the call site (`result?.filter(Boolean) ?? []`), and the changes appear to be intentional adaptations to the current state of the forum platform.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge — changes are a straightforward version bump and intentional DOM-selector updates with no logic errors.
- Both changes are small and clearly intentional: a patch-level version increment and a refactor of CSS selectors to match the current forum DOM. The `filter(Boolean)` guard at the call site (`line 89`) handles any `undefined` values produced by the `.map()`, so there is no risk of runtime errors from the changed selectors. No tests appear to cover this UI-scraping logic, so there is nothing to break on that front either.
- No files require special attention.
</details>

<sub>Last reviewed commit: ["Bump extension to 24..."](https://github.com/amitsingh-007/bypass-links/commit/5310ecb4e571d8061e1f84239ca1b74bf484c09c)</sub>

<!-- /greptile_comment -->