### PR TITLE
Bump vercel cli version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,8 +163,8 @@ catalogs:
       specifier: 5.9.3
       version: 5.9.3
     vercel:
-      specifier: 50.25.4
-      version: 50.25.4
+      specifier: 53.1.0
+      version: 53.1.0
     vite:
       specifier: 7.3.2
       version: 7.3.2
@@ -229,7 +229,7 @@ importers:
         version: 5.9.3
       vercel:
         specifier: 'catalog:'
-        version: 50.25.4(rollup@4.57.1)(typescript@5.9.3)
+        version: 53.1.0(rollup@4.57.1)(typescript@5.9.3)
       xo:
         specifier: 'catalog:'
         version: 1.2.3(@types/eslint@8.56.12)(@typescript-eslint/utils@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(jiti@2.6.1)(typescript@5.9.3)
@@ -1560,9 +1560,6 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
-
-  '@iarna/toml@2.2.5':
-    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
 
   '@img/colour@1.0.0':
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
@@ -2939,8 +2936,8 @@ packages:
       vue-router:
         optional: true
 
-  '@vercel/backends@0.0.39':
-    resolution: {integrity: sha512-Jq6gEGs06Y4mjJQjen9qkPBdEXXBxGiH7bUvumqy0/+8XTx7IF84taGB6WoVL/r7xHpjQN3X+ewzYXhfu9eNxg==}
+  '@vercel/backends@0.3.0':
+    resolution: {integrity: sha512-mhTPAeX6w2zS7GvANq+Ox2qHExFevDK8BIkAnJIIhYgrey7kFlZTM04AZjZYctybsvyInPyPYUwgpmVWNotTGg==}
     peerDependencies:
       typescript: ^4.0.0 || ^5.0.0
 
@@ -2948,30 +2945,30 @@ packages:
     resolution: {integrity: sha512-oYWiJbWRQ7gz9Mj0X/NHFJ3OcLMOBzq/2b3j6zeNrQmtFo6dHwU8FAwNpxVIYddVMd+g8eqEi7iRueYx8FtM0Q==}
     engines: {node: '>=20.0.0'}
 
-  '@vercel/build-utils@13.6.1':
-    resolution: {integrity: sha512-/qRDC8swTUDrdQLkKBnyY8TSk+DeI8RTOIhAba2BwCVCHaZoLF8+sdOCeHud1QJk/3a8R5rAmMQOvEI4P2FRZQ==}
+  '@vercel/build-utils@13.21.0':
+    resolution: {integrity: sha512-A1vtlzFYbjvxRxhnt94LUxrn9JVX2EuXALi/NFyxNA1M51eGQwI5LZaroNlgIRXdx7LCJxBQEUMKc1fi0aqU/g==}
 
-  '@vercel/cervel@0.0.26':
-    resolution: {integrity: sha512-Y7bzTBJpGdqpBaB1oAe9U7IwILJEQHLLVkoJ6uKPeQPGVoSVec1RacS4/XBxqp5i6l+gqhZNF7kCU8TBWLmqFA==}
+  '@vercel/cervel@0.1.0':
+    resolution: {integrity: sha512-YFihXM6jTNzCsX3t9thDbQxjHtQvYzN5lbv/Q+pwMNFwWrMqeFMdshXzM0qm1UH7lnW6OUQ4cNbc6xQU6JTuVQ==}
     hasBin: true
     peerDependencies:
       typescript: ^4.0.0 || ^5.0.0
 
-  '@vercel/detect-agent@1.1.0':
-    resolution: {integrity: sha512-Zfq6FbIcYl9gaAmVu6ROsqUiCNwpEj3Ljz/tMX5fl12Z95OFOxzf7vlO03WE5JBU/ri1tBDFHnW41dihMINOPQ==}
+  '@vercel/detect-agent@1.2.3':
+    resolution: {integrity: sha512-VYNCgUc0nOmC4WJmWw9GkrKdfr8Zl4/rxhC5SvgacBgxiW9W/9NRttUoHHXV8xdII3MaRgkZZVX8Ikzc/Jmjag==}
     engines: {node: '>=14'}
 
-  '@vercel/elysia@0.1.42':
-    resolution: {integrity: sha512-X+ellLiJ3oC8t2L92JhC4PXO922bVOJpk7/XAAXK+llJflanenKQj1fv7K0g3bp2acbnxLdQmyK/oi8tkDAqIQ==}
+  '@vercel/elysia@0.1.73':
+    resolution: {integrity: sha512-TSPiGgIYW1lwR2Rjjbf86dTAxepweu1+5sei/EzFXiqcCpFzVElO6aETNCeimOTcrwft7//+IsaSpVBwxkyqFw==}
 
-  '@vercel/error-utils@2.0.3':
-    resolution: {integrity: sha512-CqC01WZxbLUxoiVdh9B/poPbNpY9U+tO1N9oWHwTl5YAZxcqXmmWJ8KNMFItJCUUWdY3J3xv8LvAuQv2KZ5YdQ==}
+  '@vercel/error-utils@2.1.0':
+    resolution: {integrity: sha512-DiJcXBOB9N6QM4d7hYPM9Ck/AUjzBl58XNQPxS74o7CuvIanjzrGgygP/70VsyEASeIJMazk1LrhwcNTR/eZGQ==}
 
-  '@vercel/express@0.1.51':
-    resolution: {integrity: sha512-2xpyDstOWLUkunZ8FOEawHkPgwCjWiT8HMoyLGGYPsWid9BtzHngQD2Rx7tB6O/v/dt1ofo0MszEemC3z1+MHg==}
+  '@vercel/express@0.1.83':
+    resolution: {integrity: sha512-nFgPKHKG/rckqy6JbOqjNyFNM6PdqFmomYnGaSliZ/a4kXxadPK4NVBrhQ0aJJvDIWv+Gx6IX99QPkKLRq47Lg==}
 
-  '@vercel/fastify@0.1.45':
-    resolution: {integrity: sha512-dhWvmDr3owa7ah/ihhqtccvG9sAIf2c3mnRkuPQozcwXXbrp2Tk+a5HAUxShja7qB0kryijuIxK6N1OQJP9twg==}
+  '@vercel/fastify@0.1.76':
+    resolution: {integrity: sha512-rbKXsOYlW0cUuXjDkkl9az9tB3ukkFsQjZwT/E3o9IXhZsMmYPWGG1CqS65/qYCpsF9bCfXgPgDBErDxL1NrgA==}
 
   '@vercel/fun@1.3.0':
     resolution: {integrity: sha512-8erw9uPe0dFg45THkNxmjtvMX143SkZebmjgSVbcM3XCkXu3RIiBaJMcMNG8aaS+rnTuw8+d4De9HVT0M/r3wg==}
@@ -2980,60 +2977,65 @@ packages:
   '@vercel/gatsby-plugin-vercel-analytics@1.0.11':
     resolution: {integrity: sha512-iTEA0vY6RBPuEzkwUTVzSHDATo1aF6bdLLspI68mQ/BTbi5UQEGjpjyzdKOVcSYApDtFU6M6vypZ1t4vIEnHvw==}
 
-  '@vercel/gatsby-plugin-vercel-builder@2.0.141':
-    resolution: {integrity: sha512-esJcrTXNobTe9bpiHeUVyDNtCDjG2TNQxtkw0yMq1RyLApJuRfpw47r9x6wGYKeS/Coy6FvCroVyeTo5pgWchw==}
+  '@vercel/gatsby-plugin-vercel-builder@2.2.0':
+    resolution: {integrity: sha512-Qs3b6OjGsWdjCsSo6elZ96Ip7Bs0sgN5fkTMdKGzH/IOpX+UOXiuu3uOIjvLDMAf2zOZHwlBGYMNKXF5WW/NvQ==}
 
-  '@vercel/go@3.4.3':
-    resolution: {integrity: sha512-LDT4wpx7SW2UJHd3rOL4+2m2V4w7a5zjyuU0pu0yDBiuxp9bEh7QuAH5qZC7pINGLC3vGftiFVzynd5N454sVA==}
+  '@vercel/go@3.6.0':
+    resolution: {integrity: sha512-60gQxuQBfuGQCPdp1zmG3bfWncj+MRDm9KNogKeu4cA1uC2kGwUoCI6vr8kpGTv62v3gwSLbcnJ3RsqOqxb3KA==}
 
-  '@vercel/h3@0.1.51':
-    resolution: {integrity: sha512-4OrHj0f47N1O9ShUFNFIZQYtbr/cUq8TcUU4Q8yfYlVKooqXme0Ql79G7LohDivcoHL7RmnQ14o2/C6/JWTzLg==}
+  '@vercel/h3@0.1.82':
+    resolution: {integrity: sha512-tiLO/+EcrWYFYT3OvF/gI63Arc60w5m3zPU4dMrTuHnm0DW418oPFVvtKdN/B2FOGN+KEeUrfl8uXz1AdyTSog==}
 
-  '@vercel/hono@0.2.45':
-    resolution: {integrity: sha512-j5HNFtEU8NpV82bqPGG0v4VUxaJ/35RxW9ZQTrb2tKBQqGp0okBOnGr+zb3eJsUygs7VbnpEQ4Nb3qDtZ+DD+w==}
+  '@vercel/hono@0.2.76':
+    resolution: {integrity: sha512-gveEPPtgMHVl0Q9GPQw7FSLslBGJ8EidF56vsDyCtLIsfyIXnEiMXT9fwQ3u2fH7nc7FRk0hjFiqlhY1km8Xwg==}
 
-  '@vercel/hydrogen@1.3.5':
-    resolution: {integrity: sha512-7EE6yVKcCnjMb1io9y069GkLyGyIzRbW3Krm3Q7EEfJ3P46h9xe9v/O5UhBoPrwtqDUHxmDngZp9YyfgY8IITA==}
+  '@vercel/hydrogen@1.3.7':
+    resolution: {integrity: sha512-nh8hZ76Ipf9FRmMmQGd4SjkE0zxdjt+TUpZcuCIUG7yaHEh9STQV655I8rxKCB3hEWaKB3HALGgxZ0htIjQtZQ==}
 
-  '@vercel/koa@0.1.25':
-    resolution: {integrity: sha512-uDUe7FXsrhVGR6sX8Q5ynMTtQVagLJ4PnS1yuBLZSTg3k/3LrUrtNIenBQGEBOTTL9JmqUJ+AZdbwuBaUtU7Mg==}
+  '@vercel/koa@0.1.56':
+    resolution: {integrity: sha512-5edjnf3QiTvVCucp+peZ8RICcGjaZqbsuD6dzl6DrSUvXfSPF9Enjv/OoUErZbRCTlRjyUw7nzGP8CLf7o7XMQ==}
 
-  '@vercel/nestjs@0.2.46':
-    resolution: {integrity: sha512-0QTgF5P03BEir2apHgwh3cRkkOQTXgFz/2SPs+B1Aab64NnFvM7peFIuAjGnfFNvO1DwSLOyKEXTepihdifsYQ==}
+  '@vercel/nestjs@0.2.77':
+    resolution: {integrity: sha512-1nxP4Tcf+RQKkQA1f5bUXCUK8vhcnRzHocFiU2bE6+uu85UTaG13/VeUcYTQCmywPcomsPKi6u8B+S9fKv09xA==}
 
-  '@vercel/next@4.15.36':
-    resolution: {integrity: sha512-wlrxO/qj9IjO0SO5qM1kG5MVOks8LCEysGotbgtrL9EuGS2EEF6zK5/Ww8BLVqUzukcan7lv0Fxd2/oLh0R4Jg==}
+  '@vercel/next@4.17.0':
+    resolution: {integrity: sha512-7Yr2gdD2XMdl77Yy/y2SZfi4z8KcziKuoVgKMs25tA5qcarej6YcgOdf2FUfIf+OSdMl+MJmv+1IEE0pBj4hiA==}
 
-  '@vercel/nft@1.1.1':
-    resolution: {integrity: sha512-mKMGa7CEUcXU75474kOeqHbtvK1kAcu4wiahhmlUenB5JbTQB8wVlDI8CyHR3rpGo0qlzoRWqcDzI41FUoBJCA==}
+  '@vercel/nft@1.5.0':
+    resolution: {integrity: sha512-IWTDeIoWhQ7ZtRO/JRKH+jhmeQvZYhtGPmzw/QGDY+wDCQqfm25P9yIdoAFagu4fWsK4IwZXDFIjrmp5rRm/sA==}
     engines: {node: '>=20'}
     hasBin: true
 
-  '@vercel/nft@1.3.0':
-    resolution: {integrity: sha512-i4EYGkCsIjzu4vorDUbqglZc5eFtQI2syHb++9ZUDm6TU4edVywGpVnYDein35x9sevONOn9/UabfQXuNXtuzQ==}
-    engines: {node: '>=20'}
-    hasBin: true
+  '@vercel/node@5.7.15':
+    resolution: {integrity: sha512-o8YtafKgaYsY7/4SRKlrvTx/cEB5o3vQG3/eq5Qo66n4WaFeZV8R8GG+BzSU3SYozasQlQxkbPxedUNF4sZJ8A==}
 
-  '@vercel/node@5.6.9':
-    resolution: {integrity: sha512-SiLToxNIGNSaELFhMorNAWIW1LkBCOEIw7+P3MxDxeaY9RAn5nqymT4uLg95L94JvI4dAFZbdfS7ntgmEfB64A==}
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
 
-  '@vercel/python-analysis@0.8.1':
-    resolution: {integrity: sha512-gW1pZDqJaTcjZYPvNhXXLOPgLu6vJW9PKweJoX2f8EKAoW+JIiYncl8AddcSlngNhQRG7SqUl2u3qosZM4kUBA==}
+  '@vercel/prepare-flags-definitions@0.2.1':
+    resolution: {integrity: sha512-ouXTsqn7I9xZ1KKezgvn/w3tZeQHL/tc52j9GHiOYi6kT8xgdbT8s2x8C9BQr44iceX0hfhtZwk9q7NuI2Tqbw==}
 
-  '@vercel/python@6.19.0':
-    resolution: {integrity: sha512-As/ukwv6wBMpM37V5HEfuTX8TTixVjtuec4cD5RBCj1CJPDC6Lmbt/SMSNAlKOiiewww5TpniKelOV23EMMBrQ==}
+  '@vercel/python-analysis@0.11.1':
+    resolution: {integrity: sha512-EPPLuXJQhIDUx08H9nG76AR2HSgBquwe3OAX5s2w20M923iaWeGGVkhX/4yZ89CJfXEZgE1Aj/mX7lVHOVIcYA==}
 
-  '@vercel/redwood@2.4.9':
-    resolution: {integrity: sha512-U7bYIuWfMEFMIcKKbX7lTT8pFNjig9Q3vLeCYRYQUrKVP8xLoUBXSEfW3ijtWJBUV8GmbZCDI30A16uUfNhN+g==}
+  '@vercel/python@6.37.0':
+    resolution: {integrity: sha512-MYPt5YUVDqo+sf5B38QyJMcXIm0oBR6xj7qnzan95r31ebYTxx6/iA0vIVFNLVR8LstkWK/xPknFN5jG8hu6qA==}
 
-  '@vercel/remix-builder@5.6.0':
-    resolution: {integrity: sha512-neTpO4aGksYcPJjTbAEUhWmsOdFqgx02H47RUsXBKHdMTW4ZKrL9oAKT3pD+Bv9kUgj7uRzqAr8JeiPILPWybg==}
+  '@vercel/redwood@2.4.13':
+    resolution: {integrity: sha512-pXWzVctZea/J7WMQstjsYUDiMc6oJF72p8J5YZnLSCJWg7m+/dLzYGfaUSEo6Q0JpiO/NOcDmG3WENpn7kHwzg==}
+
+  '@vercel/remix-builder@5.8.0':
+    resolution: {integrity: sha512-phMAw9GfWQZhYQbPzjq069zCzgI3cqs29nvoUPhmGJNz8chmphb3UHWy+MaeBLoUC3rneJzYQd1DtP2xtrMZXQ==}
 
   '@vercel/ruby@2.3.2':
     resolution: {integrity: sha512-okIgMmPEePyDR9TZYaKM4oftcxVHM5Dbdl7V/tIdh3lq8MGLi7HR5vvQglmZUwZOeovE6MVtezxl960EOzeIiQ==}
 
-  '@vercel/rust@1.0.5':
-    resolution: {integrity: sha512-Y03g59nv1uT6Da+PvB/50WqJSHlaFZ9MSkG00R82dUcTySslMbQdOeaXymZtabrmU8zQYhWDb1/CwBki8sWnaQ==}
+  '@vercel/rust@1.2.0':
+    resolution: {integrity: sha512-JryMtBa0sFuqxfHpjrNgMks06XDKa8DVhGljTsoo26dIKqsoqeYhJHuepEAEXT+b5N+tUmxIOUcRq5//ewvytQ==}
+
+  '@vercel/sandbox@1.9.0':
+    resolution: {integrity: sha512-zgr1ad0tkT1xZn/8Vxo60wOUOLqMAVGo4WqJQ8/UDcUtWynNJsBjI2tiMdWZrAo9EKH1MIqEzJNkcclF0UT1EQ==}
 
   '@vercel/speed-insights@1.3.1':
     resolution: {integrity: sha512-PbEr7FrMkUrGYvlcLHGkXdCkxnylCWePx7lPxxq36DNdfo9mcUjLOmqOyPDHAOgnfqgGGdmE3XI9L/4+5fr+vQ==}
@@ -3058,11 +3060,11 @@ packages:
       vue-router:
         optional: true
 
-  '@vercel/static-build@2.8.43':
-    resolution: {integrity: sha512-9zVgVA7sIvikRdmQFsSM/40NQ6kxaucpUpOW/+BBrEe9BAx9JcHsO6wkhkJ4rdeVQ5eSzZMzPS9NR4ifqv5Low==}
+  '@vercel/static-build@2.9.22':
+    resolution: {integrity: sha512-zkwy48kv+4UlL3TTC8uoX2nWPdKXAydkKE/D8QYFq895Nq/CDB19r1q5vXno2iO9/njDsfYdl0Ftk7nXcexzgw==}
 
-  '@vercel/static-config@3.1.2':
-    resolution: {integrity: sha512-2d+TXr6K30w86a+WbMbGm2W91O0UzO5VeemZYBBUJbCjk/5FLLGIi8aV6RS2+WmaRvtcqNTn2pUA7nCOK3bGcQ==}
+  '@vercel/static-config@3.3.0':
+    resolution: {integrity: sha512-GpS3tPwUeDJCkrKbMNtS2XLRFgfxTlN7YNUL+Bo23+fGolrDw6Oq79R3yvxTYgqRaJMGSEqC7iMw6mj6I5loxg==}
 
   '@webext-core/fake-browser@1.3.4':
     resolution: {integrity: sha512-nZcVWr3JpwpS5E6hKpbAwAMBM/AXZShnfW0F76udW8oLd6Kv0nbW6vFS07md4Na/0ntQonk3hFnlQYGYBAlTrA==}
@@ -3078,6 +3080,10 @@ packages:
 
   '@wxt-dev/storage@1.2.6':
     resolution: {integrity: sha512-f6AknnpJvhNHW4s0WqwSGCuZAj0fjP3EVNPBO5kB30pY+3Zt/nqZGqJN6FgBLCSkYjPJ8VL1hNX5LMVmvxQoDw==}
+
+  '@yarnpkg/parsers@3.0.3':
+    resolution: {integrity: sha512-mQZgUSgFurUtA07ceMjxrWkYz8QtDuYkvPlu0ZqncgjopQ0t6CNEo/OSealkmnagSUx8ZD5ewvezUwUuMqutQg==}
+    engines: {node: '>=18.12.0'}
 
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
@@ -3171,6 +3177,9 @@ packages:
 
   arg@4.1.0:
     resolution: {integrity: sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -3275,6 +3284,14 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   babel-plugin-react-compiler@1.0.0:
     resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
 
@@ -3285,6 +3302,14 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  bare-events@2.8.2:
+    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -3890,6 +3915,9 @@ packages:
   es-module-lexer@1.4.1:
     resolution: {integrity: sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==}
 
+  es-module-lexer@1.5.0:
+    resolution: {integrity: sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw==}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
@@ -4169,6 +4197,9 @@ packages:
   events-intercept@2.0.0:
     resolution: {integrity: sha512-blk1va0zol9QOrdZt0rFXo5KMkNPVSp92Eju/Qz8THwKWKRKeE0T8Br/1aW6+Edkyq9xHYgYxn2QtOnUKPUp+Q==}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
@@ -4217,6 +4248,9 @@ packages:
 
   fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -5050,6 +5084,10 @@ packages:
     resolution: {integrity: sha512-/c+n06zvqFQGxdz1BbElF7S3nEghjNchLN1TjQnk2j10HYDaUc57rcvl6BbnziTx8NQmrg0JOs/iwRpvcYaxjQ==}
     engines: {node: '>=18.20'}
 
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -5099,6 +5137,9 @@ packages:
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
+  jsonlines@0.1.1:
+    resolution: {integrity: sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==}
 
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
@@ -5731,10 +5772,6 @@ packages:
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
-  ohm-js@17.5.0:
-    resolution: {integrity: sha512-l4Sa7026+6jsvYbt0PXKmL+f+ML32fD++IznLgxDhx2t9Cx6NC7zwRqblCujPHGGmkQerHoeBzRutdxaw/S72g==}
-    engines: {node: '>=0.12.1'}
-
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
@@ -5940,9 +5977,6 @@ packages:
   pino@9.7.0:
     resolution: {integrity: sha512-vnMCM6xZTb1WDmLvtG2lE/2p+t9hDEIvTWJsu6FejkE62vB7gDhvzrpFR4Cw2to+9JNQxVnkAKVPA1KPB98vWg==}
     hasBin: true
-
-  pip-requirements-js@1.0.2:
-    resolution: {integrity: sha512-awqoNOSOl4Blu4E4Hzp7jL0g8WKEhCwO+s7C2ibtIW3CAJMwspgoTXd4vnHd21UmhdrsI44Pn8FFSuA8QKrzvg==}
 
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
@@ -6296,6 +6330,10 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  sandbox@2.5.6:
+    resolution: {integrity: sha512-tnFr7nyiuEhsAGb+xy60SDbij0790X+FgDljh3J/2HaRM6yQgNJkQKHbDH8ld7mR+PozXGgEfJ2Dc/5OyFnwsg==}
+    hasBin: true
+
   sax@1.4.4:
     resolution: {integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==}
     engines: {node: '>=11.0.0'}
@@ -6470,6 +6508,9 @@ packages:
   split@1.0.1:
     resolution: {integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==}
 
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
   srvx@0.8.9:
     resolution: {integrity: sha512-wYc3VLZHRzwYrWJhkEqkhLb31TI0SOkfYZDkUhXdp3NoCnNS0FqajiQszZZjfow/VYEuc6Q5sZh9nM6kPy2NBQ==}
     engines: {node: '>=20.16.0'}
@@ -6513,6 +6554,9 @@ packages:
 
   stream-to-promise@2.2.0:
     resolution: {integrity: sha512-HAGUASw8NT0k8JvIVutB2Y/9iBk7gpgEyAudXwNJmZERdMITGdajOa4VJfD/kNiA3TppQpTP4J+CtcHwdzKBAw==}
+
+  streamx@2.25.0:
+    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
 
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
@@ -6679,6 +6723,9 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tar-stream@3.1.7:
+    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
   tar@7.5.7:
     resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
     engines: {node: '>=18'}
@@ -6687,6 +6734,9 @@ packages:
   teeny-request@9.0.0:
     resolution: {integrity: sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==}
     engines: {node: '>=14'}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
@@ -6893,6 +6943,10 @@ packages:
     resolution: {integrity: sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==}
     engines: {node: '>=18.17'}
 
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
+
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
@@ -6977,8 +7031,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vercel@50.25.4:
-    resolution: {integrity: sha512-fe8JlltG4ZQUssOWXMRGjj0GVr44TqW0PrUGSalIT4oYM/KdEU2hMY8gcuEOy5q1FxMmIn2IO2AzEduimxbF+A==}
+  vercel@53.1.0:
+    resolution: {integrity: sha512-qukrCOUS91I9M4K9dvIn9f4RLnRBMCTvjx299xLbYCjyhaRTYmZ88o56idfXuXGjGJslCUU7KIzScQVLp7qgFw==}
     engines: {node: '>= 18'}
     hasBin: true
 
@@ -7271,6 +7325,9 @@ packages:
 
   zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+
+  zod@3.24.4:
+    resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -8306,8 +8363,6 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
-
-  '@iarna/toml@2.2.5': {}
 
   '@img/colour@1.0.0': {}
 
@@ -9393,12 +9448,14 @@ snapshots:
       next: 16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
 
-  '@vercel/backends@0.0.39(rollup@4.57.1)(typescript@5.9.3)':
+  '@vercel/backends@0.3.0(rollup@4.57.1)(typescript@5.9.3)':
     dependencies:
-      '@vercel/build-utils': 13.6.1
-      '@vercel/nft': 1.3.0(rollup@4.57.1)
+      '@vercel/build-utils': 13.21.0
+      '@vercel/nft': 1.5.0(rollup@4.57.1)
+      '@yarnpkg/parsers': 3.0.3
       execa: 3.2.0
       fs-extra: 11.1.0
+      js-yaml: 3.14.2
       oxc-transform: 0.111.0
       path-to-regexp: 8.3.0
       resolve.exports: 2.0.3
@@ -9420,38 +9477,40 @@ snapshots:
       throttleit: 2.1.0
       undici: 6.23.0
 
-  '@vercel/build-utils@13.6.1':
+  '@vercel/build-utils@13.21.0':
     dependencies:
-      '@vercel/python-analysis': 0.8.1
+      '@vercel/python-analysis': 0.11.1
+      cjs-module-lexer: 1.2.3
+      es-module-lexer: 1.5.0
 
-  '@vercel/cervel@0.0.26(rollup@4.57.1)(typescript@5.9.3)':
+  '@vercel/cervel@0.1.0(rollup@4.57.1)(typescript@5.9.3)':
     dependencies:
-      '@vercel/backends': 0.0.39(rollup@4.57.1)(typescript@5.9.3)
+      '@vercel/backends': 0.3.0(rollup@4.57.1)(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/detect-agent@1.1.0': {}
+  '@vercel/detect-agent@1.2.3': {}
 
-  '@vercel/elysia@0.1.42(rollup@4.57.1)':
+  '@vercel/elysia@0.1.73(rollup@4.57.1)':
     dependencies:
-      '@vercel/node': 5.6.9(rollup@4.57.1)
-      '@vercel/static-config': 3.1.2
+      '@vercel/node': 5.7.15(rollup@4.57.1)
+      '@vercel/static-config': 3.3.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/error-utils@2.0.3': {}
+  '@vercel/error-utils@2.1.0': {}
 
-  '@vercel/express@0.1.51(rollup@4.57.1)(typescript@5.9.3)':
+  '@vercel/express@0.1.83(rollup@4.57.1)(typescript@5.9.3)':
     dependencies:
-      '@vercel/cervel': 0.0.26(rollup@4.57.1)(typescript@5.9.3)
-      '@vercel/nft': 1.1.1(rollup@4.57.1)
-      '@vercel/node': 5.6.9(rollup@4.57.1)
-      '@vercel/static-config': 3.1.2
+      '@vercel/cervel': 0.1.0(rollup@4.57.1)(typescript@5.9.3)
+      '@vercel/nft': 1.5.0(rollup@4.57.1)
+      '@vercel/node': 5.7.15(rollup@4.57.1)
+      '@vercel/static-config': 3.3.0
       fs-extra: 11.1.0
       path-to-regexp: 8.3.0
       ts-morph: 12.0.0
@@ -9462,10 +9521,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@vercel/fastify@0.1.45(rollup@4.57.1)':
+  '@vercel/fastify@0.1.76(rollup@4.57.1)':
     dependencies:
-      '@vercel/node': 5.6.9(rollup@4.57.1)
-      '@vercel/static-config': 3.1.2
+      '@vercel/node': 5.7.15(rollup@4.57.1)
+      '@vercel/static-config': 3.3.0
     transitivePeerDependencies:
       - encoding
       - rollup
@@ -9499,30 +9558,30 @@ snapshots:
     dependencies:
       web-vitals: 0.2.4
 
-  '@vercel/gatsby-plugin-vercel-builder@2.0.141':
+  '@vercel/gatsby-plugin-vercel-builder@2.2.0':
     dependencies:
       '@sinclair/typebox': 0.25.24
-      '@vercel/build-utils': 13.6.1
+      '@vercel/build-utils': 13.21.0
       esbuild: 0.27.0
       etag: 1.8.1
       fs-extra: 11.1.0
 
-  '@vercel/go@3.4.3': {}
+  '@vercel/go@3.6.0': {}
 
-  '@vercel/h3@0.1.51(rollup@4.57.1)':
+  '@vercel/h3@0.1.82(rollup@4.57.1)':
     dependencies:
-      '@vercel/node': 5.6.9(rollup@4.57.1)
-      '@vercel/static-config': 3.1.2
+      '@vercel/node': 5.7.15(rollup@4.57.1)
+      '@vercel/static-config': 3.3.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/hono@0.2.45(rollup@4.57.1)':
+  '@vercel/hono@0.2.76(rollup@4.57.1)':
     dependencies:
-      '@vercel/nft': 1.1.1(rollup@4.57.1)
-      '@vercel/node': 5.6.9(rollup@4.57.1)
-      '@vercel/static-config': 3.1.2
+      '@vercel/nft': 1.5.0(rollup@4.57.1)
+      '@vercel/node': 5.7.15(rollup@4.57.1)
+      '@vercel/static-config': 3.3.0
       fs-extra: 11.1.0
       path-to-regexp: 8.3.0
       ts-morph: 12.0.0
@@ -9532,57 +9591,38 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/hydrogen@1.3.5':
+  '@vercel/hydrogen@1.3.7':
     dependencies:
-      '@vercel/static-config': 3.1.2
+      '@vercel/static-config': 3.3.0
       ts-morph: 12.0.0
 
-  '@vercel/koa@0.1.25(rollup@4.57.1)':
+  '@vercel/koa@0.1.56(rollup@4.57.1)':
     dependencies:
-      '@vercel/node': 5.6.9(rollup@4.57.1)
-      '@vercel/static-config': 3.1.2
+      '@vercel/node': 5.7.15(rollup@4.57.1)
+      '@vercel/static-config': 3.3.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/nestjs@0.2.46(rollup@4.57.1)':
+  '@vercel/nestjs@0.2.77(rollup@4.57.1)':
     dependencies:
-      '@vercel/node': 5.6.9(rollup@4.57.1)
-      '@vercel/static-config': 3.1.2
+      '@vercel/node': 5.7.15(rollup@4.57.1)
+      '@vercel/static-config': 3.3.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/next@4.15.36(rollup@4.57.1)':
+  '@vercel/next@4.17.0(rollup@4.57.1)':
     dependencies:
-      '@vercel/nft': 1.1.1(rollup@4.57.1)
+      '@vercel/nft': 1.5.0(rollup@4.57.1)
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/nft@1.1.1(rollup@4.57.1)':
-    dependencies:
-      '@mapbox/node-pre-gyp': 2.0.3
-      '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
-      acorn: 8.15.0
-      acorn-import-attributes: 1.9.5(acorn@8.15.0)
-      async-sema: 3.1.1
-      bindings: 1.5.0
-      estree-walker: 2.0.2
-      glob: 13.0.1
-      graceful-fs: 4.2.11
-      node-gyp-build: 4.8.4
-      picomatch: 4.0.3
-      resolve-from: 5.0.0
-    transitivePeerDependencies:
-      - encoding
-      - rollup
-      - supports-color
-
-  '@vercel/nft@1.3.0(rollup@4.57.1)':
+  '@vercel/nft@1.5.0(rollup@4.57.1)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3
       '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
@@ -9601,16 +9641,16 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/node@5.6.9(rollup@4.57.1)':
+  '@vercel/node@5.7.15(rollup@4.57.1)':
     dependencies:
       '@edge-runtime/node-utils': 2.3.0
       '@edge-runtime/primitives': 4.1.0
       '@edge-runtime/vm': 3.2.0
       '@types/node': 20.11.0
-      '@vercel/build-utils': 13.6.1
-      '@vercel/error-utils': 2.0.3
-      '@vercel/nft': 1.1.1(rollup@4.57.1)
-      '@vercel/static-config': 3.1.2
+      '@vercel/build-utils': 13.21.0
+      '@vercel/error-utils': 2.1.0
+      '@vercel/nft': 1.5.0(rollup@4.57.1)
+      '@vercel/static-config': 3.3.0
       async-listen: 3.0.0
       cjs-module-lexer: 1.2.3
       edge-runtime: 2.5.9
@@ -9630,25 +9670,28 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/python-analysis@0.8.1':
+  '@vercel/oidc@3.2.0': {}
+
+  '@vercel/prepare-flags-definitions@0.2.1': {}
+
+  '@vercel/python-analysis@0.11.1':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.6
       '@renovatebot/pep440': 4.2.1
       fs-extra: 11.1.1
       js-yaml: 4.1.1
       minimatch: 10.1.1
-      pip-requirements-js: 1.0.2
       smol-toml: 1.5.2
       zod: 3.22.4
 
-  '@vercel/python@6.19.0':
+  '@vercel/python@6.37.0':
     dependencies:
-      '@vercel/python-analysis': 0.8.1
+      '@vercel/python-analysis': 0.11.1
 
-  '@vercel/redwood@2.4.9(rollup@4.57.1)':
+  '@vercel/redwood@2.4.13(rollup@4.57.1)':
     dependencies:
-      '@vercel/nft': 1.1.1(rollup@4.57.1)
-      '@vercel/static-config': 3.1.2
+      '@vercel/nft': 1.5.0(rollup@4.57.1)
+      '@vercel/static-config': 3.3.0
       semver: 6.3.1
       ts-morph: 12.0.0
     transitivePeerDependencies:
@@ -9656,11 +9699,11 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/remix-builder@5.6.0(rollup@4.57.1)':
+  '@vercel/remix-builder@5.8.0(rollup@4.57.1)':
     dependencies:
-      '@vercel/error-utils': 2.0.3
-      '@vercel/nft': 1.1.1(rollup@4.57.1)
-      '@vercel/static-config': 3.1.2
+      '@vercel/error-utils': 2.1.0
+      '@vercel/nft': 1.5.0(rollup@4.57.1)
+      '@vercel/static-config': 3.3.0
       path-to-regexp: 6.1.0
       path-to-regexp-updated: path-to-regexp@6.3.0
       ts-morph: 12.0.0
@@ -9671,24 +9714,39 @@ snapshots:
 
   '@vercel/ruby@2.3.2': {}
 
-  '@vercel/rust@1.0.5':
+  '@vercel/rust@1.2.0':
     dependencies:
-      '@iarna/toml': 2.2.5
       execa: 5.1.1
+      smol-toml: 1.5.2
+
+  '@vercel/sandbox@1.9.0':
+    dependencies:
+      '@vercel/oidc': 3.2.0
+      async-retry: 1.3.3
+      jsonlines: 0.1.1
+      ms: 2.1.3
+      picocolors: 1.1.1
+      tar-stream: 3.1.7
+      undici: 7.25.0
+      xdg-app-paths: 5.1.0
+      zod: 3.24.4
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   '@vercel/speed-insights@1.3.1(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
     optionalDependencies:
       next: 16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
 
-  '@vercel/static-build@2.8.43':
+  '@vercel/static-build@2.9.22':
     dependencies:
       '@vercel/gatsby-plugin-vercel-analytics': 1.0.11
-      '@vercel/gatsby-plugin-vercel-builder': 2.0.141
-      '@vercel/static-config': 3.1.2
+      '@vercel/gatsby-plugin-vercel-builder': 2.2.0
+      '@vercel/static-config': 3.3.0
       ts-morph: 12.0.0
 
-  '@vercel/static-config@3.1.2':
+  '@vercel/static-config@3.3.0':
     dependencies:
       ajv: 8.6.3
       json-schema-to-ts: 1.6.4
@@ -9714,6 +9772,11 @@ snapshots:
       '@wxt-dev/browser': 0.1.40
       async-mutex: 0.5.0
       dequal: 2.0.3
+
+  '@yarnpkg/parsers@3.0.3':
+    dependencies:
+      js-yaml: 3.14.2
+      tslib: 2.8.1
 
   abbrev@3.0.1: {}
 
@@ -9798,6 +9861,10 @@ snapshots:
   any-promise@1.3.0: {}
 
   arg@4.1.0: {}
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
 
@@ -9917,6 +9984,8 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
+  b4a@1.8.1: {}
+
   babel-plugin-react-compiler@1.0.0:
     dependencies:
       '@babel/types': 7.29.0
@@ -9926,6 +9995,8 @@ snapshots:
       '@babel/core': 7.29.0
 
   balanced-match@1.0.2: {}
+
+  bare-events@2.8.2: {}
 
   base64-js@1.5.1: {}
 
@@ -10538,6 +10609,8 @@ snapshots:
 
   es-module-lexer@1.4.1: {}
 
+  es-module-lexer@1.5.0: {}
+
   es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
@@ -10934,6 +11007,12 @@ snapshots:
 
   events-intercept@2.0.0: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   eventsource-parser@3.0.6: {}
 
   eventsource@3.0.7:
@@ -11029,6 +11108,8 @@ snapshots:
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.1:
     dependencies:
@@ -11927,6 +12008,11 @@ snapshots:
 
   js-types@4.0.0: {}
 
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -11965,6 +12051,8 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jsonlines@0.1.1: {}
 
   jsonwebtoken@9.0.3:
     dependencies:
@@ -12547,8 +12635,6 @@ snapshots:
 
   ohash@2.0.11: {}
 
-  ohm-js@17.5.0: {}
-
   on-exit-leak-free@2.1.2: {}
 
   on-finished@2.4.1:
@@ -12791,10 +12877,6 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.0
       thread-stream: 3.1.0
-
-  pip-requirements-js@1.0.2:
-    dependencies:
-      ohm-js: 17.5.0
 
   pkce-challenge@5.0.1: {}
 
@@ -13226,6 +13308,16 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  sandbox@2.5.6:
+    dependencies:
+      '@vercel/sandbox': 1.9.0
+      debug: 4.4.3
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+      - supports-color
+
   sax@1.4.4: {}
 
   scheduler@0.27.0: {}
@@ -13483,6 +13575,8 @@ snapshots:
     dependencies:
       through: 2.3.8
 
+  sprintf-js@1.0.3: {}
+
   srvx@0.8.9:
     dependencies:
       cookie-es: 2.0.0
@@ -13521,6 +13615,15 @@ snapshots:
       any-promise: 1.3.0
       end-of-stream: 1.1.0
       stream-to-array: 2.3.0
+
+  streamx@2.25.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   strict-event-emitter@0.5.1: {}
 
@@ -13685,6 +13788,15 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tar-stream@3.1.7:
+    dependencies:
+      b4a: 1.8.1
+      fast-fifo: 1.3.2
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   tar@7.5.7:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
@@ -13704,6 +13816,12 @@ snapshots:
       - encoding
       - supports-color
     optional: true
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   thread-stream@3.1.0:
     dependencies:
@@ -13909,6 +14027,8 @@ snapshots:
 
   undici@6.23.0: {}
 
+  undici@7.25.0: {}
+
   unicorn-magic@0.3.0: {}
 
   unimport@5.6.0:
@@ -14022,38 +14142,43 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vercel@50.25.4(rollup@4.57.1)(typescript@5.9.3):
+  vercel@53.1.0(rollup@4.57.1)(typescript@5.9.3):
     dependencies:
-      '@vercel/backends': 0.0.39(rollup@4.57.1)(typescript@5.9.3)
+      '@vercel/backends': 0.3.0(rollup@4.57.1)(typescript@5.9.3)
       '@vercel/blob': 2.3.0
-      '@vercel/build-utils': 13.6.1
-      '@vercel/detect-agent': 1.1.0
-      '@vercel/elysia': 0.1.42(rollup@4.57.1)
-      '@vercel/express': 0.1.51(rollup@4.57.1)(typescript@5.9.3)
-      '@vercel/fastify': 0.1.45(rollup@4.57.1)
+      '@vercel/build-utils': 13.21.0
+      '@vercel/detect-agent': 1.2.3
+      '@vercel/elysia': 0.1.73(rollup@4.57.1)
+      '@vercel/express': 0.1.83(rollup@4.57.1)(typescript@5.9.3)
+      '@vercel/fastify': 0.1.76(rollup@4.57.1)
       '@vercel/fun': 1.3.0
-      '@vercel/go': 3.4.3
-      '@vercel/h3': 0.1.51(rollup@4.57.1)
-      '@vercel/hono': 0.2.45(rollup@4.57.1)
-      '@vercel/hydrogen': 1.3.5
-      '@vercel/koa': 0.1.25(rollup@4.57.1)
-      '@vercel/nestjs': 0.2.46(rollup@4.57.1)
-      '@vercel/next': 4.15.36(rollup@4.57.1)
-      '@vercel/node': 5.6.9(rollup@4.57.1)
-      '@vercel/python': 6.19.0
-      '@vercel/redwood': 2.4.9(rollup@4.57.1)
-      '@vercel/remix-builder': 5.6.0(rollup@4.57.1)
+      '@vercel/go': 3.6.0
+      '@vercel/h3': 0.1.82(rollup@4.57.1)
+      '@vercel/hono': 0.2.76(rollup@4.57.1)
+      '@vercel/hydrogen': 1.3.7
+      '@vercel/koa': 0.1.56(rollup@4.57.1)
+      '@vercel/nestjs': 0.2.77(rollup@4.57.1)
+      '@vercel/next': 4.17.0(rollup@4.57.1)
+      '@vercel/node': 5.7.15(rollup@4.57.1)
+      '@vercel/prepare-flags-definitions': 0.2.1
+      '@vercel/python': 6.37.0
+      '@vercel/redwood': 2.4.13(rollup@4.57.1)
+      '@vercel/remix-builder': 5.8.0(rollup@4.57.1)
       '@vercel/ruby': 2.3.2
-      '@vercel/rust': 1.0.5
-      '@vercel/static-build': 2.8.43
+      '@vercel/rust': 1.2.0
+      '@vercel/static-build': 2.9.22
       chokidar: 4.0.0
       esbuild: 0.27.0
       form-data: 4.0.5
       jose: 5.9.6
       luxon: 3.7.2
       proxy-agent: 6.4.0
+      sandbox: 2.5.6
+      smol-toml: 1.5.2
     transitivePeerDependencies:
+      - bare-abort-controller
       - encoding
+      - react-native-b4a
       - rollup
       - supports-color
       - typescript
@@ -14467,6 +14592,8 @@ snapshots:
       zod: 3.25.76
 
   zod@3.22.4: {}
+
+  zod@3.24.4: {}
 
   zod@3.25.76: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,7 +57,7 @@ catalog:
   tw-animate-css: 1.4.0
   type-fest: 5.4.4
   typescript: 5.9.3
-  vercel: 50.25.4
+  vercel: 53.1.0
   vite: 7.3.2
   vite-tsconfig-paths: 6.1.1
   wouter: 3.9.0


### PR DESCRIPTION
#### Check if the Pull Request fulfils these requirements

- [x] Does the extension require a version change?

<!-- greptile_comment -->

 

<h3>Greptile Summary</h3>

This PR bumps the Vercel CLI from `50.25.4` to `53.1.0` by updating the catalog entry in `pnpm-workspace.yaml` and regenerating the lock file. The lock file changes are consistent with the version bump — all `@vercel/*` sub-packages are updated, new packages such as `@vercel/sandbox`, `@vercel/oidc`, and `@vercel/prepare-flags-definitions` are introduced as transitive dependencies, and obsolete packages like `pip-requirements-js` and `ohm-js` are removed.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge — it is a clean dependency version bump with no application code changes.

Only dependency files are modified. The lock file is fully consistent with the catalog change, all integrity hashes are present, and no application logic is touched.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["Bump vercel cli version"](https://github.com/amitsingh-007/bypass-links/commit/e1d87f9c7752715dc4e5912e3c61bba4c0249f76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30538917)</sub>

<!-- /greptile_comment -->