### PR TITLE
Bump vercel-action to v42 in workflows

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Deploy Preview (Vercel)
         if: ${{ !inputs.vercel_url }}
-        uses: amondnet/vercel-action@v25
+        uses: amondnet/vercel-action@v42
         id: vercel-action
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           include-hidden-files: true
 
       - name: Deploy Preview (Vercel)
-        uses: amondnet/vercel-action@v25
+        uses: amondnet/vercel-action@v42
         id: vercel-action
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
@@ -139,7 +139,7 @@ jobs:
           env: Production
 
       - name: Deploy (Vercel)
-        uses: amondnet/vercel-action@v25
+        uses: amondnet/vercel-action@v42
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update amondnet/vercel-action from v25 to v42 in CI workflows to pick up newer fixes/features. Changes applied to .github/workflows/playwright.yml and .github/workflows/release.yml (three occurrences).

#### Check if the Pull Request fulfils these requirements

- [x] Does the extension require a version change?

<!-- greptile_comment -->

 

<h3>Greptile Summary</h3>

This PR bumps `amondnet/vercel-action` from `v25` to `v42` in three places across `.github/workflows/playwright.yml` and `.github/workflows/release.yml`. The target version exists (latest patch is v42.2.0) and the changelog shows primarily bug fixes including auto-retry on scope errors and improved env var handling.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — straightforward version bump to a valid, existing release with no breaking changes affecting the current usage.

The change is minimal and mechanical: three identical version-tag substitutions. v42 exists and is compatible with the inputs/outputs used (vercel-token, vercel-org-id, vercel-project-id, github-comment, preview-url). No new inputs or removed outputs were introduced that would break the current workflow logic.

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["Bump vercel-action to v42 in workflows"](https://github.com/amitsingh-007/bypass-links/commit/107ae52add278344d9ca42424d9d6358bd19eebf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30539272)</sub>

<!-- /greptile_comment -->