### PR TITLE
Add repositories to Renovate config

### DIFF
--- a/.github/renovate-config.json
+++ b/.github/renovate-config.json
@@ -1,4 +1,5 @@
 {
   "onboarding": false,
-  "requireConfig": "optional"
+  "requireConfig": "optional",
+  "repositories": ["amitsingh-007/bypass-links"]
 }


### PR DESCRIPTION
## Summary

Self-hosted Renovate doesn't auto-detect the repo — it needs `repositories` explicitly listed. Without it, the workflow logs show:

```
WARN: No repositories found - did you want to run with flag --autodiscover?
```

This adds `"repositories": ["amitsingh-007/bypass-links"]` to `.github/renovate-config.json` so the Action processes the correct repo.

<!-- greptile_comment -->



<h3>Greptile Summary</h3>

This PR fixes the self-hosted Renovate configuration by adding the `repositories` field to `.github/renovate-config.json`, and bundles in the resulting automated dependency updates that Renovate generated once the runner began processing the repo correctly.

- **Renovate config fix**: Adds `"repositories": ["amitsingh-007/bypass-links"]` so the self-hosted Renovate Action knows which repo to manage, resolving the "No repositories found" warning.
- **pnpm major version bump**: `packageManager` advances from `10.30.3` to `11.0.7`, a major version change; `pnpm-lock.yaml` and `pnpm-workspace.yaml` are updated in sync.
- **Dependency updates**: Several catalog dependencies receive minor/patch bumps (`@base-ui/react`, `@playwright/test`, `vite`, `turbo`, `zustand`, `wretch`, and others), and the `next-release-tag` action moves from `v6.3.0` to `v6.5.0`.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the Renovate config fix is correct, and dependency updates are routine, though the pnpm major version jump warrants a passing look at CI results.

The Renovate config change is minimal and accurate. The pnpm upgrade from v10 to v11 is the most notable change since major versions can carry breaking changes; the lock file and workspace config are updated in sync, but it's worth confirming CI passes cleanly before merging. All other dependency updates are minor or patch releases with low risk.

No files require special attention beyond confirming that CI passes with pnpm v11.
</details>

<sub>Reviews (1): Last reviewed commit: ["Add repositories to Renovate config"](https://github.com/amitsingh-007/bypass-links/commit/f7a823d3ff1afe4a5d204862c85c75959921c966) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42752392)</sub>

<!-- /greptile_comment -->

## Summary by Sourcery

Configure Renovate to explicitly target this repository and apply the resulting tooling and dependency updates across the workspace.

New Features:
- Add explicit repository configuration to the self-hosted Renovate setup so it targets this project.

Enhancements:
- Update the pnpm workspace catalog with minor and patch version bumps for several dependencies and tooling packages.
- Introduce an allowBuilds configuration in the pnpm workspace to disable builds for selected dependencies.
- Upgrade the project package manager to pnpm v11 and refresh the lockfile accordingly.
- Bump the next-release-tag GitHub Action to a newer version in the release workflow.

Build:
- Align pnpm lockfile and workspace configuration with the updated package manager and dependency versions.

CI:
- Refresh the release workflow to use the newer next-release-tag action version.

<!-- Generated by sourcery-ai[bot]: start fixed-security -->
- Resolves 3/6 issues in [fast-xml-parser](https://app.sourcery.ai/dashboard/security/issues?groupId=78850359&issueIds=83142943,83142944,83142945)
- Resolves all 3 issues in [minimatch](https://app.sourcery.ai/dashboard/security/issues?groupId=78850365&issueIds=83142949,83142950,83142951)
- Resolves all 4 issues in [node-forge](https://app.sourcery.ai/dashboard/security/issues?groupId=78850396&issueIds=83142980,83142981,83142982,83142983)
- Resolves 5/11 issues in [protobufjs](https://app.sourcery.ai/dashboard/security/issues?groupId=78850400&issueIds=83142984,83142985,83142986,83142987,83142988)
<!-- Generated by sourcery-ai[bot]: end fixed-security -->