### PR TITLE
Use React Compiler

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -51,20 +51,12 @@ jobs:
           VERCEL_OUTPUT: ${{ steps.vercel-action.outputs.preview-url }}
         run: echo "url=${VERCEL_INPUT:-$VERCEL_OUTPUT}" >> "$GITHUB_OUTPUT"
 
-      # Point the extension's API host at the deployment under test (the preview)
-      # instead of production, so e2e exercises this build's backend — including
-      # /api/upload-file. Without this the extension always calls prod.
       - name: Point extension at the preview deployment
         env:
           PREVIEW_URL: ${{ steps.preview-url.outputs.url }}
         run: |
           if [ -n "$PREVIEW_URL" ]; then
-            if grep -q '^NEXT_PUBLIC_HOST_NAME=' .env; then
-              sed -i "s#^NEXT_PUBLIC_HOST_NAME=.*#NEXT_PUBLIC_HOST_NAME=${PREVIEW_URL}#" .env
-            else
-              echo "NEXT_PUBLIC_HOST_NAME=${PREVIEW_URL}" >> .env
-            fi
-            echo "Extension API host set to: ${PREVIEW_URL}"
+            sed -i "s#^NEXT_PUBLIC_HOST_NAME=.*#NEXT_PUBLIC_HOST_NAME=${PREVIEW_URL}#" .env
           fi
 
       - name: Building extension
@@ -132,12 +124,8 @@ jobs:
         if: always()
         with:
           name: playwright-report
-          path: .playwright/playwright-report/
-
-      - uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: playwright-test-results
-          path: .playwright/test-results/
+          path: |
+            .playwright/playwright-report/
+            .playwright/test-results/
           include-hidden-files: true
           if-no-files-found: ignore

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -34,15 +34,6 @@ jobs:
       - name: Pull environment variables
         run: pnpm vercel env pull .env --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
-      - name: Building extension
-        run: pnpm build --filter=@bypass/extension
-
-      - name: Uploading Chrome extension
-        uses: actions/upload-artifact@v7
-        with:
-          name: chrome-extension-folder
-          path: ./apps/extension/.output/chrome-mv3
-
       - name: Deploy Preview (Vercel)
         if: ${{ !inputs.vercel_url }}
         uses: amondnet/vercel-action@v42
@@ -59,6 +50,31 @@ jobs:
           VERCEL_INPUT: ${{ inputs.vercel_url }}
           VERCEL_OUTPUT: ${{ steps.vercel-action.outputs.preview-url }}
         run: echo "url=${VERCEL_INPUT:-$VERCEL_OUTPUT}" >> "$GITHUB_OUTPUT"
+
+      # Point the extension's API host at the deployment under test (the preview)
+      # instead of production, so e2e exercises this build's backend — including
+      # /api/upload-file. Without this the extension always calls prod.
+      - name: Point extension at the preview deployment
+        env:
+          PREVIEW_URL: ${{ steps.preview-url.outputs.url }}
+        run: |
+          if [ -n "$PREVIEW_URL" ]; then
+            if grep -q '^NEXT_PUBLIC_HOST_NAME=' .env; then
+              sed -i "s#^NEXT_PUBLIC_HOST_NAME=.*#NEXT_PUBLIC_HOST_NAME=${PREVIEW_URL}#" .env
+            else
+              echo "NEXT_PUBLIC_HOST_NAME=${PREVIEW_URL}" >> .env
+            fi
+            echo "Extension API host set to: ${PREVIEW_URL}"
+          fi
+
+      - name: Building extension
+        run: pnpm build --filter=@bypass/extension
+
+      - name: Uploading Chrome extension
+        uses: actions/upload-artifact@v7
+        with:
+          name: chrome-extension-folder
+          path: ./apps/extension/.output/chrome-mv3
 
   Playwright:
     needs: [Build]

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -46,10 +46,7 @@ jobs:
 
       - name: Set preview URL
         id: preview-url
-        env:
-          VERCEL_INPUT: ${{ inputs.vercel_url }}
-          VERCEL_OUTPUT: ${{ steps.vercel-action.outputs.preview-url }}
-        run: echo "url=${VERCEL_INPUT:-$VERCEL_OUTPUT}" >> "$GITHUB_OUTPUT"
+        run: echo "url=${{ inputs.vercel_url || steps.vercel-action.outputs.preview-url }}" >> "$GITHUB_OUTPUT"
 
       - name: Point extension at the preview deployment
         run: sed -i "s#^NEXT_PUBLIC_HOST_NAME=.*#NEXT_PUBLIC_HOST_NAME=${{ steps.preview-url.outputs.url }}#" .env

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -46,7 +46,10 @@ jobs:
 
       - name: Set preview URL
         id: preview-url
-        run: echo "url=${{ inputs.vercel_url || steps.vercel-action.outputs.preview-url }}" >> "$GITHUB_OUTPUT"
+        env:
+          VERCEL_INPUT: ${{ inputs.vercel_url }}
+          VERCEL_OUTPUT: ${{ steps.vercel-action.outputs.preview-url }}
+        run: echo "url=${VERCEL_INPUT:-$VERCEL_OUTPUT}" >> "$GITHUB_OUTPUT"
 
       - name: Point extension at the preview deployment
         run: sed -i "s#^NEXT_PUBLIC_HOST_NAME=.*#NEXT_PUBLIC_HOST_NAME=${{ steps.preview-url.outputs.url }}#" .env

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -117,3 +117,11 @@ jobs:
         with:
           name: playwright-report
           path: .playwright/playwright-report/
+
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: playwright-test-results
+          path: .playwright/test-results/
+          include-hidden-files: true
+          if-no-files-found: ignore

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -52,12 +52,7 @@ jobs:
         run: echo "url=${VERCEL_INPUT:-$VERCEL_OUTPUT}" >> "$GITHUB_OUTPUT"
 
       - name: Point extension at the preview deployment
-        env:
-          PREVIEW_URL: ${{ steps.preview-url.outputs.url }}
-        run: |
-          if [ -n "$PREVIEW_URL" ]; then
-            sed -i "s#^NEXT_PUBLIC_HOST_NAME=.*#NEXT_PUBLIC_HOST_NAME=${PREVIEW_URL}#" .env
-          fi
+        run: sed -i "s#^NEXT_PUBLIC_HOST_NAME=.*#NEXT_PUBLIC_HOST_NAME=${{ steps.preview-url.outputs.url }}#" .env
 
       - name: Building extension
         run: pnpm build --filter=@bypass/extension

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,17 +83,17 @@ jobs:
           key: cache-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: cache-playwright-
 
-      - name: Download extensions
-        uses: actions/download-artifact@v8
-        with:
-          name: extensions-folder
-          path: ./apps/extension/.output
-
       - name: Install dependencies
         run: pnpm install
 
       - name: Pull environment variables
         run: pnpm vercel env pull .env --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Point extension at the preview deployment
+        run: sed -i "s#^NEXT_PUBLIC_HOST_NAME=.*#NEXT_PUBLIC_HOST_NAME=${{ needs.Build.outputs.preview_url }}#" .env
+
+      - name: Building extension
+        run: pnpm build --filter=@bypass/extension
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,15 @@ jobs:
       - name: Pull environment variables
         run: pnpm vercel env pull .env --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
+      - name: Deploy Preview (Vercel)
+        uses: amondnet/vercel-action@v42
+        id: vercel-action
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID}}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID}}
+          github-comment: false
+
       - name: Building Extension
         run: pnpm build --filter=@bypass/extension
 
@@ -43,14 +52,17 @@ jobs:
           path: ./apps/extension/.output
           include-hidden-files: true
 
-      - name: Deploy Preview (Vercel)
-        uses: amondnet/vercel-action@v42
-        id: vercel-action
+      - name: Point extension at the preview deployment
+        run: sed -i "s#^NEXT_PUBLIC_HOST_NAME=.*#NEXT_PUBLIC_HOST_NAME=${{ steps.vercel-action.outputs.preview-url }}#" .env
+
+      - name: Building extension for e2e
+        run: pnpm build --filter=@bypass/extension
+
+      - name: Uploading e2e extension
+        uses: actions/upload-artifact@v7
         with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID}}
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID}}
-          github-comment: false
+          name: chrome-extension-folder
+          path: ./apps/extension/.output/chrome-mv3
 
   Playwright:
     needs: [Build]
@@ -83,17 +95,17 @@ jobs:
           key: cache-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: cache-playwright-
 
+      - name: Download extension
+        uses: actions/download-artifact@v8
+        with:
+          name: chrome-extension-folder
+          path: ./apps/extension/.output/chrome-mv3/
+
       - name: Install dependencies
         run: pnpm install
 
       - name: Pull environment variables
         run: pnpm vercel env pull .env --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Point extension at the preview deployment
-        run: sed -i "s#^NEXT_PUBLIC_HOST_NAME=.*#NEXT_PUBLIC_HOST_NAME=${{ needs.Build.outputs.preview_url }}#" .env
-
-      - name: Building extension
-        run: pnpm build --filter=@bypass/extension
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ All new UI components should be added to `packages/ui` and exported from `packag
 
 **IMPORTANT**: Never modify files inside `packages/ui` unless explicitly asked. The UI package contains shadcn/ui components that should remain unchanged unless adding new components or making approved modifications.
 
-## Development Guidelines
+## IMPORTANT: Development Guidelines
 
 - Ask any questions instead of assuming things when in plan mode
 - Never automatically commit or push changes unless explicitly asked

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bypass/extension",
   "type": "module",
-  "version": "24.10.0",
+  "version": "24.11.0",
   "private": true,
   "description": "Bypass links from various sites to required links, with added functionality of Bookmarks Manager, Tagging Panel.",
   "scripts": {

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -41,7 +41,9 @@
     "zustand": "catalog:"
   },
   "devDependencies": {
+    "@babel/core": "catalog:",
     "@playwright/test": "catalog:",
+    "@rolldown/plugin-babel": "catalog:",
     "@tailwindcss/vite": "catalog:",
     "@types/chrome": "catalog:",
     "@types/node": "catalog:",
@@ -49,6 +51,7 @@
     "@types/react-avatar-editor": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "catalog:",
+    "babel-plugin-react-compiler": "catalog:",
     "shadcn": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",

--- a/apps/extension/src/entrypoints/popup/components/ContextMenu.tsx
+++ b/apps/extension/src/entrypoints/popup/components/ContextMenu.tsx
@@ -5,7 +5,7 @@ import {
   ContextMenuItem,
   ContextMenuTrigger,
 } from '@bypass/ui';
-import { useMemo, useRef } from 'react';
+import { useRef } from 'react';
 
 export interface IMenuOption {
   text: string;
@@ -23,23 +23,21 @@ interface Props {
 function ContextMenuWrapper({ options, children }: Props) {
   const idRef = useRef('');
 
-  const menuOptions = useMemo(() => {
-    return options.map((option) => {
-      const { id, text, onClick, icon, variant } = option;
+  const menuOptions = options.map((option) => {
+    const { id, text, onClick, icon, variant } = option;
 
-      return {
-        id,
-        key: text,
-        title: text,
-        icon,
-        variant,
-        onClick() {
-          onClick(idRef.current);
-          idRef.current = '';
-        },
-      };
-    });
-  }, [options]);
+    return {
+      id,
+      key: text,
+      title: text,
+      icon,
+      variant,
+      onClick() {
+        onClick(idRef.current);
+        idRef.current = '';
+      },
+    };
+  });
 
   const handleContextMenu = (e: React.MouseEvent) => {
     const dataCtxId = (e.target as HTMLElement).dataset.contextId ?? '';

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarkAddEditDialog.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarkAddEditDialog.tsx
@@ -157,8 +157,7 @@ function BookmarkAddEditDialog({ curFolderId, handleScroll }: Props) {
         dialogHandlers.open();
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [contextBookmarks, curFolderId, defaultFolderId]
+    [contextBookmarks, curFolderId, defaultFolderId, form, dialogHandlers]
   );
 
   useEffect(() => {

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarkContextMenu.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarkContextMenu.tsx
@@ -7,7 +7,7 @@ import {
   LinkSquare02Icon,
 } from '@hugeicons/core-free-icons';
 import { useHotkeys } from '@mantine/hooks';
-import { memo, useCallback, type PropsWithChildren } from 'react';
+import { type PropsWithChildren } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import ContextMenu, { type IMenuOption } from '@popup/components/ContextMenu';
 import useBookmarkStore from '../store/useBookmarkStore';
@@ -20,131 +20,120 @@ type Props = PropsWithChildren<{
   handleOpenSelectedBookmarks: VoidFunction;
 }>;
 
-const BookmarkContextMenu = memo<Props>(
-  ({ children, handleOpenSelectedBookmarks }) => {
-    const setBookmarkOperation = useBookmarkRouteStore(
-      (state) => state.setBookmarkOperation
-    );
-    const {
-      contextBookmarks,
-      selectedBookmarks,
-      cutBookmarks,
-      handleUrlRemove,
-      handleBulkUrlRemove,
-      handleCutBookmarks,
-      handlePasteSelectedBookmarks,
-    } = useBookmarkStore(
-      useShallow((state) => ({
-        contextBookmarks: state.contextBookmarks,
-        selectedBookmarks: state.selectedBookmarks,
-        cutBookmarks: state.cutBookmarks,
-        handleUrlRemove: state.handleUrlRemove,
-        handleBulkUrlRemove: state.handleBulkUrlRemove,
-        handleCutBookmarks: state.handleCutBookmarks,
-        handlePasteSelectedBookmarks: state.handlePasteSelectedBookmarks,
-      }))
-    );
-    const selectedCount = getSelectedCount(selectedBookmarks);
-    const cutCount = getCutCount(cutBookmarks);
+function BookmarkContextMenu({ children, handleOpenSelectedBookmarks }: Props) {
+  const setBookmarkOperation = useBookmarkRouteStore(
+    (state) => state.setBookmarkOperation
+  );
+  const {
+    contextBookmarks,
+    selectedBookmarks,
+    cutBookmarks,
+    handleUrlRemove,
+    handleBulkUrlRemove,
+    handleCutBookmarks,
+    handlePasteSelectedBookmarks,
+  } = useBookmarkStore(
+    useShallow((state) => ({
+      contextBookmarks: state.contextBookmarks,
+      selectedBookmarks: state.selectedBookmarks,
+      cutBookmarks: state.cutBookmarks,
+      handleUrlRemove: state.handleUrlRemove,
+      handleBulkUrlRemove: state.handleBulkUrlRemove,
+      handleCutBookmarks: state.handleCutBookmarks,
+      handlePasteSelectedBookmarks: state.handlePasteSelectedBookmarks,
+    }))
+  );
+  const selectedCount = getSelectedCount(selectedBookmarks);
+  const cutCount = getCutCount(cutBookmarks);
 
-    useHotkeys([
-      [
-        'mod+X',
-        (e) => {
-          e.stopPropagation();
-          handleCutBookmarks();
-        },
-      ],
-      [
-        'mod+V',
-        (e) => {
-          e.stopPropagation();
-          handlePasteSelectedBookmarks();
-        },
-      ],
-    ]);
-
-    const getBookmark = useCallback(
-      (id: string) => {
-        const bookmark = findBookmarkById(contextBookmarks, id);
-        if (!bookmark) {
-          throw new Error(`Bookmark not found for id: ${id}`);
-        }
-        return bookmark;
+  useHotkeys([
+    [
+      'mod+X',
+      (e) => {
+        e.stopPropagation();
+        handleCutBookmarks();
       },
-      [contextBookmarks]
-    );
-
-    const handleDeleteOptionClick = useCallback(
-      (id: string) => {
-        handleUrlRemove(id);
+    ],
+    [
+      'mod+V',
+      (e) => {
+        e.stopPropagation();
+        handlePasteSelectedBookmarks();
       },
-      [handleUrlRemove]
-    );
+    ],
+  ]);
 
-    const handleBookmarkEdit = useCallback(
-      (id: string) => {
-        const bookmark = getBookmark(id);
-        setBookmarkOperation(EBookmarkOperation.EDIT, bookmark.url);
+  const getBookmark = (id: string) => {
+    const bookmark = findBookmarkById(contextBookmarks, id);
+    if (!bookmark) {
+      throw new Error(`Bookmark not found for id: ${id}`);
+    }
+    return bookmark;
+  };
+
+  const handleDeleteOptionClick = (id: string) => {
+    handleUrlRemove(id);
+  };
+
+  const handleBookmarkEdit = (id: string) => {
+    const bookmark = getBookmark(id);
+    setBookmarkOperation(EBookmarkOperation.EDIT, bookmark.url);
+  };
+
+  const getMenuOptions = (): IMenuOption[] => {
+    const menuOptionsList: IMenuOption[] = [
+      {
+        onClick: handleOpenSelectedBookmarks,
+        text: `Open ${
+          selectedCount > 1 ? `all (${selectedCount}) ` : ''
+        }in new tab`,
+        id: 'open',
+        icon: LinkSquare02Icon,
       },
-      [getBookmark, setBookmarkOperation]
-    );
-
-    const getMenuOptions = (): IMenuOption[] => {
-      const menuOptionsList: IMenuOption[] = [
+      {
+        onClick: handleCutBookmarks,
+        text: 'Cut',
+        icon: FileExportIcon,
+        id: 'cut',
+      },
+    ];
+    if (cutCount > 0 && selectedCount === 1) {
+      menuOptionsList.push({
+        onClick: handlePasteSelectedBookmarks,
+        text: `Paste (${cutCount})`,
+        id: 'paste',
+        icon: FilePasteIcon,
+      });
+    }
+    if (selectedCount > 1) {
+      menuOptionsList.push({
+        onClick: handleBulkUrlRemove,
+        text: 'Delete All',
+        id: 'delete-all',
+        icon: BookmarkRemove01Icon,
+        variant: 'destructive',
+      });
+    } else {
+      menuOptionsList.push(
         {
-          onClick: handleOpenSelectedBookmarks,
-          text: `Open ${
-            selectedCount > 1 ? `all (${selectedCount}) ` : ''
-          }in new tab`,
-          id: 'open',
-          icon: LinkSquare02Icon,
+          onClick: handleBookmarkEdit,
+          text: 'Edit',
+          id: 'edit',
+          icon: BookEditIcon,
         },
         {
-          onClick: handleCutBookmarks,
-          text: 'Cut',
-          icon: FileExportIcon,
-          id: 'cut',
-        },
-      ];
-      if (cutCount > 0 && selectedCount === 1) {
-        menuOptionsList.push({
-          onClick: handlePasteSelectedBookmarks,
-          text: `Paste (${cutCount})`,
-          id: 'paste',
-          icon: FilePasteIcon,
-        });
-      }
-      if (selectedCount > 1) {
-        menuOptionsList.push({
-          onClick: handleBulkUrlRemove,
-          text: 'Delete All',
-          id: 'delete-all',
+          onClick: handleDeleteOptionClick,
+          text: 'Delete',
+          id: 'delete',
           icon: BookmarkRemove01Icon,
           variant: 'destructive',
-        });
-      } else {
-        menuOptionsList.push(
-          {
-            onClick: handleBookmarkEdit,
-            text: 'Edit',
-            id: 'edit',
-            icon: BookEditIcon,
-          },
-          {
-            onClick: handleDeleteOptionClick,
-            text: 'Delete',
-            id: 'delete',
-            icon: BookmarkRemove01Icon,
-            variant: 'destructive',
-          }
-        );
-      }
-      return menuOptionsList;
-    };
+        }
+      );
+    }
+    return menuOptionsList;
+  };
 
-    return <ContextMenu options={getMenuOptions()}>{children}</ContextMenu>;
-  }
-);
+  return <ContextMenu options={getMenuOptions()}>{children}</ContextMenu>;
+}
 
 export default BookmarkContextMenu;

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksPanel.tsx
@@ -58,8 +58,10 @@ function BookmarksPanel({ folderId, operation, bmUrl }: BMPanelQueryParams) {
     getItemKey: (idx) => filteredContextBookmarks[idx].id,
   });
 
-  const handleScroll = (itemNumber: number) =>
-    virtualizer.scrollToIndex(itemNumber);
+  const handleScroll = useCallback(
+    (itemNumber: number) => virtualizer.scrollToIndex(itemNumber),
+    [virtualizer]
+  );
 
   const handleOpenSelectedBookmarks = useCallback(() => {
     startHistoryMonitor();
@@ -75,8 +77,7 @@ function BookmarksPanel({ folderId, operation, bmUrl }: BMPanelQueryParams) {
     if (!isFetching) {
       handleScroll(0);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isFetching]);
+  }, [isFetching, handleScroll]);
 
   useEffect(() => {
     loadData(folderId);

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksPanel.tsx
@@ -10,7 +10,7 @@ import {
 import { ScrollArea } from '@bypass/ui';
 import useHistoryStore from '@store/history';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import useBookmarkRouteStore from '../store/useBookmarkRouteStore';
 import useBookmarkStore from '../store/useBookmarkStore';
@@ -46,9 +46,9 @@ function BookmarksPanel({ folderId, operation, bmUrl }: BMPanelQueryParams) {
   );
   const scrollAreaRef = useRef<HTMLDivElement>(null);
   const [searchText, setSearchText] = useState('');
-  const filteredContextBookmarks = useMemo(
-    () => getFilteredContextBookmarks(contextBookmarks, searchText),
-    [contextBookmarks, searchText]
+  const filteredContextBookmarks = getFilteredContextBookmarks(
+    contextBookmarks,
+    searchText
   );
   const virtualizer = useVirtualizer({
     count: filteredContextBookmarks.length,
@@ -63,14 +63,14 @@ function BookmarksPanel({ folderId, operation, bmUrl }: BMPanelQueryParams) {
     [virtualizer]
   );
 
-  const handleOpenSelectedBookmarks = useCallback(() => {
+  const handleOpenSelectedBookmarks = () => {
     startHistoryMonitor();
     contextBookmarks.forEach((bookmark, index) => {
       if (selectedBookmarks[index] && !bookmark.isDir) {
         browser.tabs.create({ url: bookmark.url, active: false });
       }
     });
-  }, [contextBookmarks, selectedBookmarks, startHistoryMonitor]);
+  };
 
   // Reset scroll on folder change
   useEffect(() => {

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/FolderRow.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/FolderRow.tsx
@@ -7,7 +7,6 @@ import {
   StarIcon,
   StarOffIcon,
 } from '@hugeicons/core-free-icons';
-import { memo, useCallback, useMemo } from 'react';
 import ContextMenu, { type IMenuOption } from '@popup/components/ContextMenu';
 import { FolderAddEditDialog } from './FolderAddEditDialog';
 
@@ -18,88 +17,78 @@ interface Props extends FolderProps {
   handleEdit: (folderId: string, newName: string) => void;
 }
 
-const FolderRow = memo<Props>(
-  ({
-    id,
-    name: origName,
-    isDefault,
+function FolderRow({
+  id,
+  name: origName,
+  isDefault,
 
-    handleRemove,
-    handleEdit,
-    toggleDefaultFolder,
-    ...restProps
-  }) => {
-    const [openEditDialog, editDialogHandlers] = useDisclosure(false);
+  handleRemove,
+  handleEdit,
+  toggleDefaultFolder,
+  ...restProps
+}: Props) {
+  const [openEditDialog, editDialogHandlers] = useDisclosure(false);
 
-    const handleDeleteOptionClick = useCallback(() => {
-      handleRemove(id);
-    }, [handleRemove, id]);
+  const handleDeleteOptionClick = () => {
+    handleRemove(id);
+  };
 
-    const handleDefaultOptionClick = useCallback(() => {
-      toggleDefaultFolder(id, !isDefault);
-    }, [id, isDefault, toggleDefaultFolder]);
+  const handleDefaultOptionClick = () => {
+    toggleDefaultFolder(id, !isDefault);
+  };
 
-    const handleFolderSave = (newName: string) => {
-      handleEdit(id, newName);
-    };
+  const handleFolderSave = (newName: string) => {
+    handleEdit(id, newName);
+  };
 
-    const menuOptions = useMemo(() => {
-      const options: IMenuOption[] = [
-        {
-          onClick: editDialogHandlers.open,
-          text: 'Edit',
-          id: 'edit',
-          icon: FolderEditIcon,
-        },
-        {
-          onClick: handleDefaultOptionClick,
-          text: isDefault ? 'Remove default' : 'Make default',
-          id: isDefault ? 'remove-default' : 'make-default',
-          icon: isDefault ? StarOffIcon : StarIcon,
-        },
-        {
-          onClick: handleDeleteOptionClick,
-          text: 'Delete',
-          id: 'delete',
-          icon: FolderRemoveIcon,
-          variant: 'destructive',
-        },
-      ];
-      return options;
-    }, [
-      handleDefaultOptionClick,
-      handleDeleteOptionClick,
-      editDialogHandlers.open,
-      isDefault,
-    ]);
+  const menuOptions: IMenuOption[] = [
+    {
+      onClick: editDialogHandlers.open,
+      text: 'Edit',
+      id: 'edit',
+      icon: FolderEditIcon,
+    },
+    {
+      onClick: handleDefaultOptionClick,
+      text: isDefault ? 'Remove default' : 'Make default',
+      id: isDefault ? 'remove-default' : 'make-default',
+      icon: isDefault ? StarOffIcon : StarIcon,
+    },
+    {
+      onClick: handleDeleteOptionClick,
+      text: 'Delete',
+      id: 'delete',
+      icon: FolderRemoveIcon,
+      variant: 'destructive',
+    },
+  ];
 
-    return (
-      <>
-        <ContextMenu options={menuOptions}>
-          <div className="relative size-full">
-            <Folder id={id} name={origName} {...restProps} />
-            {isDefault && (
-              <div
-                className="
-                  absolute top-1/2 right-1.5 flex -translate-y-1/2 items-center
-                  text-yellow-500
-                "
-              >
-                <HugeiconsIcon icon={StarIcon} className="size-4" />
-              </div>
-            )}
-          </div>
-        </ContextMenu>
-        <FolderAddEditDialog
-          headerText="Edit folder"
-          origName={origName}
-          handleSave={handleFolderSave}
-          isOpen={openEditDialog}
-          onClose={editDialogHandlers.close}
-        />
-      </>
-    );
-  }
-);
+  return (
+    <>
+      <ContextMenu options={menuOptions}>
+        <div className="relative size-full">
+          <Folder id={id} name={origName} {...restProps} />
+          {isDefault && (
+            <div
+              className="
+                absolute top-1/2 right-1.5 flex -translate-y-1/2 items-center
+                text-yellow-500
+              "
+            >
+              <HugeiconsIcon icon={StarIcon} className="size-4" />
+            </div>
+          )}
+        </div>
+      </ContextMenu>
+      <FolderAddEditDialog
+        headerText="Edit folder"
+        origName={origName}
+        handleSave={handleFolderSave}
+        isOpen={openEditDialog}
+        onClose={editDialogHandlers.close}
+      />
+    </>
+  );
+}
 
 export default FolderRow;

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/PersonSelect.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/PersonSelect.tsx
@@ -27,7 +27,7 @@ import {
 } from '@bypass/ui';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { UserWarning03Icon } from '@hugeicons/core-free-icons';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 interface IOptionData {
   label: string;
@@ -44,37 +44,39 @@ interface AvatarWithPreviewProps {
   person: IOptionData;
 }
 
-const AvatarWithPreview = memo<AvatarWithPreviewProps>(({ person }) => (
-  <HoverCard>
-    <HoverCardTrigger delay={0} closeDelay={0}>
-      <Avatar size="sm" className="size-6!">
-        <AvatarImage src={person.image} alt={person.label} />
-        <AvatarFallback>
-          <HugeiconsIcon icon={UserWarning03Icon} className="size-3" />
-        </AvatarFallback>
-      </Avatar>
-    </HoverCardTrigger>
-    <HoverCardContent
-      side="top"
-      align="center"
-      sideOffset={4}
-      className="z-50 size-auto rounded-full p-0.5"
-      data-testid={`person-avatar-preview-${person.value}`}
-    >
-      <Tooltip>
-        <TooltipTrigger className="flex items-center justify-center">
-          <Avatar className="size-20">
-            <AvatarImage src={person.image} alt={person.label} />
-            <AvatarFallback>
-              <HugeiconsIcon icon={UserWarning03Icon} className="size-6" />
-            </AvatarFallback>
-          </Avatar>
-        </TooltipTrigger>
-        <TooltipContent side="right">{person.label}</TooltipContent>
-      </Tooltip>
-    </HoverCardContent>
-  </HoverCard>
-));
+function AvatarWithPreview({ person }: AvatarWithPreviewProps) {
+  return (
+    <HoverCard>
+      <HoverCardTrigger delay={0} closeDelay={0}>
+        <Avatar size="sm" className="size-6!">
+          <AvatarImage src={person.image} alt={person.label} />
+          <AvatarFallback>
+            <HugeiconsIcon icon={UserWarning03Icon} className="size-3" />
+          </AvatarFallback>
+        </Avatar>
+      </HoverCardTrigger>
+      <HoverCardContent
+        side="top"
+        align="center"
+        sideOffset={4}
+        className="z-50 size-auto rounded-full p-0.5"
+        data-testid={`person-avatar-preview-${person.value}`}
+      >
+        <Tooltip>
+          <TooltipTrigger className="flex items-center justify-center">
+            <Avatar className="size-20">
+              <AvatarImage src={person.image} alt={person.label} />
+              <AvatarFallback>
+                <HugeiconsIcon icon={UserWarning03Icon} className="size-6" />
+              </AvatarFallback>
+            </Avatar>
+          </TooltipTrigger>
+          <TooltipContent side="right">{person.label}</TooltipContent>
+        </Tooltip>
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
 
 function PersonSelect({ value, onChange }: PersonSelectProps) {
   const { getDefaultOrRootFolderUrls } = useBookmark();
@@ -110,18 +112,14 @@ function PersonSelect({ value, onChange }: PersonSelectProps) {
 
   const toggleOrderByRecency = () => setOrderByRecency((prev) => !prev);
 
-  const selectedPersons = useMemo(
-    () => personList.filter((p) => value.includes(p.value)),
-    [personList, value]
-  );
+  const selectedPersons = personList.filter((p) => value.includes(p.value));
 
   // Filter persons based on search query
-  const filteredPersonList = useMemo(() => {
-    if (!searchQuery.trim()) return personList;
-    return personList.filter((person) =>
-      person.label.toLowerCase().includes(searchQuery.toLowerCase())
-    );
-  }, [personList, searchQuery]);
+  const filteredPersonList = searchQuery.trim()
+    ? personList.filter((person) =>
+        person.label.toLowerCase().includes(searchQuery.toLowerCase())
+      )
+    : personList;
 
   const hasResults = filteredPersonList.length > 0;
 

--- a/apps/extension/src/entrypoints/popup/panels/HomePopup/components/ToggleExtension.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/HomePopup/components/ToggleExtension.tsx
@@ -1,6 +1,6 @@
 import { Switch } from '@bypass/ui';
 import useExtStore from '@store/extension';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { getIsExtensionActive } from '@/utils/common';
 import { EExtensionState } from '@/constants';
 import { extStateItem } from '@/storage/items';
@@ -12,22 +12,21 @@ function ToggleExtension() {
     EExtensionState.INACTIVE
   );
 
-  const dispatchActionAndSetState = (
-    _extState: EExtensionState,
-    isActive: boolean
-  ) => {
-    setExtState(_extState);
-    const action = isActive ? turnOnExtension : turnOffExtension;
-    action();
-  };
+  const dispatchActionAndSetState = useCallback(
+    (_extState: EExtensionState, isActive: boolean) => {
+      setExtState(_extState);
+      const action = isActive ? turnOnExtension : turnOffExtension;
+      action();
+    },
+    [turnOnExtension, turnOffExtension]
+  );
 
   useEffect(() => {
     extStateItem.getValue().then((_extState) => {
       const isActive = getIsExtensionActive(_extState);
       dispatchActionAndSetState(_extState, isActive);
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [dispatchActionAndSetState]);
 
   const handleToggle = (checked: boolean) => {
     const extensionState = checked

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/ImagePicker.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/ImagePicker.tsx
@@ -68,34 +68,13 @@ function ImagePicker({ uid, isOpen, onDialogClose, handleImageSave }: Props) {
     }
   };
 
-  // react-avatar-editor paints onto its canvas asynchronously, so getImage()
-  // can throw for a frame or two even after onImageReady has fired — a race the
-  // React Compiler's render-timing changes make easy to hit. Retry across a few
-  // animation frames before giving up.
-  const getCroppedDataUrl = async () => {
-    for (let attempt = 0; attempt < 10; attempt += 1) {
-      const editor = imageCropperRef.current;
-      if (editor) {
-        try {
-          return editor.getImage().toDataURL();
-        } catch {
-          // Canvas not ready yet — wait a frame and retry.
-        }
-      }
-      await new Promise((resolve) => {
-        requestAnimationFrame(() => resolve(null));
-      });
-    }
-    throw new Error('Avatar editor image was not ready for cropping');
-  };
-
   const saveCroppedImage = async () => {
     if (!debouncedInputUrl || !imageCropperRef.current) {
       return;
     }
     try {
       setIsUploadingImage(true);
-      const canvas = await getCroppedDataUrl();
+      const canvas = imageCropperRef.current.getImage().toDataURL();
       const croppedImage = await wretch().get(canvas).blob();
       const fileName = getPersonImageName(uid);
       await uploadFileToFirebase(croppedImage, fileName);

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/ImagePicker.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/ImagePicker.tsx
@@ -28,12 +28,6 @@ interface Props {
 }
 
 function ImagePicker({ uid, isOpen, onDialogClose, handleImageSave }: Props) {
-  // Opt out of React Compiler: this component drives the react-avatar-editor
-  // class component via an imperative ref (imageCropperRef.getImage()), which
-  // the compiler's memoization breaks — the crop/upload flow stops closing the
-  // dialog. See issue #4061.
-  'use no memo';
-
   const [isUploadingImage, setIsUploadingImage] = useState(false);
   const [inputOrFileValue, setInputOrFileValue] = useState<string | File>('');
   const [debouncedInputUrl] = useDebouncedValue(inputOrFileValue, 500);
@@ -74,13 +68,34 @@ function ImagePicker({ uid, isOpen, onDialogClose, handleImageSave }: Props) {
     }
   };
 
+  // react-avatar-editor paints onto its canvas asynchronously, so getImage()
+  // can throw for a frame or two even after onImageReady has fired — a race the
+  // React Compiler's render-timing changes make easy to hit. Retry across a few
+  // animation frames before giving up.
+  const getCroppedDataUrl = async () => {
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      const editor = imageCropperRef.current;
+      if (editor) {
+        try {
+          return editor.getImage().toDataURL();
+        } catch {
+          // Canvas not ready yet — wait a frame and retry.
+        }
+      }
+      await new Promise((resolve) => {
+        requestAnimationFrame(() => resolve(null));
+      });
+    }
+    throw new Error('Avatar editor image was not ready for cropping');
+  };
+
   const saveCroppedImage = async () => {
     if (!debouncedInputUrl || !imageCropperRef.current) {
       return;
     }
     try {
       setIsUploadingImage(true);
-      const canvas = imageCropperRef.current.getImage().toDataURL();
+      const canvas = await getCroppedDataUrl();
       const croppedImage = await wretch().get(canvas).blob();
       const fileName = getPersonImageName(uid);
       await uploadFileToFirebase(croppedImage, fileName);

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/ImagePicker.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/ImagePicker.tsx
@@ -28,6 +28,12 @@ interface Props {
 }
 
 function ImagePicker({ uid, isOpen, onDialogClose, handleImageSave }: Props) {
+  // Opt out of React Compiler: this component drives the react-avatar-editor
+  // class component via an imperative ref (imageCropperRef.getImage()), which
+  // the compiler's memoization breaks — the crop/upload flow stops closing the
+  // dialog. See issue #4061.
+  'use no memo';
+
   const [isUploadingImage, setIsUploadingImage] = useState(false);
   const [inputOrFileValue, setInputOrFileValue] = useState<string | File>('');
   const [debouncedInputUrl] = useDebouncedValue(inputOrFileValue, 500);

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/PersonVirtualCell.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/PersonVirtualCell.tsx
@@ -1,7 +1,6 @@
 import { type IPerson, Person } from '@bypass/shared';
 import { useDisclosure } from '@mantine/hooks';
 import { Delete02Icon, Edit01Icon } from '@hugeicons/core-free-icons';
-import { memo, useCallback, useMemo } from 'react';
 import ContextMenu, { type IMenuOption } from '@popup/components/ContextMenu';
 import AddOrEditPersonDialog from './AddOrEditPersonDialog';
 
@@ -11,55 +10,53 @@ interface Props {
   handlePersonDelete: (person: IPerson) => void;
 }
 
-const PersonVirtualCell = memo<Props>(
-  ({ person, handleEditPerson, handlePersonDelete }) => {
-    const [showEditPersonDialog, editPersonDialogHandlers] =
-      useDisclosure(false);
+function PersonVirtualCell({
+  person,
+  handleEditPerson,
+  handlePersonDelete,
+}: Props) {
+  const [showEditPersonDialog, editPersonDialogHandlers] = useDisclosure(false);
 
-    const handleDeleteOptionClick = useCallback(() => {
-      handlePersonDelete(person);
-    }, [handlePersonDelete, person]);
+  const handleDeleteOptionClick = () => {
+    handlePersonDelete(person);
+  };
 
-    const menuOptions = useMemo(() => {
-      const options: IMenuOption[] = [
-        {
-          onClick: editPersonDialogHandlers.open,
-          text: 'Edit',
-          id: 'edit',
-          icon: Edit01Icon,
-        },
-        {
-          onClick: handleDeleteOptionClick,
-          text: 'Delete',
-          id: 'delete',
-          icon: Delete02Icon,
-          variant: 'destructive',
-        },
-      ];
-      return options;
-    }, [editPersonDialogHandlers.open, handleDeleteOptionClick]);
+  const menuOptions: IMenuOption[] = [
+    {
+      onClick: editPersonDialogHandlers.open,
+      text: 'Edit',
+      id: 'edit',
+      icon: Edit01Icon,
+    },
+    {
+      onClick: handleDeleteOptionClick,
+      text: 'Delete',
+      id: 'delete',
+      icon: Delete02Icon,
+      variant: 'destructive',
+    },
+  ];
 
-    const handlePersonSave = async (updatedPerson: IPerson) => {
-      await handleEditPerson(updatedPerson);
-      editPersonDialogHandlers.close();
-    };
+  const handlePersonSave = async (updatedPerson: IPerson) => {
+    await handleEditPerson(updatedPerson);
+    editPersonDialogHandlers.close();
+  };
 
-    return (
-      <div className="h-full p-1.5">
-        <ContextMenu options={menuOptions}>
-          <Person person={person} />
-        </ContextMenu>
-        {showEditPersonDialog && (
-          <AddOrEditPersonDialog
-            person={person}
-            isOpen={showEditPersonDialog}
-            handleSaveClick={handlePersonSave}
-            onClose={editPersonDialogHandlers.close}
-          />
-        )}
-      </div>
-    );
-  }
-);
+  return (
+    <div className="h-full p-1.5">
+      <ContextMenu options={menuOptions}>
+        <Person person={person} />
+      </ContextMenu>
+      {showEditPersonDialog && (
+        <AddOrEditPersonDialog
+          person={person}
+          isOpen={showEditPersonDialog}
+          handleSaveClick={handlePersonSave}
+          onClose={editPersonDialogHandlers.close}
+        />
+      )}
+    </div>
+  );
+}
 
 export default PersonVirtualCell;

--- a/apps/extension/src/entrypoints/popup/panels/ShortcutsPanel/components/ShortcutsPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/ShortcutsPanel/components/ShortcutsPanel.tsx
@@ -53,14 +53,15 @@ function ShortcutsPanel() {
   };
 
   const handleAddRule = () => {
-    saveRedirectionTemp([
+    const newRedirections = [
       {
         alias: DEFAULT_RULE_ALIAS,
         website: '',
         isDefault: false,
       },
       ...redirections,
-    ]);
+    ];
+    saveRedirectionTemp(newRedirections);
   };
 
   const handleRemoveRule = (pos: number) => {

--- a/apps/extension/src/entrypoints/popup/panels/ShortcutsPanel/components/ShortcutsPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/ShortcutsPanel/components/ShortcutsPanel.tsx
@@ -53,12 +53,14 @@ function ShortcutsPanel() {
   };
 
   const handleAddRule = () => {
-    redirections.unshift({
-      alias: DEFAULT_RULE_ALIAS,
-      website: '',
-      isDefault: false,
-    });
-    saveRedirectionTemp([...redirections]);
+    saveRedirectionTemp([
+      {
+        alias: DEFAULT_RULE_ALIAS,
+        website: '',
+        isDefault: false,
+      },
+      ...redirections,
+    ]);
   };
 
   const handleRemoveRule = (pos: number) => {
@@ -68,8 +70,9 @@ function ShortcutsPanel() {
   };
 
   const handleSaveRule = (redirection: IRedirection, pos: number) => {
-    redirections[pos] = redirection;
-    saveRedirectionTemp([...redirections]);
+    const newRedirections = [...redirections];
+    newRedirections[pos] = redirection;
+    saveRedirectionTemp(newRedirections);
   };
 
   const handleRuleMoveUp = (pos: number) => {

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -11,6 +11,16 @@ const envDir = path.resolve(
   '../..'
 );
 
+// React Compiler mis-optimizes the Persons image-crop flow (react-avatar-editor
+// + nested base-ui dialogs), leaving the "Upload Image" dialog stuck open on
+// save — see issue #4061. Exclude that subtree from compilation; the compiler
+// stays enabled for the rest of the extension.
+const reactCompiler = reactCompilerPreset();
+reactCompiler.rolldown.filter = {
+  ...reactCompiler.rolldown.filter,
+  id: { exclude: [/\/PersonsPanel\//] },
+};
+
 export default defineConfig({
   srcDir: 'src',
   browser: 'chrome',
@@ -33,7 +43,7 @@ export default defineConfig({
       plugins: [
         react(),
         babel({
-          presets: [reactCompilerPreset()],
+          presets: [reactCompiler],
         }),
         tailwindcss(),
       ],

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -1,7 +1,6 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import babel from '@rolldown/plugin-babel';
-import react, { reactCompilerPreset } from '@vitejs/plugin-react';
+import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'wxt';
 import { devManifest, prodOAuth2 } from './src/constants/manifest';
@@ -10,16 +9,6 @@ const envDir = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   '../..'
 );
-
-// Keep React Compiler off third-party node_modules. Compiling @base-ui/react
-// broke its dialog close behaviour, leaving the Persons "Upload Image" dialog
-// stuck open on save — see issue #4061. The compiler still runs on the
-// extension's own src and the @bypass/* workspace packages (real paths).
-const reactCompiler = reactCompilerPreset();
-reactCompiler.rolldown.filter = {
-  ...reactCompiler.rolldown.filter,
-  id: { exclude: [/\/node_modules\//] },
-};
 
 export default defineConfig({
   srcDir: 'src',
@@ -40,13 +29,7 @@ export default defineConfig({
       envDir,
       envPrefix: 'NEXT_PUBLIC_',
 
-      plugins: [
-        react(),
-        babel({
-          presets: [reactCompiler],
-        }),
-        tailwindcss(),
-      ],
+      plugins: [react(), tailwindcss()],
       build: { target: 'esnext' },
       resolve: {
         tsconfigPaths: true,

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -11,14 +11,14 @@ const envDir = path.resolve(
   '../..'
 );
 
-// React Compiler mis-optimizes the Persons image-crop flow (react-avatar-editor
-// + nested base-ui dialogs), leaving the "Upload Image" dialog stuck open on
-// save — see issue #4061. Exclude that subtree from compilation; the compiler
-// stays enabled for the rest of the extension.
+// Keep React Compiler off third-party node_modules. Compiling @base-ui/react
+// broke its dialog close behaviour, leaving the Persons "Upload Image" dialog
+// stuck open on save — see issue #4061. The compiler still runs on the
+// extension's own src and the @bypass/* workspace packages (real paths).
 const reactCompiler = reactCompilerPreset();
 reactCompiler.rolldown.filter = {
   ...reactCompiler.rolldown.filter,
-  id: { exclude: [/\/PersonsPanel\//] },
+  id: { exclude: [/\/node_modules\//] },
 };
 
 export default defineConfig({

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import react from '@vitejs/plugin-react';
+import babel from '@rolldown/plugin-babel';
+import react, { reactCompilerPreset } from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'wxt';
 import { devManifest, prodOAuth2 } from './src/constants/manifest';
@@ -29,7 +30,13 @@ export default defineConfig({
       envDir,
       envPrefix: 'NEXT_PUBLIC_',
 
-      plugins: [react(), tailwindcss()],
+      plugins: [
+        react(),
+        babel({
+          presets: [reactCompilerPreset()],
+        }),
+        tailwindcss(),
+      ],
       build: { target: 'esnext' },
       resolve: {
         tsconfigPaths: true,

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -12,6 +12,13 @@ if (!process.env.VERCEL) {
 
 const isDev = process.env.NODE_ENV === 'development';
 
+// TODO: The build runs via `next build --webpack` (see package.json) instead of
+// the Turbopack default. Turbopack emits hash-suffixed external-module
+// references that don't resolve under pnpm's symlinked node_modules on Vercel,
+// so sharp's native binary fails to load in /api/upload-file (ERR_DLOPEN_FAILED)
+// and the endpoint 500s. webpack traces the native module correctly.
+// Tracking: https://github.com/vercel/next.js/issues/87737
+// Once fixed upstream, drop `--webpack` to switch the build back to Turbopack.
 const nextConfig: NextConfig = {
   productionBrowserSourceMaps: true,
   cacheComponents: true,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "next build",
+    "build": "next build --webpack",
     "dev": "next dev",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "next build --webpack",
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/web/src/app/bookmark-panel/page.tsx
+++ b/apps/web/src/app/bookmark-panel/page.tsx
@@ -16,7 +16,7 @@ import {
 import { ScrollArea } from '@bypass/ui';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useSearchParams } from 'next/navigation';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import VirtualRow from './components/VirtualRow';
 
 export default function BookmarksPage() {
@@ -29,9 +29,9 @@ export default function BookmarksPage() {
   );
   const [folders, setFolders] = useState<IBookmarksObj['folders']>({});
   const [searchText, setSearchText] = useState('');
-  const filteredContextBookmarks = useMemo(
-    () => getFilteredContextBookmarks(contextBookmarks, searchText),
-    [contextBookmarks, searchText]
+  const filteredContextBookmarks = getFilteredContextBookmarks(
+    contextBookmarks,
+    searchText
   );
   const virtualizer = useVirtualizer({
     count: filteredContextBookmarks.length,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@playwright/test": "catalog:",
     "@types/node": "catalog:",
     "eslint-plugin-better-tailwindcss": "catalog:",
+    "eslint-plugin-react-compiler": "catalog:",
     "lefthook": "catalog:",
     "prettier": "catalog:",
     "tailwindcss": "catalog:",

--- a/packages/shared/src/components/Bookmarks/components/Bookmark.tsx
+++ b/packages/shared/src/components/Bookmarks/components/Bookmark.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { memo, useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   Tooltip,
   TooltipContent,
@@ -35,91 +35,89 @@ const getPersonsFromUids = (uids: string[], persons: IPerson[]) => {
   return persons.filter((person) => uids.includes(person.uid ?? ''));
 };
 
-const Bookmark = memo<BookmarkProps>(
-  ({
-    id,
-    url,
-    title,
-    pos = 0,
-    taggedPersons,
-    isSelected,
-    handleSelectedChange,
-    onOpenLink,
-    getFaviconUrl,
-  }) => {
-    const [personsWithImageUrls, setPersonsWithImageUrls] = useState<
-      IPersonWithImage[]
-    >([]);
-    const { getAllDecodedPersons, getPersonsWithImageUrl } = usePerson();
-    const isMobile = usePlatform();
+function Bookmark({
+  id,
+  url,
+  title,
+  pos = 0,
+  taggedPersons,
+  isSelected,
+  handleSelectedChange,
+  onOpenLink,
+  getFaviconUrl,
+}: BookmarkProps) {
+  const [personsWithImageUrls, setPersonsWithImageUrls] = useState<
+    IPersonWithImage[]
+  >([]);
+  const { getAllDecodedPersons, getPersonsWithImageUrl } = usePerson();
+  const isMobile = usePlatform();
 
-    const initImageUrl = useCallback(async () => {
-      const allPersons = await getAllDecodedPersons();
-      const persons = getPersonsFromUids(taggedPersons, allPersons);
-      const newPersonsWithImageUrls = await getPersonsWithImageUrl(persons);
-      setPersonsWithImageUrls(newPersonsWithImageUrls);
-    }, [getAllDecodedPersons, getPersonsWithImageUrl, taggedPersons]);
+  const initImageUrl = useCallback(async () => {
+    const allPersons = await getAllDecodedPersons();
+    const persons = getPersonsFromUids(taggedPersons, allPersons);
+    const newPersonsWithImageUrls = await getPersonsWithImageUrl(persons);
+    setPersonsWithImageUrls(newPersonsWithImageUrls);
+  }, [getAllDecodedPersons, getPersonsWithImageUrl, taggedPersons]);
 
-    useEffect(() => {
-      initImageUrl();
-    }, [initImageUrl]);
+  useEffect(() => {
+    initImageUrl();
+  }, [initImageUrl]);
 
-    const handleOpenLink: React.MouseEventHandler<HTMLDivElement> = (event) => {
-      if (event.ctrlKey || event.metaKey) {
-        return;
-      }
-      onOpenLink(url);
-    };
+  const handleOpenLink: React.MouseEventHandler<HTMLDivElement> = (event) => {
+    if (event.ctrlKey || event.metaKey) {
+      return;
+    }
+    onOpenLink(url);
+  };
 
-    const handleSelectionChange = (event: React.MouseEvent<HTMLDivElement>) => {
-      if (!handleSelectedChange) {
-        return;
-      }
-      const isCtrlOrCommandKey = event.ctrlKey || event.metaKey;
-      handleSelectedChange(pos, !isCtrlOrCommandKey);
-    };
+  const handleSelectionChange = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (!handleSelectedChange) {
+      return;
+    }
+    const isCtrlOrCommandKey = event.ctrlKey || event.metaKey;
+    handleSelectedChange(pos, !isCtrlOrCommandKey);
+  };
 
-    const onRightClick = () => {
-      if (!isSelected && handleSelectedChange) {
-        handleSelectedChange(pos, true);
-      }
-    };
+  const onRightClick = () => {
+    if (!isSelected && handleSelectedChange) {
+      handleSelectedChange(pos, true);
+    }
+  };
 
-    return (
-      <div
-        className="flex size-full items-center gap-3 px-1.5"
-        data-context-id={id}
-        data-testid={`bookmark-item-${title}`}
-        onDoubleClick={handleOpenLink}
-        onClick={handleSelectionChange}
-        onContextMenu={onRightClick}
-      >
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger>
-              <Favicon url={url} getFaviconUrl={getFaviconUrl} />
-            </TooltipTrigger>
-            <TooltipContent
-              side="right"
-              className="w-auto max-w-[500px] text-xs/relaxed break-all"
-            >
-              {url}
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-        <PersonAvatars persons={personsWithImageUrls} />
-        <div className="flex-1 truncate text-sm" data-context-id={id}>
-          {isMobile ? (
-            <a href={url} title={title} className="text-inherit no-underline">
-              {title}
-            </a>
-          ) : (
-            title
-          )}
-        </div>
+  return (
+    <div
+      className="flex size-full items-center gap-3 px-1.5"
+      data-context-id={id}
+      data-testid={`bookmark-item-${title}`}
+      onDoubleClick={handleOpenLink}
+      onClick={handleSelectionChange}
+      onContextMenu={onRightClick}
+    >
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger>
+            <Favicon url={url} getFaviconUrl={getFaviconUrl} />
+          </TooltipTrigger>
+          <TooltipContent
+            side="right"
+            className="w-auto max-w-[500px] text-xs/relaxed break-all"
+          >
+            {url}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <PersonAvatars persons={personsWithImageUrls} />
+      <div className="flex-1 truncate text-sm" data-context-id={id}>
+        {isMobile ? (
+          <a href={url} title={title} className="text-inherit no-underline">
+            {title}
+          </a>
+        ) : (
+          title
+        )}
       </div>
-    );
-  }
-);
+    </div>
+  );
+}
 
 export default Bookmark;

--- a/packages/shared/src/components/Persons/components/BookmarksList.tsx
+++ b/packages/shared/src/components/Persons/components/BookmarksList.tsx
@@ -10,7 +10,7 @@ import {
 } from '@bypass/ui';
 import { BookEditIcon } from '@hugeicons/core-free-icons';
 import { HugeiconsIcon } from '@hugeicons/react';
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import DynamicContext from '../../../provider/DynamicContext';
 import Bookmark from '../../Bookmarks/components/Bookmark';
 import { EBookmarkOperation } from '../../Bookmarks/constants';
@@ -109,10 +109,7 @@ function BookmarksList({
     };
   }, [initBookmarks]);
 
-  const filteredBookmarks = useMemo(
-    () => getFilteredModifiedBookmarks(bookmarks, searchText),
-    [bookmarks, searchText]
-  );
+  const filteredBookmarks = getFilteredModifiedBookmarks(bookmarks, searchText);
 
   const renderContent = () => (
     <>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@babel/core':
+      specifier: 8.0.1
+      version: 8.0.1
     '@base-ui/react':
       specifier: 1.6.0
       version: 1.6.0
@@ -27,6 +30,9 @@ catalogs:
     '@playwright/test':
       specifier: 1.61.1
       version: 1.61.1
+    '@rolldown/plugin-babel':
+      specifier: 0.2.3
+      version: 0.2.3
     '@t3-oss/env-core':
       specifier: 0.13.11
       version: 0.13.11
@@ -99,6 +105,9 @@ catalogs:
     eslint-plugin-better-tailwindcss:
       specifier: 4.6.1
       version: 4.6.1
+    eslint-plugin-react-compiler:
+      specifier: 19.1.0-rc.2
+      version: 19.1.0-rc.2
     file-type:
       specifier: 22.0.1
       version: 22.0.1
@@ -212,6 +221,9 @@ importers:
       eslint-plugin-better-tailwindcss:
         specifier: 'catalog:'
         version: 4.6.1(eslint@9.39.4(jiti@2.7.0))(tailwindcss@4.3.2)(typescript@6.0.3)
+      eslint-plugin-react-compiler:
+        specifier: 'catalog:'
+        version: 19.1.0-rc.2(eslint@9.39.4(jiti@2.7.0))
       lefthook:
         specifier: 'catalog:'
         version: 2.1.9
@@ -324,9 +336,15 @@ importers:
         specifier: 'catalog:'
         version: 5.0.14(@types/react@19.2.15)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
     devDependencies:
+      '@babel/core':
+        specifier: 'catalog:'
+        version: 8.0.1
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.61.1
+      '@rolldown/plugin-babel':
+        specifier: 'catalog:'
+        version: 0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.2)(rolldown@1.1.5)(vite@8.1.3)
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.3.2(vite@8.1.3)
@@ -347,7 +365,10 @@ importers:
         version: 19.2.3(@types/react@19.2.15)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.3(babel-plugin-react-compiler@1.0.0)(vite@8.1.3)
+        version: 6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.2)(rolldown@1.1.5)(vite@8.1.3))(babel-plugin-react-compiler@1.0.0)(vite@8.1.3)
+      babel-plugin-react-compiler:
+        specifier: 'catalog:'
+        version: 1.0.0
       shadcn:
         specifier: 'catalog:'
         version: 4.13.0(typescript@6.0.3)
@@ -401,10 +422,10 @@ importers:
         version: 11.18.0(typescript@6.0.3)
       '@vercel/analytics':
         specifier: 'catalog:'
-        version: 2.0.1(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.39(typescript@6.0.3))
+        version: 2.0.1(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.39(typescript@6.0.3))
       '@vercel/speed-insights':
         specifier: 'catalog:'
-        version: 2.0.0(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.39(typescript@6.0.3))
+        version: 2.0.0(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.39(typescript@6.0.3))
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
@@ -422,7 +443,7 @@ importers:
         version: 14.1.0
       next:
         specifier: 'catalog:'
-        version: 16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: 'catalog:'
         version: 19.2.6
@@ -628,17 +649,33 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@8.0.0':
+    resolution: {integrity: sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/compat-data@7.29.3':
     resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@8.0.0':
+    resolution: {integrity: sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/core@7.29.0':
     resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/core@8.0.1':
+    resolution: {integrity: sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/generator@7.29.1':
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/generator@8.0.0':
+    resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-annotate-as-pure@7.27.3':
     resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
@@ -647,6 +684,10 @@ packages:
   '@babel/helper-compilation-targets@7.28.6':
     resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@8.0.0':
+    resolution: {integrity: sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-create-class-features-plugin@7.29.3':
     resolution: {integrity: sha512-RpLYy2sb51oNLjuu1iD3bwBqCBWUzjO0ocp+iaCP/lJtb2CPLcnC2Fftw+4sAzaMELGeWTgExSKADbdo0GFVzA==}
@@ -657,6 +698,10 @@ packages:
   '@babel/helper-globals@7.28.0':
     resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@8.0.0':
+    resolution: {integrity: sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     resolution: {integrity: sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==}
@@ -694,6 +739,10 @@ packages:
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@8.0.0':
+    resolution: {integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
@@ -702,18 +751,42 @@ packages:
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@8.0.4':
+    resolution: {integrity: sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-validator-option@7.27.1':
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@8.0.0':
+    resolution: {integrity: sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helpers@7.29.2':
     resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helpers@8.0.0':
+    resolution: {integrity: sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/parser@8.0.4':
+    resolution: {integrity: sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    hasBin: true
+
+  '@babel/plugin-proposal-private-methods@7.18.6':
+    resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
+    engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
 
   '@babel/plugin-syntax-jsx@7.28.6':
     resolution: {integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==}
@@ -757,13 +830,25 @@ packages:
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@8.0.0':
+    resolution: {integrity: sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/traverse@7.29.0':
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@8.0.4':
+    resolution: {integrity: sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@8.0.4':
+    resolution: {integrity: sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@base-ui/react@1.6.0':
     resolution: {integrity: sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==}
@@ -2657,6 +2742,23 @@ packages:
   '@rolldown/debug@1.1.5':
     resolution: {integrity: sha512-GJDtRyJkktO4fcFe8cjnUf99ylufh+GWjE9RevRw8Y/aIt0xQkBc27/Pmu1EoUZFfwyz5LjEJGh+XSTqsuXG8g==}
 
+  '@rolldown/plugin-babel@0.2.3':
+    resolution: {integrity: sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw==}
+    engines: {node: '>=22.12.0 || ^24.0.0'}
+    peerDependencies:
+      '@babel/core': ^7.29.0 || ^8.0.0-rc.1
+      '@babel/plugin-transform-runtime': ^7.29.0 || ^8.0.0-rc.1
+      '@babel/runtime': ^7.27.0 || ^8.0.0-rc.1
+      rolldown: ^1.0.0-rc.5
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@babel/plugin-transform-runtime':
+        optional: true
+      '@babel/runtime':
+        optional: true
+      vite:
+        optional: true
+
   '@rolldown/pluginutils@1.0.0-rc.1':
     resolution: {integrity: sha512-UTBjtTxVOhodhzFVp/ayITaTETRHPUPYZPXQe0WU0wOgxghMojXxYjOiPOauKIYNWJAWS2fd7gJgGQK8GU8vDA==}
 
@@ -3110,8 +3212,14 @@ packages:
   '@types/filewriter@0.0.33':
     resolution: {integrity: sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==}
 
+  '@types/gensync@1.0.5':
+    resolution: {integrity: sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==}
+
   '@types/har-format@1.2.16':
     resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
+
+  '@types/jsesc@2.5.1':
+    resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -4335,6 +4443,10 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  empathic@2.0.1:
+    resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
+    engines: {node: '>=14'}
+
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
@@ -4579,6 +4691,12 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
+
+  eslint-plugin-react-compiler@19.1.0-rc.2:
+    resolution: {integrity: sha512-oKalwDGcD+RX9mf3NEO4zOoUMeLvjSvcbbEOpquzmzqEEM2MQdp7/FY/Hx9NzmUwFzH1W9SKTz5fihfMldpEYw==}
+    engines: {node: ^14.17.0 || ^16.0.0 || >= 18.0.0}
+    peerDependencies:
+      eslint: '>=7'
 
   eslint-plugin-react-hooks@5.2.0:
     resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
@@ -5163,6 +5281,12 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
+  hermes-estree@0.25.1:
+    resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
+
+  hermes-parser@0.25.1:
+    resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
   hono@4.12.18:
     resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
     engines: {node: '>=16.9.0'}
@@ -5570,6 +5694,9 @@ packages:
 
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -7923,6 +8050,12 @@ packages:
     peerDependencies:
       zod: ^3.25.28 || ^4
 
+  zod-validation-error@3.5.4:
+    resolution: {integrity: sha512-+hEiRIiPobgyuFlEojnqjJnhFvg4r/i3cqgcm67eehZf/WBaK3g6cD02YU9mtdVxZjv8CzCA9n/Rhrs3yAAvAw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.24.4
+
   zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
 
@@ -7980,7 +8113,14 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@8.0.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 8.0.4
+      js-tokens: 10.0.0
+
   '@babel/compat-data@7.29.3': {}
+
+  '@babel/compat-data@8.0.0': {}
 
   '@babel/core@7.29.0':
     dependencies:
@@ -8002,12 +8142,40 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/core@8.0.1':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/generator': 8.0.0
+      '@babel/helper-compilation-targets': 8.0.0
+      '@babel/helpers': 8.0.0
+      '@babel/parser': 8.0.4
+      '@babel/template': 8.0.0
+      '@babel/traverse': 8.0.4
+      '@babel/types': 8.0.4
+      '@types/gensync': 1.0.5
+      convert-source-map: 2.0.0
+      empathic: 2.0.1
+      gensync: 1.0.0-beta.2
+      import-meta-resolve: 4.2.0
+      json5: 2.2.3
+      obug: 2.1.3
+      semver: 7.8.5
+
   '@babel/generator@7.29.1':
     dependencies:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/generator@8.0.0':
+    dependencies:
+      '@babel/parser': 8.0.4
+      '@babel/types': 8.0.4
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/jsesc': 2.5.1
       jsesc: 3.1.0
 
   '@babel/helper-annotate-as-pure@7.27.3':
@@ -8021,6 +8189,14 @@ snapshots:
       browserslist: 4.28.5
       lru-cache: 5.1.1
       semver: 6.3.1
+
+  '@babel/helper-compilation-targets@8.0.0':
+    dependencies:
+      '@babel/compat-data': 8.0.0
+      '@babel/helper-validator-option': 8.0.0
+      browserslist: 4.28.5
+      lru-cache: 11.3.6
+      semver: 7.8.5
 
   '@babel/helper-create-class-features-plugin@7.29.3(@babel/core@7.29.0)':
     dependencies:
@@ -8036,6 +8212,8 @@ snapshots:
       - supports-color
 
   '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-globals@8.0.0': {}
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
@@ -8084,20 +8262,43 @@ snapshots:
 
   '@babel/helper-string-parser@7.29.7': {}
 
+  '@babel/helper-string-parser@8.0.0': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
+  '@babel/helper-validator-identifier@8.0.4': {}
+
   '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helper-validator-option@8.0.0': {}
 
   '@babel/helpers@7.29.2':
     dependencies:
       '@babel/template': 7.28.6
       '@babel/types': 7.29.7
 
+  '@babel/helpers@8.0.0':
+    dependencies:
+      '@babel/template': 8.0.0
+      '@babel/types': 8.0.4
+
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@babel/parser@8.0.4':
+    dependencies:
+      '@babel/types': 8.0.4
+
+  '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -8149,6 +8350,12 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
+  '@babel/template@8.0.0':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/parser': 8.0.4
+      '@babel/types': 8.0.4
+
   '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -8161,10 +8368,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@8.0.4':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/generator': 8.0.0
+      '@babel/helper-globals': 8.0.0
+      '@babel/parser': 8.0.4
+      '@babel/template': 8.0.0
+      '@babel/types': 8.0.4
+      obug: 2.1.3
+
   '@babel/types@7.29.7':
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@babel/types@8.0.4':
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0
+      '@babel/helper-validator-identifier': 8.0.4
 
   '@base-ui/react@1.6.0(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
@@ -9740,6 +9962,15 @@ snapshots:
   '@rolldown/debug@1.1.5':
     optional: true
 
+  '@rolldown/plugin-babel@0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.2)(rolldown@1.1.5)(vite@8.1.3)':
+    dependencies:
+      '@babel/core': 8.0.1
+      picomatch: 4.0.4
+      rolldown: 1.1.5
+    optionalDependencies:
+      '@babel/runtime': 7.29.2
+      vite: 8.1.3(@types/node@24.13.2)(@vitejs/devtools@0.3.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)
+
   '@rolldown/pluginutils@1.0.0-rc.1': {}
 
   '@rolldown/pluginutils@1.0.1': {}
@@ -10082,7 +10313,11 @@ snapshots:
 
   '@types/filewriter@0.0.33': {}
 
+  '@types/gensync@1.0.5': {}
+
   '@types/har-format@1.2.16': {}
+
+  '@types/jsesc@2.5.1': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -10286,9 +10521,9 @@ snapshots:
     dependencies:
       valibot: 1.4.2(typescript@6.0.3)
 
-  '@vercel/analytics@2.0.1(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.39(typescript@6.0.3))':
+  '@vercel/analytics@2.0.1(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.39(typescript@6.0.3))':
     optionalDependencies:
-      next: 16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       vue: 3.5.39(typescript@6.0.3)
 
@@ -10600,9 +10835,9 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  '@vercel/speed-insights@2.0.0(next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.39(typescript@6.0.3))':
+  '@vercel/speed-insights@2.0.0(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(vue@3.5.39(typescript@6.0.3))':
     optionalDependencies:
-      next: 16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       vue: 3.5.39(typescript@6.0.3)
 
@@ -10735,11 +10970,12 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@vitejs/plugin-react@6.0.3(babel-plugin-react-compiler@1.0.0)(vite@8.1.3)':
+  '@vitejs/plugin-react@6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.2)(rolldown@1.1.5)(vite@8.1.3))(babel-plugin-react-compiler@1.0.0)(vite@8.1.3)':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.1.3(@types/node@24.13.2)(@vitejs/devtools@0.3.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)
     optionalDependencies:
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.2)(rolldown@1.1.5)(vite@8.1.3)
       babel-plugin-react-compiler: 1.0.0
 
   '@vue/compiler-core@3.5.39':
@@ -11572,6 +11808,8 @@ snapshots:
   emoji-regex@9.2.2:
     optional: true
 
+  empathic@2.0.1: {}
+
   encodeurl@2.0.0: {}
 
   end-of-stream@1.1.0:
@@ -11946,6 +12184,18 @@ snapshots:
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
       eslint: 9.39.4(jiti@2.7.0)
+
+  eslint-plugin-react-compiler@19.1.0-rc.2(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.29.0)
+      eslint: 9.39.4(jiti@2.7.0)
+      hermes-parser: 0.25.1
+      zod: 3.25.76
+      zod-validation-error: 3.5.4(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-react-hooks@5.2.0(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
@@ -12751,6 +13001,12 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hermes-estree@0.25.1: {}
+
+  hermes-parser@0.25.1:
+    dependencies:
+      hermes-estree: 0.25.1
+
   hono@4.12.18: {}
 
   hookable@6.1.1: {}
@@ -13115,6 +13371,8 @@ snapshots:
   jose@5.9.6: {}
 
   jose@6.2.3: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -13574,7 +13832,7 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  next@16.2.10(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@next/env': 16.2.10
       '@swc/helpers': 0.5.15
@@ -13583,7 +13841,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      styled-jsx: 5.1.6(react@19.2.6)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.6)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.10
       '@next/swc-darwin-x64': 16.2.10
@@ -14968,10 +15226,12 @@ snapshots:
   stubs@3.0.0:
     optional: true
 
-  styled-jsx@5.1.6(react@19.2.6):
+  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.6):
     dependencies:
       client-only: 0.0.1
       react: 19.2.6
+    optionalDependencies:
+      '@babel/core': 7.29.0
 
   supports-color@7.2.0:
     dependencies:
@@ -15837,6 +16097,10 @@ snapshots:
     dependencies:
       zod: 4.4.3
     optional: true
+
+  zod-validation-error@3.5.4(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.22.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ allowBuilds:
   unrs-resolver: false
 
 catalog:
+  '@babel/core': 8.0.1
   '@base-ui/react': 1.6.0
   '@hugeicons/core-free-icons': 4.2.2
   '@hugeicons/react': 1.1.9
@@ -27,6 +28,7 @@ catalog:
   '@next/eslint-plugin-next': 16.2.10
   '@octokit/rest': 22.0.1
   '@playwright/test': 1.61.1
+  '@rolldown/plugin-babel': 0.2.3
   '@t3-oss/env-core': 0.13.11
   '@t3-oss/env-nextjs': 0.13.11
   '@tailwindcss/postcss': 4.3.2
@@ -51,6 +53,7 @@ catalog:
   clsx: 2.1.1
   dayjs: 1.11.21
   eslint-plugin-better-tailwindcss: 4.6.1
+  eslint-plugin-react-compiler: 19.1.0-rc.2
   file-type: 22.0.1
   filenamify: 7.0.2
   firebase: 12.15.0

--- a/xo.config.ts
+++ b/xo.config.ts
@@ -47,8 +47,7 @@ const xoConfig: FlatXoConfig = [
     rules: {
       'react-compiler/react-compiler': 'error',
     },
-    // packages/ui is globally ignored below (shadcn-generated); the React
-    // Compiler still processes it at build time via the extension's Vite config.
+    // packages/ui is globally ignored below, but the compiler still compiles it at build.
     files: ['apps/extension/**/*.{ts,tsx}', 'packages/shared/**/*.{ts,tsx}'],
   },
   {

--- a/xo.config.ts
+++ b/xo.config.ts
@@ -1,6 +1,7 @@
 import { type FlatXoConfig } from 'xo';
 import nextPlugin from '@next/eslint-plugin-next';
 import betterTailwindcssPlugin from 'eslint-plugin-better-tailwindcss';
+import reactCompilerPlugin from 'eslint-plugin-react-compiler';
 
 const xoConfig: FlatXoConfig = [
   {
@@ -40,6 +41,15 @@ const xoConfig: FlatXoConfig = [
       },
     },
     files: ['**/*.{ts,tsx}'],
+  },
+  {
+    plugins: { 'react-compiler': reactCompilerPlugin },
+    rules: {
+      'react-compiler/react-compiler': 'error',
+    },
+    // packages/ui is globally ignored below (shadcn-generated); the React
+    // Compiler still processes it at build time via the extension's Vite config.
+    files: ['apps/extension/**/*.{ts,tsx}', 'packages/shared/**/*.{ts,tsx}'],
   },
   {
     ignores: [


### PR DESCRIPTION
#### Check if the Pull Request fulfils these requirements

- [x] Does the extension require a version change?

## Summary by Sourcery

Integrate React Compiler into the browser extension build and linting pipeline and adjust components to comply with compiler and lint rules.

New Features:
- Enable React Compiler for the extension via Babel and Vite React plugin presets.

Enhancements:
- Refine state and effect handling in popup and bookmarks panels to avoid mutable patterns and ensure stable callbacks.
- Introduce a workspace-level mapping file for agent documentation references.

Build:
- Add @rolldown/plugin-babel and @babel/core to the extension build, configuring Babel with the React Compiler preset in the Vite/WXT config.
- Bump the extension package version from 24.10.0 to 24.11.0.

CI:
- Add eslint-plugin-react-compiler to the lint configuration and enforce React Compiler rules for extension and shared packages.

Documentation:
- Add a CLAUDE.md pointer file referencing AGENTS.md.

Chores:
- Update workspace catalog entries for new Babel and React Compiler-related dependencies.
- Record eslint-plugin-react-compiler and Babel-related packages in root and extension package manifests.

<!-- greptile_comment -->

 

<h3>Greptile Summary</h3>

This PR integrates the React Compiler into the browser extension's build pipeline via `@rolldown/plugin-babel` and `reactCompilerPreset()` exported from `@vitejs/plugin-react` v6, and migrates components across the extension and shared packages to comply with the compiler's rules.

- **Build integration**: Adds `@babel/core@8`, `@rolldown/plugin-babel`, and `babel-plugin-react-compiler` to the extension; wires `react()` + `babel({ presets: [reactCompilerPreset()] })` in `wxt.config.ts`; and adds `eslint-plugin-react-compiler` to enforce compiler rules in CI.
- **Component refactors**: Removes manual `memo`, `useCallback`, and `useMemo` from components now covered by the compiler; replaces in-place array mutations in `ShortcutsPanel` with immutable patterns; and fills previously-suppressed exhaustive `useEffect` dependency arrays.
- **CI improvements**: The extension is now built twice in release/playwright workflows — once for the release artifact (production URL) and once, after the preview deployment, for e2e tests pointing at the Vercel preview URL.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are well-scoped React Compiler migrations with no new mutations or broken state logic.

The component changes correctly remove manual memoization where the compiler takes over, fix array mutations that would violate compiler invariants, and expand previously-suppressed useEffect dependency arrays with stable references (Zustand actions and @tanstack/react-virtual's stable virtualizer instance). The dual-plugin build setup is the intended usage pattern for @vitejs/plugin-react v6, confirmed by the peer-dependency declaration of @rolldown/plugin-babel in the lock file. CI workflows are restructured correctly to ensure e2e tests run against the preview-URL extension build.

No files require special attention.
</details>

<sub>Reviews (16): Last reviewed commit: ["ci(release): build e2e extension in Buil..."](https://github.com/amitsingh-007/bypass-links/commit/3258c3b509b48b7e3b2823f61340ace22957316b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43485800)</sub>

<!-- /greptile_comment -->