### PR TITLE
Feat react compiler migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ Playwright tests use setup/teardown projects for both web and extension flows:
 - Use workspace protocol (`workspace:*`) for internal dependencies
 - Shared types and utilities go in `packages/shared`
 - tRPC procedures are defined in `packages/trpc`
+- Add comments only when needed, and keep them short. Explain the reasoning (the "why"), not what the code does. Only elaborate for edge cases or logic that is tricky or hard to follow.
 
 ## shadcn/ui Components
 

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bypass/extension",
   "type": "module",
-  "version": "24.11.0",
+  "version": "24.12.0",
   "private": true,
   "description": "Bypass links from various sites to required links, with added functionality of Bookmarks Manager, Tagging Panel.",
   "scripts": {

--- a/apps/extension/src/entrypoints/popup/hooks/useCurrentTab.ts
+++ b/apps/extension/src/entrypoints/popup/hooks/useCurrentTab.ts
@@ -5,9 +5,15 @@ const useCurrentTab = () => {
   const [tab, setTab] = useState<Browser.tabs.Tab>();
 
   useEffect(() => {
+    let ignore = false;
     getCurrentTab().then((curTab) => {
-      setTab(curTab);
+      if (!ignore) {
+        setTab(curTab);
+      }
     });
+    return () => {
+      ignore = true;
+    };
   }, []);
 
   return tab;

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarkRow.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarkRow.tsx
@@ -4,27 +4,26 @@ import {
   type BookmarkProps,
 } from '@bypass/shared';
 import useHistoryStore from '@store/history';
-import { memo } from 'react';
 
-const BookmarkRow = memo<Omit<BookmarkProps, 'onOpenLink' | 'getFaviconUrl'>>(
-  (props) => {
-    const startHistoryMonitor = useHistoryStore(
-      (state) => state.startHistoryMonitor
-    );
+function BookmarkRow(
+  props: Omit<BookmarkProps, 'onOpenLink' | 'getFaviconUrl'>
+) {
+  const startHistoryMonitor = useHistoryStore(
+    (state) => state.startHistoryMonitor
+  );
 
-    const onOpenLink = (url: string) => {
-      startHistoryMonitor();
-      browser.tabs.create({ url, active: false });
-    };
+  const onOpenLink = (url: string) => {
+    startHistoryMonitor();
+    browser.tabs.create({ url, active: false });
+  };
 
-    return (
-      <Bookmark
-        {...props}
-        getFaviconUrl={getGoogleFaviconUrl}
-        onOpenLink={onOpenLink}
-      />
-    );
-  }
-);
+  return (
+    <Bookmark
+      {...props}
+      getFaviconUrl={getGoogleFaviconUrl}
+      onOpenLink={onOpenLink}
+    />
+  );
+}
 
 export default BookmarkRow;

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksHeader.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksHeader.tsx
@@ -1,7 +1,6 @@
 import { Header } from '@bypass/shared';
 import { Button } from '@bypass/ui';
 import { useDisclosure, useHotkeys } from '@mantine/hooks';
-import { memo } from 'react';
 import { BookmarkCheck01Icon, FolderAddIcon } from '@hugeicons/core-free-icons';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { useShallow } from 'zustand/react/shallow';
@@ -18,7 +17,7 @@ const handleClose = () => {
   window.history.back();
 };
 
-const BookmarksHeader = memo<Props>(({ onSearchChange, folderId }) => {
+function BookmarksHeader({ onSearchChange, folderId }: Props) {
   const {
     contextBookmarks,
     isFetching,
@@ -115,6 +114,6 @@ const BookmarksHeader = memo<Props>(({ onSearchChange, folderId }) => {
       />
     </>
   );
-});
+}
 
 export default BookmarksHeader;

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/ConfirmationDialog.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/ConfirmationDialog.tsx
@@ -7,7 +7,6 @@ import {
   Button,
 } from '@bypass/ui';
 import { noOp } from '@bypass/shared';
-import { memo } from 'react';
 import { handleEscapeKey } from '@popup/utils/dialog';
 
 interface Props {
@@ -16,7 +15,7 @@ interface Props {
   isOpen: boolean;
 }
 
-const ConfirmationDialog = memo<Props>(({ onClose, onOk, isOpen }) => {
+function ConfirmationDialog({ onClose, onOk, isOpen }: Props) {
   return (
     <Dialog open={isOpen} onOpenChange={noOp}>
       <DialogContent
@@ -38,6 +37,6 @@ const ConfirmationDialog = memo<Props>(({ onClose, onOk, isOpen }) => {
       </DialogContent>
     </Dialog>
   );
-});
+}
 
 export default ConfirmationDialog;

--- a/apps/extension/src/entrypoints/popup/panels/HomePopup/components/ToggleHistory.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/HomePopup/components/ToggleHistory.tsx
@@ -1,7 +1,7 @@
 import { Switch } from '@bypass/ui';
 import useExtStore from '@store/extension';
 import useHistoryStore from '@store/history';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useEffectEvent, useState } from 'react';
 import { startHistoryWatch } from '@/utils/history';
 import { historyStartTimeItem } from '@/storage/items';
 
@@ -30,20 +30,22 @@ function ToggleHistory() {
   const isExtensionActive = useExtStore((state) => state.isExtensionActive);
   const [isHistoryActive, setIsHistoryActive] = useState(false);
 
-  const turnOffHistory = useCallback(() => {
+  const turnOffHistory = () => {
     if (isHistoryActive) {
       endHistoryWatch();
       setIsHistoryActive(false);
     }
-  }, [isHistoryActive]);
+  };
+  const onExtensionInactive = useEffectEvent(turnOffHistory);
 
-  const turnOnHistory = useCallback(async () => {
+  const turnOnHistory = async () => {
     if (!isHistoryActive) {
       resetHistoryMonitor();
       await startHistoryWatch();
       setIsHistoryActive(true);
     }
-  }, [isHistoryActive, resetHistoryMonitor]);
+  };
+  const onMonitorHistory = useEffectEvent(turnOnHistory);
 
   // Init toggle on mount
   useEffect(() => {
@@ -55,16 +57,16 @@ function ToggleHistory() {
   // Turn off history when extension is off
   useEffect(() => {
     if (!isExtensionActive) {
-      turnOffHistory();
+      onExtensionInactive();
     }
-  }, [isExtensionActive, turnOffHistory]);
+  }, [isExtensionActive]);
 
   // Turn on history on store change
   useEffect(() => {
     if (monitorHistory) {
-      turnOnHistory();
+      onMonitorHistory();
     }
-  }, [monitorHistory, turnOnHistory]);
+  }, [monitorHistory]);
 
   const handleToggle = async (checked: boolean) => {
     if (checked) {

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/PersonHeader.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/PersonHeader.tsx
@@ -3,7 +3,6 @@ import { Button, Switch } from '@bypass/ui';
 import { useDisclosure } from '@mantine/hooks';
 import { UserAdd01Icon } from '@hugeicons/core-free-icons';
 import { HugeiconsIcon } from '@hugeicons/react';
-import { memo } from 'react';
 import AddOrEditPersonDialog from './AddOrEditPersonDialog';
 
 interface Props {
@@ -15,53 +14,51 @@ interface Props {
   toggleOrderByRecency: VoidFunction;
 }
 
-const PersonHeader = memo<Props>(
-  ({
-    isFetching,
-    handleAddPerson,
-    persons,
-    onSearchChange,
-    orderByRecency,
-    toggleOrderByRecency,
-  }) => {
-    const [showAddPersonDialog, addPersonDialogHandlers] = useDisclosure(false);
+function PersonHeader({
+  isFetching,
+  handleAddPerson,
+  persons,
+  onSearchChange,
+  orderByRecency,
+  toggleOrderByRecency,
+}: Props) {
+  const [showAddPersonDialog, addPersonDialogHandlers] = useDisclosure(false);
 
-    const handlePersonSave = async (person: IPerson) => {
-      await handleAddPerson(person);
-      addPersonDialogHandlers.close();
-    };
+  const handlePersonSave = async (person: IPerson) => {
+    await handleAddPerson(person);
+    addPersonDialogHandlers.close();
+  };
 
-    return (
-      <>
-        <Header text={persons?.length || 0} onSearchChange={onSearchChange}>
-          <Button
-            disabled={isFetching}
-            variant="secondary"
-            className="font-medium"
-            onClick={addPersonDialogHandlers.open}
-          >
-            <HugeiconsIcon icon={UserAdd01Icon} />
-            Add
-          </Button>
-          <div className="flex items-center gap-2">
-            <Switch
-              data-testid="recency-switch"
-              checked={orderByRecency}
-              onCheckedChange={toggleOrderByRecency}
-            />
-            <span className="text-sm">Recency</span>
-          </div>
-        </Header>
-        {showAddPersonDialog && (
-          <AddOrEditPersonDialog
-            isOpen={showAddPersonDialog}
-            handleSaveClick={handlePersonSave}
-            onClose={addPersonDialogHandlers.close}
+  return (
+    <>
+      <Header text={persons?.length || 0} onSearchChange={onSearchChange}>
+        <Button
+          disabled={isFetching}
+          variant="secondary"
+          className="font-medium"
+          onClick={addPersonDialogHandlers.open}
+        >
+          <HugeiconsIcon icon={UserAdd01Icon} />
+          Add
+        </Button>
+        <div className="flex items-center gap-2">
+          <Switch
+            data-testid="recency-switch"
+            checked={orderByRecency}
+            onCheckedChange={toggleOrderByRecency}
           />
-        )}
-      </>
-    );
-  }
-);
+          <span className="text-sm">Recency</span>
+        </div>
+      </Header>
+      {showAddPersonDialog && (
+        <AddOrEditPersonDialog
+          isOpen={showAddPersonDialog}
+          handleSaveClick={handlePersonSave}
+          onClose={addPersonDialogHandlers.close}
+        />
+      )}
+    </>
+  );
+}
 
 export default PersonHeader;

--- a/apps/web/src/app/provider/AuthProvider.tsx
+++ b/apps/web/src/app/provider/AuthProvider.tsx
@@ -3,7 +3,7 @@ import { usePathname } from 'next/navigation';
 import {
   type PropsWithChildren,
   createContext,
-  useContext,
+  use,
   useEffect,
   useMemo,
   useState,
@@ -52,7 +52,7 @@ export function AuthProvider({ children }: PropsWithChildren) {
 }
 
 export const useUser = () => {
-  const { user, isLoginIntialized } = useContext(AuthContext);
+  const { user, isLoginIntialized } = use(AuthContext);
 
   return {
     user,

--- a/packages/shared/src/components/Bookmarks/components/Folder.tsx
+++ b/packages/shared/src/components/Bookmarks/components/Folder.tsx
@@ -2,7 +2,7 @@
 
 import { HugeiconsIcon } from '@hugeicons/react';
 import { Folder01Icon } from '@hugeicons/core-free-icons';
-import { memo, useContext } from 'react';
+import { use } from 'react';
 import { cn } from '@bypass/ui/lib/utils';
 import DynamicContext from '../../../provider/DynamicContext';
 import { getBookmarksPanelUrl } from '../utils/url';
@@ -14,33 +14,36 @@ export interface FolderProps {
   resetSelectedBookmarks?: React.MouseEventHandler<HTMLDivElement>;
 }
 
-const Folder = memo<FolderProps>(
-  ({ id, name: origName, isEmpty, resetSelectedBookmarks }) => {
-    const { location } = useContext(DynamicContext);
+function Folder({
+  id,
+  name: origName,
+  isEmpty,
+  resetSelectedBookmarks,
+}: FolderProps) {
+  const { location } = use(DynamicContext);
 
-    const handleFolderOpen = () => {
-      if (!isEmpty) {
-        location.push(getBookmarksPanelUrl({ folderId: id }));
-      }
-    };
+  const handleFolderOpen = () => {
+    if (!isEmpty) {
+      location.push(getBookmarksPanelUrl({ folderId: id }));
+    }
+  };
 
-    return (
-      <div
-        className={cn(
-          'flex size-full items-center justify-center gap-3 p-1.5',
-          isEmpty && 'cursor-not-allowed opacity-60'
-        )}
-        data-testid={`folder-item-${origName}`}
-        onClick={resetSelectedBookmarks}
-        onDoubleClick={handleFolderOpen}
-      >
-        <HugeiconsIcon icon={Folder01Icon} className="size-5 text-yellow-400" />
-        <span className="flex-1 truncate text-[0.9375rem] font-bold">
-          {origName}
-        </span>
-      </div>
-    );
-  }
-);
+  return (
+    <div
+      className={cn(
+        'flex size-full items-center justify-center gap-3 p-1.5',
+        isEmpty && 'cursor-not-allowed opacity-60'
+      )}
+      data-testid={`folder-item-${origName}`}
+      onClick={resetSelectedBookmarks}
+      onDoubleClick={handleFolderOpen}
+    >
+      <HugeiconsIcon icon={Folder01Icon} className="size-5 text-yellow-400" />
+      <span className="flex-1 truncate text-[0.9375rem] font-bold">
+        {origName}
+      </span>
+    </div>
+  );
+}
 
 export default Folder;

--- a/packages/shared/src/components/Bookmarks/components/PersonAvatars.tsx
+++ b/packages/shared/src/components/Bookmarks/components/PersonAvatars.tsx
@@ -1,4 +1,4 @@
-import { memo, useContext } from 'react';
+import { use } from 'react';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { UserWarning03Icon } from '@hugeicons/core-free-icons';
 import {
@@ -17,8 +17,8 @@ import DynamicContext from '../../../provider/DynamicContext';
 import { type IPersonWithImage } from '../../Persons/interfaces/persons';
 import { getPersonsPanelUrl } from '../../Persons/utils/urls';
 
-const PersonAvatars = memo<{ persons: IPersonWithImage[] }>(({ persons }) => {
-  const { location } = useContext(DynamicContext);
+function PersonAvatars({ persons }: { persons: IPersonWithImage[] }) {
+  const { location } = use(DynamicContext);
 
   if (persons.length === 0) {
     return (
@@ -71,6 +71,6 @@ const PersonAvatars = memo<{ persons: IPersonWithImage[] }>(({ persons }) => {
       ))}
     </AvatarGroup>
   );
-});
+}
 
 export default PersonAvatars;

--- a/packages/shared/src/components/Header.tsx
+++ b/packages/shared/src/components/Header.tsx
@@ -1,7 +1,7 @@
 import { Badge, Button } from '@bypass/ui';
 import { ArrowLeft01Icon } from '@hugeicons/core-free-icons';
 import { HugeiconsIcon } from '@hugeicons/react';
-import { memo, useContext } from 'react';
+import { use } from 'react';
 import { HEADER_HEIGHT } from '../constants';
 import DynamicContext from '../provider/DynamicContext';
 import Search from './Search';
@@ -14,54 +14,51 @@ interface Props {
   onBackClick?: React.MouseEventHandler<HTMLButtonElement>;
 }
 
-const Header = memo<Props>(
-  ({
-    children,
-    text,
-    onSearchChange,
-    rightContent: RightContent = null,
-    onBackClick,
-  }) => {
-    const { location } = useContext(DynamicContext);
+function Header({
+  children,
+  text,
+  onSearchChange,
+  rightContent: RightContent = null,
+  onBackClick,
+}: Props) {
+  const { location } = use(DynamicContext);
 
-    return (
-      <header
-        className="
-          flex shrink-0 items-center justify-between border-b border-border
-          px-2.5
-        "
-        style={{ height: HEADER_HEIGHT }}
-      >
-        <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            className="font-medium"
-            onClick={onBackClick ?? location.goBack}
+  return (
+    <header
+      className="
+        flex shrink-0 items-center justify-between border-b border-border px-2.5
+      "
+      style={{ height: HEADER_HEIGHT }}
+    >
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          className="font-medium"
+          onClick={onBackClick ?? location.goBack}
+        >
+          <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
+          Back
+        </Button>
+        {children}
+      </div>
+      <div className="flex items-center justify-end gap-2">
+        {onSearchChange ? <Search onChange={onSearchChange} /> : null}
+        {text !== undefined && (
+          <Badge
+            data-testid="header-badge"
+            variant="secondary"
+            className="
+              hidden h-8
+              sm:inline-flex
+            "
           >
-            <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
-            Back
-          </Button>
-          {children}
-        </div>
-        <div className="flex items-center justify-end gap-2">
-          {onSearchChange ? <Search onChange={onSearchChange} /> : null}
-          {text !== undefined && (
-            <Badge
-              data-testid="header-badge"
-              variant="secondary"
-              className="
-                hidden h-8
-                sm:inline-flex
-              "
-            >
-              {text}
-            </Badge>
-          )}
-          {RightContent}
-        </div>
-      </header>
-    );
-  }
-);
+            {text}
+          </Badge>
+        )}
+        {RightContent}
+      </div>
+    </header>
+  );
+}
 
 export default Header;

--- a/packages/shared/src/components/Persons/components/BookmarksList.tsx
+++ b/packages/shared/src/components/Persons/components/BookmarksList.tsx
@@ -10,7 +10,7 @@ import {
 } from '@bypass/ui';
 import { BookEditIcon } from '@hugeicons/core-free-icons';
 import { HugeiconsIcon } from '@hugeicons/react';
-import { useCallback, useContext, useEffect, useState } from 'react';
+import { use, useCallback, useEffect, useState } from 'react';
 import DynamicContext from '../../../provider/DynamicContext';
 import Bookmark from '../../Bookmarks/components/Bookmark';
 import { EBookmarkOperation } from '../../Bookmarks/constants';
@@ -43,7 +43,7 @@ function BookmarksList({
   showEditButton,
   getFaviconUrl,
 }: Props) {
-  const { location } = useContext(DynamicContext);
+  const { location } = use(DynamicContext);
   const { getBookmarkFromHash, getFolderFromHash, getDefaultOrRootFolderUrls } =
     useBookmark();
   const { getPersonTaggedUrls } = usePerson();

--- a/packages/shared/src/components/Persons/components/Person.tsx
+++ b/packages/shared/src/components/Persons/components/Person.tsx
@@ -1,5 +1,5 @@
 import { Avatar, AvatarImage, Button } from '@bypass/ui';
-import { memo, useContext, useEffect, useState } from 'react';
+import { use, useEffect, useState } from 'react';
 import DynamicContext from '../../../provider/DynamicContext';
 import usePerson from '../hooks/usePerson';
 import { type IPerson } from '../interfaces/persons';
@@ -9,8 +9,8 @@ interface Props {
   person: IPerson;
 }
 
-const Person = memo<Props>(({ person }) => {
-  const { location } = useContext(DynamicContext);
+function Person({ person }: Props) {
+  const { location } = use(DynamicContext);
   const { uid, name } = person;
   const { resolvePersonImageFromUid } = usePerson();
   const [imageUrl, setImageUrl] = useState('');
@@ -19,7 +19,7 @@ const Person = memo<Props>(({ person }) => {
     resolvePersonImageFromUid(uid).then((url) => {
       setImageUrl(url);
     });
-  }, [uid, person, resolvePersonImageFromUid]);
+  }, [uid, resolvePersonImageFromUid]);
 
   const openBookmarksList = () => {
     location.push(getPersonsPanelUrl({ openBookmarksList: uid }));
@@ -57,6 +57,6 @@ const Person = memo<Props>(({ person }) => {
       </div>
     </Button>
   );
-});
+}
 
 export default Person;

--- a/packages/shared/src/components/Persons/components/Persons.tsx
+++ b/packages/shared/src/components/Persons/components/Persons.tsx
@@ -1,13 +1,7 @@
 import { ScrollArea } from '@bypass/ui';
 import { useElementSize } from '@mantine/hooks';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import {
-  type ReactNode,
-  useCallback,
-  useContext,
-  useEffect,
-  useState,
-} from 'react';
+import { type ReactNode, use, useCallback, useEffect, useState } from 'react';
 import usePlatform from '../../../hooks/usePlatform';
 import DynamicContext from '../../../provider/DynamicContext';
 import { deserializeQueryStringToObject } from '../../../utils/url';
@@ -124,7 +118,7 @@ function Persons(props: Props) {
   const handleViewportRef = useCallback((node: HTMLDivElement | null) => {
     setScrollElement(node);
   }, []);
-  const { location } = useContext(DynamicContext);
+  const { location } = use(DynamicContext);
   const queryString = location.query();
   const { resolvePersonImageFromUid } = usePerson();
 

--- a/packages/shared/src/components/ScrollButton.tsx
+++ b/packages/shared/src/components/ScrollButton.tsx
@@ -1,14 +1,13 @@
 import { Button, ButtonGroup } from '@bypass/ui';
 import { ArrowUp01Icon, ArrowDown01Icon } from '@hugeicons/core-free-icons';
 import { HugeiconsIcon } from '@hugeicons/react';
-import { memo } from 'react';
 
 interface Props {
   itemsSize: number;
   onScroll: (itemNumber: number) => void;
 }
 
-export const ScrollButton = memo<Props>(({ itemsSize, onScroll }) => {
+export function ScrollButton({ itemsSize, onScroll }: Props) {
   if (itemsSize === 0) {
     return null;
   }
@@ -33,4 +32,4 @@ export const ScrollButton = memo<Props>(({ itemsSize, onScroll }) => {
       </Button>
     </ButtonGroup>
   );
-});
+}

--- a/packages/shared/src/components/Search.tsx
+++ b/packages/shared/src/components/Search.tsx
@@ -2,18 +2,19 @@ import { InputGroup, InputGroupAddon, InputGroupInput } from '@bypass/ui';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { Search02Icon } from '@hugeicons/core-free-icons';
 import { useDebouncedState, useHotkeys } from '@mantine/hooks';
-import { memo, useEffect } from 'react';
+import { useEffect, useEffectEvent } from 'react';
 
 interface SearchProps {
   onChange: (searchText: string) => void;
 }
 
-const Search = memo<SearchProps>(({ onChange }) => {
+function Search({ onChange }: SearchProps) {
   const [debouncedValue, setDebouncedValue] = useDebouncedState('', 200);
 
+  const onSearchChange = useEffectEvent(onChange);
   useEffect(() => {
-    onChange(debouncedValue);
-  }, [debouncedValue, onChange]);
+    onSearchChange(debouncedValue);
+  }, [debouncedValue]);
 
   useHotkeys([
     [
@@ -60,6 +61,6 @@ const Search = memo<SearchProps>(({ onChange }) => {
       />
     </InputGroup>
   );
-});
+}
 
 export default Search;

--- a/packages/shared/src/hooks/useStorage.ts
+++ b/packages/shared/src/hooks/useStorage.ts
@@ -1,4 +1,4 @@
-import { useCallback, useContext } from 'react';
+import { use, useCallback } from 'react';
 import DynamicContext from '../provider/DynamicContext';
 import {
   type IPersons,
@@ -8,7 +8,7 @@ import { STORAGE_KEYS } from '../constants/storage';
 import { type IBookmarksObj } from '../components/Bookmarks/interfaces';
 
 const useStorage = () => {
-  const { storage } = useContext(DynamicContext);
+  const { storage } = use(DynamicContext);
 
   const getBookmarks = useCallback(
     async () => storage.get<IBookmarksObj>(STORAGE_KEYS.bookmarks),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,7 @@ catalogs:
 
 overrides:
   jwks-rsa>jose: 4.15.9
+  eslint-config-xo-react>eslint-plugin-react-hooks: 6.1.1
 
 importers:
 
@@ -4698,9 +4699,9 @@ packages:
     peerDependencies:
       eslint: '>=7'
 
-  eslint-plugin-react-hooks@5.2.0:
-    resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
-    engines: {node: '>=10'}
+  eslint-plugin-react-hooks@6.1.1:
+    resolution: {integrity: sha512-St9EKZzOAQF704nt2oJvAKZHjhrpg25ClQoaAlHmPZuajFldVLqRDW4VBNAS01NzeiQF0m0qhG1ZA807K6aVaQ==}
+    engines: {node: '>=18'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
@@ -12053,7 +12054,9 @@ snapshots:
     dependencies:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-react-hooks: 5.2.0(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-react-hooks: 6.1.1(eslint@9.39.4(jiti@2.7.0))
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-config-xo-typescript@7.0.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
@@ -12197,9 +12200,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-hooks@5.2.0(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-react-hooks@6.1.1(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.7
       eslint: 9.39.4(jiti@2.7.0)
+      zod: 4.4.3
+      zod-validation-error: 3.5.4(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
@@ -16101,6 +16110,10 @@ snapshots:
   zod-validation-error@3.5.4(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-validation-error@3.5.4(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@3.22.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,10 @@ packages:
 # Remove once auth0/node-jwks-rsa#508 ships. See firebase/firebase-admin-node#3181.
 overrides:
   jwks-rsa>jose: 4.15.9
+  # TODO: xo@1.2.3 pulls eslint-plugin-react-hooks@5.2.0, whose exhaustive-deps rule stubs out
+  # useEffectEvent support (isUseEffectEventIdentifier returns false), so effect events are
+  # wrongly flagged as missing deps. v6 aligns with React 19.2 and lints useEffectEvent correctly.
+  eslint-config-xo-react>eslint-plugin-react-hooks: 6.1.1
 
 allowBuilds:
   '@firebase/util': false


### PR DESCRIPTION
#### Check if the Pull Request fulfils these requirements

- [x] Does the extension require a version change?

## Summary by Sourcery

Migrate several React components and hooks to React 19 compiler patterns while updating the extension version and workspace tooling.

New Features:
- Introduce useEffectEvent-based handlers for history monitoring and debounced search to align with React 19 effect event semantics.

Enhancements:
- Replace memoized component wrappers with plain function components across shared and extension UI, relying on the new React compiler for rendering optimizations.
- Adopt the experimental use() API in place of useContext for consuming shared DynamicContext and AuthContext.
- Make the current tab hook resilient to unmount during async resolution by guarding state updates.
- Adjust exhaustive-deps behavior via eslint-plugin-react-hooks upgrade to support useEffectEvent in the workspace configuration.
- Clarify contribution guidelines around code comments in AGENTS.md.

Build:
- Bump the extension package version from 24.11.0 to 24.12.0.

<!-- greptile_comment -->

 

<h3>Greptile Summary</h3>

This PR migrates the extension and shared packages to the React Compiler, removing `memo()` wrappers that are now handled automatically, replacing `useContext` with the React 19 `use()` hook, and adopting `useEffectEvent` for callbacks that are used inside effects but should not be reactive dependencies.

- All `memo()` removals are backed by the compiler being configured in both `wxt.config.ts` (via `reactCompilerPreset()`) and `next.config.ts` (`reactCompiler: true`), so no memoization is lost.
- `useEffectEvent` is used correctly: it is only ever called inside `useEffect` bodies, and the `eslint-plugin-react-hooks` override to v6.1.1 ensures the exhaustive-deps rule recognizes it instead of treating it as a missing dependency.
- `useCurrentTab` gains a standard ignore-flag cleanup pattern, and `Person`'s effect dependency array is correctly trimmed to `uid` only.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all memo() removals are backed by the React Compiler being active in both apps, useEffectEvent is used correctly within effect bodies only, and the eslint-plugin override ensures the linter validates the new patterns properly.

The migration is consistent and complete: the compiler is wired up in both the extension (wxt.config.ts with reactCompilerPreset) and the web app (next.config.ts with reactCompiler: true), so dropping memo() is safe. The useEffectEvent usages follow React 19 rules — called only from inside effects, never passed to custom hooks. The use() replacements for synchronous context reads are semantically identical to useContext().

No files require special attention.
</details>

<sub>Reviews (1): Last reviewed commit: ["Update package.json"](https://github.com/amitsingh-007/bypass-links/commit/2b849ce7faf2626d53b36660f27b8c11a0aabf27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43537642)</sub>

<!-- /greptile_comment -->