### PR TITLE
fix: restore Cmd+S save and title caret in bookmarks panel

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bypass/extension",
   "type": "module",
-  "version": "24.12.0",
+  "version": "24.12.1",
   "private": true,
   "description": "Bypass links from various sites to required links, with added functionality of Bookmarks Manager, Tagging Panel.",
   "scripts": {

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarkAddEditDialog.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarkAddEditDialog.tsx
@@ -1,7 +1,7 @@
 import { z } from 'zod/mini';
 import { useForm } from '@tanstack/react-form';
 import { useDisclosure } from '@mantine/hooks';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useLocation } from 'wouter';
 import { useShallow } from 'zustand/react/shallow';
 import {
@@ -80,6 +80,17 @@ function BookmarkAddEditDialog({ curFolderId, handleScroll }: Props) {
   );
   const { operation, url: bmUrl } = bookmarkOperation;
   const [openDialog, dialogHandlers] = useDisclosure(false);
+  const titleInputRef = useRef<HTMLInputElement>(null);
+
+  const focusCaretAtTitleStart = () => {
+    const input = titleInputRef.current;
+    if (!input) {
+      return true; // fallback to default focus behavior
+    }
+    input.focus();
+    input.setSelectionRange(0, 0);
+    return false; // focus already handled; don't let base-ui override it
+  };
 
   const { folderOptions, defaultFolderId } = useMemo(() => {
     const decodedFolderList = getDecodedFolderList(folderList);
@@ -189,7 +200,11 @@ function BookmarkAddEditDialog({ curFolderId, handleScroll }: Props) {
 
   return (
     <Dialog open={openDialog} onOpenChange={closeDialog}>
-      <DialogContent className="sm:max-w-lg" onKeyDown={handleEscapeKey}>
+      <DialogContent
+        className="sm:max-w-lg"
+        initialFocus={focusCaretAtTitleStart}
+        onKeyDown={handleEscapeKey}
+      >
         <DialogHeader>
           <DialogTitle>{HEADING[operation]}</DialogTitle>
         </DialogHeader>
@@ -208,6 +223,7 @@ function BookmarkAddEditDialog({ curFolderId, handleScroll }: Props) {
                   Title <span className="text-destructive">*</span>
                 </FieldLabel>
                 <Input
+                  ref={titleInputRef}
                   data-testid="bookmark-title-input"
                   placeholder="Enter bookmark title"
                   value={field.state.value}

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksHeader.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksHeader.tsx
@@ -50,6 +50,11 @@ function BookmarksHeader({ onSearchChange, folderId }: Props) {
         (e) => {
           e.preventDefault();
           e.stopPropagation();
+          // Skip when focus is inside a dialog (e.g. the add/edit bookmark
+          // form) so an in-progress edit isn't excluded from the saved snapshot.
+          if (document.activeElement?.closest('[role="dialog"]')) {
+            return;
+          }
           if (!disableSave) {
             handleSaveClick();
           }

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksHeader.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksHeader.tsx
@@ -43,18 +43,21 @@ function BookmarksHeader({ onSearchChange, folderId }: Props) {
     handleSave(folderId);
   };
 
-  useHotkeys([
+  useHotkeys(
     [
-      'mod+S',
-      (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        if (!disableSave) {
-          handleSaveClick();
-        }
-      },
+      [
+        'mod+S',
+        (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          if (!disableSave) {
+            handleSaveClick();
+          }
+        },
+      ],
     ],
-  ]);
+    [] // fire even when focus is inside an input
+  );
 
   const onBackClick = () => {
     if (isSaveButtonActive) {

--- a/apps/extension/tests/specs/bookmarks.spec.ts
+++ b/apps/extension/tests/specs/bookmarks.spec.ts
@@ -101,6 +101,7 @@ test.describe('Bookmarks Panel', () => {
         TEST_BOOKMARKS.REACT_DOCS
       );
       const titleInput = dialog.getByTestId('bookmark-title-input');
+      await expect(titleInput).toHaveValue(TEST_BOOKMARKS.REACT_DOCS);
       await expect(titleInput).toBeFocused();
 
       const selection = await titleInput.evaluate((el) => ({
@@ -456,7 +457,7 @@ test.describe('Bookmarks Panel', () => {
     await search.click();
     await expect(search).toBeFocused();
 
-    await bookmarksPage.keyboard.press('Meta+s');
+    await bookmarksPage.keyboard.press('ControlOrMeta+s');
 
     await expect(bookmarksPage.getByText('Saved temporarily')).toBeVisible();
   });

--- a/apps/extension/tests/specs/bookmarks.spec.ts
+++ b/apps/extension/tests/specs/bookmarks.spec.ts
@@ -91,6 +91,28 @@ test.describe('Bookmarks Panel', () => {
       await expect(dialog).toBeHidden();
     });
 
+    test('should focus the title input with caret at start when opening the edit modal', async ({
+      bookmarksPage,
+    }) => {
+      const panel = new BookmarksPanel(bookmarksPage);
+      await panel.ensureAtRoot();
+
+      const dialog = await panel.openEditBookmarkDialog(
+        TEST_BOOKMARKS.REACT_DOCS
+      );
+      const titleInput = dialog.getByTestId('bookmark-title-input');
+      await expect(titleInput).toBeFocused();
+
+      const selection = await titleInput.evaluate((el) => ({
+        start: (el as HTMLInputElement).selectionStart,
+        end: (el as HTMLInputElement).selectionEnd,
+      }));
+      expect(selection.start).toBe(0);
+      expect(selection.end).toBe(0);
+
+      await panel.closeDialog();
+    });
+
     test('should add and remove person tag from bookmark', async ({
       bookmarksPage,
     }) => {
@@ -419,5 +441,23 @@ test.describe('Bookmarks Panel', () => {
     await panel.clickContextMenuItem('delete');
 
     await panel.verifyFolderNotExists(folderName);
+  });
+
+  test('should save via Cmd+S while focus is in the search input', async ({
+    bookmarksPage,
+  }) => {
+    const panel = new BookmarksPanel(bookmarksPage);
+    await panel.ensureAtRoot();
+
+    // Create a pending change so the Save button is active
+    await panel.createFolder('Cmd S Save Test Folder');
+
+    const search = panel.getSearchInput();
+    await search.click();
+    await expect(search).toBeFocused();
+
+    await bookmarksPage.keyboard.press('Meta+s');
+
+    await expect(bookmarksPage.getByText('Saved temporarily')).toBeVisible();
   });
 });


### PR DESCRIPTION
#### Check if the Pull Request fulfils these requirements

- [x] Does the extension require a version change?

## Summary by Sourcery

Restore expected save hotkey behaviour and title field focus in the bookmarks panel edit dialog.

Enhancements:
- Ensure Cmd+S (mod+S) triggers save even when focus is inside the bookmarks search input.
- Set the edit bookmark dialog to focus the title field with the caret positioned at the start when opened.

Tests:
- Add coverage for title input focus and caret position when opening the bookmark edit modal.
- Add coverage to verify Cmd+S saves changes while focus is in the bookmarks search input.

<!-- greptile_comment -->

 

<h3>Greptile Summary</h3>

This PR restores two regression fixes in the bookmarks panel: Cmd+S now fires even when focus is in the search input by passing `[]` as `tagsToIgnore` to `useHotkeys`, with a `[role="dialog"]` guard preventing spurious saves when any dialog is open; and the bookmark edit dialog now focuses the title input with the caret at position 0 via an `initialFocus` callback and a `useRef`.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The changes are narrowly scoped and well-tested; the dialog guard correctly prevents the hotkey from interfering with in-progress edits across all dialog types.

Both fixes are tightly scoped with matching E2E test coverage. The [role=dialog] guard is the correct idiomatic check and covers all dialogs in the component tree. No new code paths are introduced that could cause data loss or incorrect behavior.

No files require special attention.
</details>

<sub>Reviews (3): Last reviewed commit: ["Update package.json"](https://github.com/amitsingh-007/bypass-links/commit/8276417a2727b15d2ed132573fb42e791ad777b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43590119)</sub>

<!-- /greptile_comment -->