### PR TITLE
fix: use redirect sign-in on mobile to fix Safari login (#4067)

### DIFF
--- a/apps/web/src/app/helpers/firebase/auth.ts
+++ b/apps/web/src/app/helpers/firebase/auth.ts
@@ -1,9 +1,11 @@
 import {
   getAuth,
+  getRedirectResult,
   GoogleAuthProvider,
   onAuthStateChanged,
   signInWithEmailAndPassword,
   signInWithPopup,
+  signInWithRedirect,
   signOut,
   type User,
 } from 'firebase/auth';
@@ -13,7 +15,16 @@ import firebaseApp from '.';
 const auth = getAuth(firebaseApp);
 const provider = new GoogleAuthProvider();
 
-export const googleSignIn = async () => signInWithPopup(auth, provider);
+// Safari mobile blocks the cross-origin popup flow silently, so redirect there.
+export const googleSignIn = async (isMobile: boolean) => {
+  if (isMobile) {
+    await signInWithRedirect(auth, provider);
+    return null;
+  }
+  return signInWithPopup(auth, provider);
+};
+
+export const getGoogleRedirectResult = async () => getRedirectResult(auth);
 
 export const googleSignOut = async () => signOut(auth);
 

--- a/apps/web/src/app/helpers/firebase/auth.ts
+++ b/apps/web/src/app/helpers/firebase/auth.ts
@@ -15,9 +15,7 @@ import firebaseApp from '.';
 const auth = getAuth(firebaseApp);
 const provider = new GoogleAuthProvider();
 
-// Popups are unreliable on mobile web (silently blocked on iOS Safari), so
-// Firebase recommends redirect there. Fire-and-forget: the redirect result is
-// picked up via getGoogleRedirectResult after the page reloads.
+// Popups are silently blocked on iOS Safari, so use redirect on mobile.
 export const googleSignIn = async (isMobile: boolean): Promise<void> => {
   if (isMobile) {
     await signInWithRedirect(auth, provider);

--- a/apps/web/src/app/helpers/firebase/auth.ts
+++ b/apps/web/src/app/helpers/firebase/auth.ts
@@ -15,13 +15,15 @@ import firebaseApp from '.';
 const auth = getAuth(firebaseApp);
 const provider = new GoogleAuthProvider();
 
-// Safari mobile blocks the cross-origin popup flow silently, so redirect there.
-export const googleSignIn = async (isMobile: boolean) => {
+// Popups are unreliable on mobile web (silently blocked on iOS Safari), so
+// Firebase recommends redirect there. Fire-and-forget: the redirect result is
+// picked up via getGoogleRedirectResult after the page reloads.
+export const googleSignIn = async (isMobile: boolean): Promise<void> => {
   if (isMobile) {
     await signInWithRedirect(auth, provider);
-    return null;
+    return;
   }
-  return signInWithPopup(auth, provider);
+  await signInWithPopup(auth, provider);
 };
 
 export const getGoogleRedirectResult = async () => getRedirectResult(auth);

--- a/apps/web/src/app/web-ext/page.tsx
+++ b/apps/web/src/app/web-ext/page.tsx
@@ -34,8 +34,7 @@ export default function Web() {
 
   const isMobile = os === 'ios' || os === 'android';
 
-  // Mobile sign-in uses a redirect, which reloads the page and loses the
-  // shouldPreloadData state set in handleSignIn — recover it on return.
+  // Complete the mobile redirect sign-in and re-trigger preload after reload.
   useEffect(() => {
     getGoogleRedirectResult()
       .then((result) => {

--- a/apps/web/src/app/web-ext/page.tsx
+++ b/apps/web/src/app/web-ext/page.tsx
@@ -9,6 +9,7 @@ import {
   UserGroupIcon,
 } from '@hugeicons/core-free-icons';
 import { HugeiconsIcon } from '@hugeicons/react';
+import { useOs } from '@mantine/hooks';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
@@ -17,6 +18,7 @@ import {
   googleSignIn,
   googleSignOut,
   emailAndPasswordSignIn,
+  getGoogleRedirectResult,
 } from '@app/helpers/firebase/auth';
 import { useUser } from '@app/provider/AuthProvider';
 
@@ -24,10 +26,27 @@ import useWebPreload from './hooks/useWebPreload';
 
 export default function Web() {
   const router = useRouter();
+  const os = useOs();
   const { isLoggedIn } = useUser();
   const { isLoading, preloadData, clearData } = useWebPreload();
   const [shouldPreloadData, setShouldPreloadData] = useState(false);
   const [isSigningOut, setIsSigningOut] = useState(false);
+
+  const isMobile = os === 'ios' || os === 'android';
+
+  // Mobile sign-in uses a redirect, which reloads the page and loses the
+  // shouldPreloadData state set in handleSignIn — recover it on return.
+  useEffect(() => {
+    getGoogleRedirectResult()
+      .then((result) => {
+        if (result?.user) {
+          setShouldPreloadData(true);
+        }
+      })
+      .catch((error: unknown) => {
+        console.error('Redirect sign-in failed', error);
+      });
+  }, []);
 
   /**
    * Preload data only when:
@@ -49,17 +68,21 @@ export default function Web() {
   }, [isLoading, preloadData, shouldPreloadData, isLoggedIn]);
 
   const handleSignIn = async () => {
-    const testCredentialsJson = localStorage.getItem(TEST_CREDENTIALS_KEY);
-    if (testCredentialsJson) {
-      const testCredentials = JSON.parse(testCredentialsJson);
-      await emailAndPasswordSignIn(
-        testCredentials.email,
-        testCredentials.password
-      );
-    } else {
-      await googleSignIn();
+    try {
+      const testCredentialsJson = localStorage.getItem(TEST_CREDENTIALS_KEY);
+      if (testCredentialsJson) {
+        const testCredentials = JSON.parse(testCredentialsJson);
+        await emailAndPasswordSignIn(
+          testCredentials.email,
+          testCredentials.password
+        );
+      } else {
+        await googleSignIn(isMobile);
+      }
+      setShouldPreloadData(true);
+    } catch (error) {
+      console.error('Sign-in failed', error);
     }
-    setShouldPreloadData(true);
   };
 
   const handleSignOut = async () => {


### PR DESCRIPTION
#### Check if the Pull Request fulfils these requirements

- [ ] Does the extension require a version change?

<!-- greptile_comment -->

 

<h3>Greptile Summary</h3>

This PR fixes Safari (iOS) login by switching from `signInWithPopup` to `signInWithRedirect` on mobile, where popups are silently blocked. A `useEffect` on mount calls `getRedirectResult` to complete the sign-in after the browser redirects back to the page.

- `auth.ts` adds an `isMobile` param to `googleSignIn` and exports `getGoogleRedirectResult` wrapping `getRedirectResult`.
- `page.tsx` uses Mantine's `useOs()` to compute `isMobile`, passes it to `googleSignIn`, and adds a mount-time effect to pick up the redirect result and trigger preload on return.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the redirect flow is correctly implemented and the popup path is unchanged.

Both the redirect and popup paths are logically correct. Auth state is recovered via onAuthStateChanged in AuthProvider and via getRedirectResult in the mount effect.

The handleSignIn flow in page.tsx deserves a second look to clarify which codepath sets shouldPreloadData for mobile vs desktop.
</details>

<sub>Reviews (2): Last reviewed commit: ["docs: tighten sign-in comments"](https://github.com/amitsingh-007/bypass-links/commit/4574ac4d02e450e15568ae7ac23b1cb2f52b22fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43636428)</sub>

<!-- /greptile_comment -->