### PR TITLE
fix: proxy Firebase auth handler so Safari mobile redirect login completes (#4067)

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -42,9 +42,7 @@ const nextConfig: NextConfig = {
   // blocked by Safari ITP. Must be a rewrite (transparent), not a 302.
   // https://firebase.google.com/docs/auth/web/redirect-best-practices
   async rewrites() {
-    const authHelper = isDev
-      ? 'https://bypass-links-dev.firebaseapp.com'
-      : 'https://bypass-links.firebaseapp.com';
+    const authHelper = 'https://bypass-links.firebaseapp.com';
     return [
       {
         source: '/__/auth/:path*',

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -38,12 +38,10 @@ const nextConfig: NextConfig = {
     // for type info + tsconfig paths instead. Requires Next >= 16.3.
     useTypeScriptCli: true,
   },
-  // Serve Firebase's auth handler from our own domain so signInWithRedirect is
-  // same-origin — Safari's ITP blocks the default cross-origin firebaseapp.com
-  // flow. Must be a transparent proxy (rewrite), not a 302.
+  // Same-origin proxy for Firebase's auth handler so signInWithRedirect isn't
+  // blocked by Safari ITP. Must be a rewrite (transparent), not a 302.
   // https://firebase.google.com/docs/auth/web/redirect-best-practices
   async rewrites() {
-    // Match the Firebase project that getFirebasePublicConfig selects by env.
     const authHelper = isDev
       ? 'https://bypass-links-dev.firebaseapp.com'
       : 'https://bypass-links.firebaseapp.com';

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -38,6 +38,23 @@ const nextConfig: NextConfig = {
     // for type info + tsconfig paths instead. Requires Next >= 16.3.
     useTypeScriptCli: true,
   },
+  // Serve Firebase's auth handler from our own domain so signInWithRedirect is
+  // same-origin — Safari's ITP blocks the default cross-origin firebaseapp.com
+  // flow. Must be a transparent proxy (rewrite), not a 302.
+  // https://firebase.google.com/docs/auth/web/redirect-best-practices
+  async rewrites() {
+    const authHelper = 'https://bypass-links.firebaseapp.com';
+    return [
+      {
+        source: '/__/auth/:path*',
+        destination: `${authHelper}/__/auth/:path*`,
+      },
+      {
+        source: '/__/firebase/:path*',
+        destination: `${authHelper}/__/firebase/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -43,7 +43,10 @@ const nextConfig: NextConfig = {
   // flow. Must be a transparent proxy (rewrite), not a 302.
   // https://firebase.google.com/docs/auth/web/redirect-best-practices
   async rewrites() {
-    const authHelper = 'https://bypass-links.firebaseapp.com';
+    // Match the Firebase project that getFirebasePublicConfig selects by env.
+    const authHelper = isDev
+      ? 'https://bypass-links-dev.firebaseapp.com'
+      : 'https://bypass-links.firebaseapp.com';
     return [
       {
         source: '/__/auth/:path*',

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "next build --webpack",
     "dev": "next dev --webpack",
+    "dev:https": "next dev --webpack --experimental-https",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "build": "next build --webpack",
     "dev": "next dev --webpack",
-    "dev:https": "next dev --webpack --experimental-https",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/web/src/app/helpers/firebase/index.ts
+++ b/apps/web/src/app/helpers/firebase/index.ts
@@ -1,8 +1,21 @@
 import { getFirebasePublicConfig } from '@bypass/configs/firebase.config';
 import { initializeApp } from 'firebase/app';
 
-const firebaseApp = initializeApp(
-  getFirebasePublicConfig(process.env.NODE_ENV === 'production')
-);
+const isProd = process.env.NODE_ENV === 'production';
+const config = getFirebasePublicConfig(isProd);
+
+// In HTTPS local dev (`pnpm dev:https`), point authDomain at our own origin so
+// signInWithRedirect stays same-origin via the /__/auth proxy in next.config —
+// Firebase always builds the handler URL as `https://<authDomain>/__/auth/...`,
+// so this only works over https, not the default http `pnpm dev`.
+if (
+  !isProd &&
+  typeof window !== 'undefined' &&
+  window.location.protocol === 'https:'
+) {
+  config.authDomain = window.location.host;
+}
+
+const firebaseApp = initializeApp(config);
 
 export default firebaseApp;

--- a/apps/web/src/app/helpers/firebase/index.ts
+++ b/apps/web/src/app/helpers/firebase/index.ts
@@ -1,20 +1,11 @@
 import { getFirebasePublicConfig } from '@bypass/configs/firebase.config';
 import { initializeApp } from 'firebase/app';
 
-const isProd = process.env.NODE_ENV === 'production';
-const config = getFirebasePublicConfig(isProd);
-
-// HTTPS local dev (`pnpm dev:https`): use our own origin as authDomain to keep
-// signInWithRedirect same-origin. Firebase forces https on the handler URL, so
-// this can't work over the default http `pnpm dev`.
-if (
-  !isProd &&
-  typeof window !== 'undefined' &&
-  window.location.protocol === 'https:'
-) {
-  config.authDomain = window.location.host;
-}
-
-const firebaseApp = initializeApp(config);
+// The Safari redirect fix (same-origin authDomain + /__/auth proxy) is applied
+// to prod only. Local dev keeps the cross-domain authDomain — replicating it
+// needs https dev + a separate OAuth redirect URI, which isn't worth the setup.
+const firebaseApp = initializeApp(
+  getFirebasePublicConfig(process.env.NODE_ENV === 'production')
+);
 
 export default firebaseApp;

--- a/apps/web/src/app/helpers/firebase/index.ts
+++ b/apps/web/src/app/helpers/firebase/index.ts
@@ -4,10 +4,9 @@ import { initializeApp } from 'firebase/app';
 const isProd = process.env.NODE_ENV === 'production';
 const config = getFirebasePublicConfig(isProd);
 
-// In HTTPS local dev (`pnpm dev:https`), point authDomain at our own origin so
-// signInWithRedirect stays same-origin via the /__/auth proxy in next.config —
-// Firebase always builds the handler URL as `https://<authDomain>/__/auth/...`,
-// so this only works over https, not the default http `pnpm dev`.
+// HTTPS local dev (`pnpm dev:https`): use our own origin as authDomain to keep
+// signInWithRedirect same-origin. Firebase forces https on the handler URL, so
+// this can't work over the default http `pnpm dev`.
 if (
   !isProd &&
   typeof window !== 'undefined' &&

--- a/packages/configs/firebase.config.ts
+++ b/packages/configs/firebase.config.ts
@@ -2,8 +2,7 @@ export const getFirebasePublicConfig = (isProd: boolean) => {
   if (isProd) {
     return {
       apiKey: 'AIzaSyDiMRlBhW36sLjEADoQj9T5L1H-hIDUAso',
-      // Same-origin as the app so signInWithRedirect works on Safari (ITP);
-      // /__/auth/* is reverse-proxied to firebaseapp.com via next.config rewrites.
+      // Same-origin as the app (vs Safari ITP); /__/auth/* proxied in next.config.
       authDomain: 'bypass-links.vercel.app',
       databaseURL: 'https://bypass-links.firebaseio.com/',
       projectId: 'bypass-links',

--- a/packages/configs/firebase.config.ts
+++ b/packages/configs/firebase.config.ts
@@ -2,7 +2,9 @@ export const getFirebasePublicConfig = (isProd: boolean) => {
   if (isProd) {
     return {
       apiKey: 'AIzaSyDiMRlBhW36sLjEADoQj9T5L1H-hIDUAso',
-      authDomain: 'bypass-links.firebaseapp.com',
+      // Same-origin as the app so signInWithRedirect works on Safari (ITP);
+      // /__/auth/* is reverse-proxied to firebaseapp.com via next.config rewrites.
+      authDomain: 'bypass-links.vercel.app',
       databaseURL: 'https://bypass-links.firebaseio.com/',
       projectId: 'bypass-links',
       storageBucket: 'bypass-links.appspot.com',


### PR DESCRIPTION
## Context

Follow-up to #4070. That change made mobile use `signInWithRedirect`, but on iOS Safari the redirect returned **no user** — `getRedirectResult()` resolved `null` and the button stayed on "Login".

Root cause: `authDomain` (`bypass-links.firebaseapp.com`) is a different origin than the app (`bypass-links.vercel.app`). Firebase completes the redirect by reading state from a cross-origin iframe on `firebaseapp.com`, which Safari's ITP blocks. (The `/__/firebase/init.json` 404 in the Network tab was a symptom.)

## Fix

Make the auth handler same-origin with the app, per [Firebase's redirect best practices](https://firebase.google.com/docs/auth/web/redirect-best-practices):

- `apps/web/next.config.ts` — `rewrites()` transparently proxy `/__/auth/*` and `/__/firebase/*` to `bypass-links.firebaseapp.com`.
- `packages/configs/firebase.config.ts` — prod `authDomain` → `bypass-links.vercel.app` (dev unchanged).

Prerequisite (done): `https://bypass-links.vercel.app/__/auth/handler` added as an Authorized redirect URI on the web OAuth client.

**Rollback:** revert the one `authDomain` line + redeploy; the old `firebaseapp.com` redirect URI is still registered.

#### Check if the Pull Request fulfils these requirements

- [ ] Does the extension require a version change?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

 

<h3>Greptile Summary</h3>

This PR fixes Safari ITP blocking `signInWithRedirect` on iOS by making the Firebase auth handler same-origin with the app. The approach follows Firebase's official redirect best-practices guide.

- `next.config.ts` adds transparent Next.js rewrites that proxy `/__/auth/*` and `/__/firebase/*` to `bypass-links.firebaseapp.com`, making the auth handler reachable on the app's own domain.
- `firebase.config.ts` changes the prod `authDomain` from `bypass-links.firebaseapp.com` to `bypass-links.vercel.app` so Firebase SDK directs redirect traffic through the same-origin proxy.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge for production; the fix is the standard Firebase-recommended approach and scoped correctly to prod config.

The change is a well-understood pattern (same-origin proxy for Firebase auth) with no functional issues on the production deployment. The one concern worth watching is that Vercel preview deployments inherit NODE_ENV=production, so auth redirects on preview URLs will land on the production domain — a workflow inconvenience rather than a production regression.

The authDomain / NODE_ENV coupling in packages/configs/firebase.config.ts and apps/web/src/app/helpers/firebase/index.ts is worth revisiting if preview deployments need to exercise the auth flow.
</details>

<sub>Reviews (4): Last reviewed commit: ["revert: drop dev-mode redirect handling"](https://github.com/amitsingh-007/bypass-links/commit/e04c46c0fa57d3d0fc879960f1cbd2d9538b26da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43822667)</sub>

<!-- /greptile_comment -->