### PR TITLE
fix(web): fall back to redirect sign-in when the popup is blocked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ apps/web/next-env.d.ts
 apps/extension/build/
 apps/extension/.output/
 apps/extension/.wxt/
+.claude/settings.json

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,6 @@
     "@bypass/ui": "workspace:*",
     "@hugeicons/core-free-icons": "catalog:",
     "@hugeicons/react": "catalog:",
-    "@mantine/hooks": "catalog:",
     "@t3-oss/env-nextjs": "catalog:",
     "@tanstack/react-virtual": "catalog:",
     "@trpc/client": "catalog:",

--- a/apps/web/src/app/helpers/firebase/auth.ts
+++ b/apps/web/src/app/helpers/firebase/auth.ts
@@ -1,3 +1,4 @@
+import { FirebaseError } from 'firebase/app';
 import {
   getAuth,
   getRedirectResult,
@@ -15,13 +16,19 @@ import firebaseApp from '.';
 const auth = getAuth(firebaseApp);
 const provider = new GoogleAuthProvider();
 
-// Popups are silently blocked on iOS Safari, so use redirect on mobile.
-export const googleSignIn = async (isMobile: boolean): Promise<void> => {
-  if (isMobile) {
-    await signInWithRedirect(auth, provider);
-    return;
+// Popup first per Firebase best-practices. Blocked popups (iOS Safari default,
+// desktop blockers) fall back to redirect, which needs no popup permission and
+// works via the same-origin /__/auth proxy on prod.
+export const googleSignIn = async (): Promise<void> => {
+  try {
+    await signInWithPopup(auth, provider);
+  } catch (error) {
+    if (error instanceof FirebaseError && error.code === 'auth/popup-blocked') {
+      await signInWithRedirect(auth, provider);
+      return;
+    }
+    throw error;
   }
-  await signInWithPopup(auth, provider);
 };
 
 export const getGoogleRedirectResult = async () => getRedirectResult(auth);

--- a/apps/web/src/app/web-ext/page.tsx
+++ b/apps/web/src/app/web-ext/page.tsx
@@ -9,7 +9,6 @@ import {
   UserGroupIcon,
 } from '@hugeicons/core-free-icons';
 import { HugeiconsIcon } from '@hugeicons/react';
-import { useOs } from '@mantine/hooks';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { z } from 'zod/mini';
@@ -32,15 +31,12 @@ const testCredentialsSchema = z.object({
 
 export default function Web() {
   const router = useRouter();
-  const os = useOs();
   const { isLoggedIn } = useUser();
   const { isLoading, preloadData, clearData } = useWebPreload();
   const [shouldPreloadData, setShouldPreloadData] = useState(false);
   const [isSigningOut, setIsSigningOut] = useState(false);
 
-  const isMobile = os === 'ios' || os === 'android';
-
-  // Complete the mobile redirect sign-in and re-trigger preload after reload.
+  // Complete the redirect sign-in and re-trigger preload after reload.
   useEffect(() => {
     getGoogleRedirectResult()
       .then((result) => {
@@ -84,7 +80,7 @@ export default function Web() {
           testCredentials.password
         );
       } else {
-        await googleSignIn(isMobile);
+        await googleSignIn();
       }
       setShouldPreloadData(true);
     } catch (error) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -402,9 +402,6 @@ importers:
       '@hugeicons/react':
         specifier: 'catalog:'
         version: 1.1.9(react@19.2.8)
-      '@mantine/hooks':
-        specifier: 'catalog:'
-        version: 9.5.0(react@19.2.8)
       '@t3-oss/env-nextjs':
         specifier: 'catalog:'
         version: 0.13.11(typescript@7.0.2)(zod@4.4.3)


### PR DESCRIPTION
#### Check if the Pull Request fulfils these requirements

- [x] Does the extension require a version change?

<!-- greptile_comment -->

 

<details><summary><h3>Greptile Summary</h3></summary>

The PR changes Google authentication to try popup sign-in first and fall back to redirect sign-in when Firebase reports that the popup was blocked.
- Removes mobile OS detection and the now-unused Mantine hooks dependency.
- Retains redirect-result processing on `/web-ext`.
- Adds a local Claude settings file to `.gitignore`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete changed-code defect identified.

The popup-blocked path now transitions to the existing redirect flow, redirect results remain processed after reload, and the removed OS-detection dependency is no longer referenced.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): fall back to redirect sign-in ..."](https://github.com/amitsingh-007/bypass-links/commit/6002841494eb902f032ff2cc24239c2b85ea5214) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49355748)</sub>

**Context used:**

- Knowledge Base — [Web App (apps/web)](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/web-app.md)

<!-- /greptile_comment -->