### PR TITLE
feat(web): switch build and dev back to Turbopack

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -13,13 +13,6 @@ if (!process.env.VERCEL) {
 
 const isDev = process.env.NODE_ENV === 'development';
 
-// TODO: The build runs via `next build --webpack` (see package.json) instead of
-// the Turbopack default. Turbopack emits hash-suffixed external-module
-// references that don't resolve under pnpm's symlinked node_modules on Vercel,
-// so sharp's native binary fails to load in /api/upload-file (ERR_DLOPEN_FAILED)
-// and the endpoint 500s. webpack traces the native module correctly.
-// Tracking: https://github.com/vercel/next.js/issues/87737
-// Once fixed upstream, drop `--webpack` to switch the build back to Turbopack.
 const nextConfig: NextConfig = {
   productionBrowserSourceMaps: true,
   cacheComponents: true,
@@ -34,8 +27,10 @@ const nextConfig: NextConfig = {
   agentRules: false,
   experimental: {
     // TODO: TypeScript 7's native package drops the JS compiler API that Next's
-    // default backend uses; this runs the local `tsc` (via tsc --showConfig)
-    // for type info + tsconfig paths instead. Requires Next >= 16.3.
+    // default backend uses; this runs the local `tsc` (via tsc --showConfig) for
+    // type info + tsconfig paths instead. Next never selects the CLI checker on
+    // its own, so this is required, not optional. Remove once it leaves experimental.
+    // Tracking: https://github.com/vercel/next.js/discussions/95633
     useTypeScriptCli: true,
   },
   // Same-origin proxy for Firebase's auth handler so signInWithRedirect isn't

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "next build --webpack",
-    "dev": "next dev --webpack",
+    "build": "next build",
+    "dev": "next dev",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
#### Check if the Pull Request fulfils these requirements

- [x] Does the extension require a version change?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

 

<details><summary><h3>Greptile Summary</h3></summary>

Switches the web application’s development and production builds from webpack back to Next.js’s default Turbopack bundler.
- Removes the explicit `--webpack` flags from the web build and development scripts.
- Updates configuration comments explaining the TypeScript CLI checker requirement.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The pinned Next.js version and documented validation address the prior Turbopack tracing failure, while the remaining configuration and script changes are internally consistent.
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): switch build and dev back to ..."](https://github.com/amitsingh-007/bypass-links/commit/ffe5eb207845be34f65bacbe999b1e50746afb85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49358487)</sub>

<!-- /greptile_comment -->