### PR TITLE
refactor: remove dead code across workspaces

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bypass/extension",
-  "version": "25.1.0",
+  "version": "25.2.0",
   "private": true,
   "description": "Bypass links from various sites to required links, with added functionality of Bookmarks Manager, Tagging Panel.",
   "type": "module",

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksPanel.tsx
@@ -5,7 +5,6 @@ import {
   HEADER_HEIGHT,
   ScrollButton,
   getFilteredContextBookmarks,
-  shouldRenderBookmarks,
 } from '@bypass/shared';
 import { ScrollArea } from '@bypass/ui';
 import { useVirtualizer } from '@tanstack/react-virtual';
@@ -31,7 +30,6 @@ function BookmarksPanel({ folderId, operation, bmUrl }: BMPanelQueryParams) {
   );
   const {
     contextBookmarks,
-    folders,
     selectedBookmarks,
     cutBookmarks,
     isFetching,
@@ -39,7 +37,6 @@ function BookmarksPanel({ folderId, operation, bmUrl }: BMPanelQueryParams) {
   } = useBookmarkStore(
     useShallow((state) => ({
       contextBookmarks: state.contextBookmarks,
-      folders: state.folders,
       selectedBookmarks: state.selectedBookmarks,
       cutBookmarks: state.cutBookmarks,
       isFetching: state.isFetching,
@@ -117,7 +114,7 @@ function BookmarksPanel({ folderId, operation, bmUrl }: BMPanelQueryParams) {
             className="w-full"
             style={{ height: MAX_PANEL_SIZE.HEIGHT - HEADER_HEIGHT }}
           >
-            {shouldRenderBookmarks(folders, filteredContextBookmarks) ? (
+            {filteredContextBookmarks.length > 0 ? (
               <div
                 className="relative w-full"
                 style={{ height: virtualizer.getTotalSize() }}

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/store/useBookmarkStore.ts
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/store/useBookmarkStore.ts
@@ -60,7 +60,6 @@ const useBookmarkStore = create<State>()((set, get) => ({
   cutBookmarks: [],
   isFetching: true,
   isSaveButtonActive: false,
-  updateTaggedPersons: [],
 
   async loadData(folderId: string) {
     set({ isSaveButtonActive: false, isFetching: true });
@@ -97,8 +96,6 @@ const useBookmarkStore = create<State>()((set, get) => ({
     const { selectedBookmarks } = get();
     set({ cutBookmarks: [...selectedBookmarks] });
   },
-
-  resetCutBookmarks: () => set({ cutBookmarks: [] }),
 
   handleCreateNewFolder(name: string, parentFolderId: string) {
     const { contextBookmarks, folderList } = get();

--- a/apps/extension/src/interfaces/firebase.ts
+++ b/apps/extension/src/interfaces/firebase.ts
@@ -1,7 +1,6 @@
 export interface IAuthResponse {
   readonly uid: string;
   readonly email: string;
-  readonly fullName: string;
   readonly photoUrl?: string;
   readonly displayName?: string;
   readonly expiresIn: number;

--- a/apps/extension/src/store/firebase/api.ts
+++ b/apps/extension/src/store/firebase/api.ts
@@ -32,7 +32,6 @@ export const signInWithCredential = async (accessToken: string) => {
     .json<IAuthResponse>((res) => ({
       uid: res.localId,
       email: res.email,
-      fullName: res.displayName,
       photoUrl: res.photoUrl,
       displayName: res.displayName,
       idToken: res.idToken,

--- a/apps/extension/src/store/progress.ts
+++ b/apps/extension/src/store/progress.ts
@@ -5,9 +5,7 @@ interface ProgressState {
   progress: number;
   startLoading: () => void;
   stopLoading: () => void;
-  setProgress: (progress: number) => void;
   incrementProgress: (totalSteps: number) => void;
-  resetProgress: () => void;
 }
 
 const useProgressStore = create<ProgressState>()((set, get) => ({
@@ -21,17 +19,11 @@ const useProgressStore = create<ProgressState>()((set, get) => ({
       set(() => ({ isLoading: false, progress: 0 }));
     }, 300); // 300ms delay allows users to see progress at 100% before overlay disappears
   },
-  setProgress(progress: number) {
-    set(() => ({ progress }));
-  },
   incrementProgress(totalSteps: number) {
     const { progress } = get();
     const stepSize = 100 / totalSteps;
     const newProgress = Math.min(progress + stepSize, 100);
     set(() => ({ progress: newProgress }));
-  },
-  resetProgress() {
-    set(() => ({ progress: 0 }));
   },
 }));
 

--- a/apps/extension/tests/auth.setup.ts
+++ b/apps/extension/tests/auth.setup.ts
@@ -38,7 +38,6 @@ const signInWithEmailAndPassword = async (): Promise<IAuthResponse> => {
     .json<IAuthResponse>((res) => ({
       uid: res.localId,
       email: res.email,
-      fullName: res.displayName,
       photoUrl: '',
       displayName: res.displayName,
       idToken: res.idToken,

--- a/apps/extension/tests/utils/test-utils.ts
+++ b/apps/extension/tests/utils/test-utils.ts
@@ -1,7 +1,4 @@
-import {
-  fillSearchInput as fillSearchInputShared,
-  parseBadgeCount,
-} from '@bypass/shared/tests';
+import { parseBadgeCount } from '@bypass/shared/tests';
 import { expect, type Page } from '@playwright/test';
 
 // Re-export shared utilities for convenience
@@ -81,38 +78,6 @@ export const openFolder = async (page: Page, folderName: string) => {
   const folder = page.getByTestId(`folder-item-${folderName}`);
   await expect(folder).toBeVisible();
   await folder.click();
-};
-
-interface SearchAndVerifyOptions {
-  visibleTexts: string[];
-  hiddenTexts?: string[];
-  selector?: string;
-}
-
-/**
- * Search and verify elements are visible/not visible.
- */
-export const searchAndVerify = async (
-  page: Page,
-  searchText: string,
-  options: SearchAndVerifyOptions
-) => {
-  const {
-    visibleTexts,
-    hiddenTexts = [],
-    selector = '[data-testid^="person-item-"]',
-  } = options;
-  await fillSearchInputShared(page, searchText);
-
-  for (const text of visibleTexts) {
-    const element = page.locator(selector).filter({ hasText: text });
-    await expect(element).toBeVisible();
-  }
-
-  for (const text of hiddenTexts) {
-    const element = page.locator(selector).filter({ hasText: text });
-    await expect(element).not.toBeVisible();
-  }
 };
 
 /**

--- a/apps/web/src/app/bookmark-panel/page.tsx
+++ b/apps/web/src/app/bookmark-panel/page.tsx
@@ -9,7 +9,6 @@ import {
   getFolderName,
   Header,
   type IBookmarksObj,
-  shouldRenderBookmarks,
   STORAGE_KEYS,
 } from '@bypass/shared';
 import { ScrollArea } from '@bypass/ui';
@@ -17,7 +16,7 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import { useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { getFromLocalStorage, setToLocalStorage } from '@app/utils/storage';
+import { getFromLocalStorage } from '@app/utils/storage';
 
 import VirtualRow from './components/VirtualRow';
 
@@ -61,7 +60,6 @@ export default function BookmarksPage() {
     setContextBookmarks(modifiedBookmarks);
     setFolders(foldersData);
     setFolderName(getFolderName(folderListData, folderId));
-    setToLocalStorage(STORAGE_KEYS.bookmarks, bookmarksData);
   }, [folderId]);
 
   useEffect(() => {
@@ -77,7 +75,7 @@ export default function BookmarksPage() {
         onSearchChange={handleSearchTextChange}
       />
       <ScrollArea viewportRef={scrollAreaRef} className="flex-1">
-        {shouldRenderBookmarks(folders, filteredContextBookmarks) ? (
+        {filteredContextBookmarks.length > 0 ? (
           <div
             style={{ height: virtualizer.getTotalSize() }}
             className="relative w-full"

--- a/packages/shared/src/components/Bookmarks/utils/index.ts
+++ b/packages/shared/src/components/Bookmarks/utils/index.ts
@@ -29,11 +29,6 @@ export const getFilteredContextBookmarks = (
     return hasText(searchText, ctx.url) || hasText(searchText, ctx.title);
   });
 
-export const shouldRenderBookmarks = (
-  folders: IBookmarksObj['folders'],
-  contextBookmarks: ContextBookmarks
-) => folders && contextBookmarks && contextBookmarks.length > 0;
-
 export const getEncryptedBookmark = (
   bookmark: IEncodedBookmark
 ): IEncodedBookmark => ({

--- a/packages/shared/src/constants/e2e-tests.ts
+++ b/packages/shared/src/constants/e2e-tests.ts
@@ -54,11 +54,6 @@ export const TEST_SITES = {
 } as const;
 
 /**
- * Default rule alias that indicates an incomplete rule.
- */
-export const DEFAULT_RULE_ALIAS = 'http://///';
-
-/**
  * Timeout constants used across test files to avoid magic numbers.
  */
 export const TEST_TIMEOUTS = {

--- a/packages/shared/src/utils/test-helpers.ts
+++ b/packages/shared/src/utils/test-helpers.ts
@@ -78,22 +78,6 @@ export const clearSearchInput = async (page: Page, placeholder = 'Search') => {
 };
 
 /**
- * Click a button by its visible text/label.
- */
-export const clickButtonByName = async (
-  page: Page,
-  name: string | RegExp,
-  options?: { exact?: boolean; within?: ReturnType<Page['locator']> }
-) => {
-  const scope = options?.within ?? page;
-  const button = scope.getByRole('button', {
-    name,
-    exact: options?.exact ?? false,
-  });
-  await button.click();
-};
-
-/**
  * Get the count from a badge text in format "Name (N)" or just "(N)".
  */
 export const parseBadgeCount = (badgeText: string): number => {

--- a/packages/trpc/src/@types/trpc.ts
+++ b/packages/trpc/src/@types/trpc.ts
@@ -8,9 +8,5 @@ export interface IUser {
 }
 
 export interface ITRPCContext {
-  reqMetaData: {
-    ip: string | null;
-    userAgent: string | null;
-  };
   user: IUser | null;
 }

--- a/packages/trpc/src/trpc.ts
+++ b/packages/trpc/src/trpc.ts
@@ -5,7 +5,7 @@ import {
   getFirebaseUser,
   verifyAuthToken,
 } from './services/firebaseAdminService';
-import { getAuthBearer, getIpAddress } from './utils/headers';
+import { getAuthBearer } from './utils/headers';
 
 const getLoggedInUser = async (idToken: string | undefined) => {
   if (!idToken) {
@@ -26,19 +26,9 @@ const getLoggedInUser = async (idToken: string | undefined) => {
 export const createTRPCContext = async (
   req: Request
 ): Promise<ITRPCContext> => {
-  const { headers } = req;
-  const ip = getIpAddress(req);
-  const userAgent = headers.get('user-agent');
-  const bearerToken = getAuthBearer(req);
-  const user = await getLoggedInUser(bearerToken);
+  const user = await getLoggedInUser(getAuthBearer(req));
 
-  return {
-    reqMetaData: {
-      ip,
-      userAgent,
-    },
-    user,
-  };
+  return { user };
 };
 
 export const t = initTRPC

--- a/packages/trpc/src/utils/headers.ts
+++ b/packages/trpc/src/utils/headers.ts
@@ -1,16 +1,2 @@
-const FALLBACK_IP_ADDRESS = '0.0.0.0';
-
-/**
- * @link https://nextjs.org/docs/app/api-reference/functions/headers#ip-address
- */
-export const getIpAddress = (req: Request) => {
-  const { headers } = req;
-  const forwardedFor = headers.get('x-forwarded-for');
-  if (forwardedFor) {
-    return forwardedFor.split(',')[0] ?? FALLBACK_IP_ADDRESS;
-  }
-  return headers.get('x-real-ip') ?? FALLBACK_IP_ADDRESS;
-};
-
 export const getAuthBearer = (req: Request) =>
   req.headers.get('authorization')?.split?.('Bearer ')?.[1];


### PR DESCRIPTION
PR 1/6 of a stacked cleanup. **Base: `main`.**

Removes nine unused symbols, each confirmed by repo-wide grep including both test suites.

| Workspace | Removed |
|---|---|
| `trpc` | `reqMetaData` context field, `getIpAddress`, `FALLBACK_IP_ADDRESS` — two header parses per request, read by nothing |
| `shared` | `DEFAULT_RULE_ALIAS` from e2e constants — unused **and** drifted to `'http://///'` vs the real `'http:///'` |
| `shared` | `clickButtonByName`; `shouldRenderBookmarks`, which reduced to `.length > 0` and is inlined |
| `extension` | `searchAndVerify`, `updateTaggedPersons`, `resetCutBookmarks`, `setProgress`/`resetProgress`, `fullName` |
| `web` | bookmarks localStorage write-back that re-serialised the whole DB on every mount and folder nav |

`updateTaggedPersons` and `resetCutBookmarks` weren't in the `State` interface, so the compiler couldn't see them.

Dropping `shouldRenderBookmarks` also removes `folders` from the `BookmarksPanel` `useShallow` selector, so it no longer re-renders on folder changes.

**Net: 14 files, -115/+7.**

### Verification
`typecheck:all` / `lint` / `format:check` clean. e2e: extension bookmarks 22/22, web 23/23. The extension run matters because this edits `tests/auth.setup.ts`.

<!-- greptile_comment -->

 

<details><summary><h3>Greptile Summary</h3></summary>

The PR removes unused request metadata, helpers, store actions, and redundant bookmark storage work across the extension, web, shared, and tRPC workspaces.
- Simplifies bookmark rendering and avoids unnecessary folder-driven renders and local-storage writes.
- Removes unused authentication, progress, test-helper, and request-context fields.
- Updates the extension package version to 25.2.0.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["chore(extension): bump minor version to ..."](https://github.com/amitsingh-007/bypass-links/commit/4e6634270fec6c607a13d5de4473bc3384f8d684) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49463431)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Knowledge Base — [Extension background service worker](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/extension-background.md)
- Knowledge Base — [Extension Popup UI](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/extension-popup.md)
- Knowledge Base — [Web App (apps/web)](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/web-app.md)
- Knowledge Base — [packages/trpc: shared tRPC API layer](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/trpc-package.md)
- Knowledge Base — [Shared package (`packages/shared`)](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/shared-package.md)
</details>

<!-- /greptile_comment -->