### PR TITLE
fix: close upload auth gap, empty-state failures and background listener leak

### DIFF
--- a/apps/extension/src/entrypoints/background/index.ts
+++ b/apps/extension/src/entrypoints/background/index.ts
@@ -71,10 +71,27 @@ export default defineBackground({
      * consuming the tab's pending reload.
      */
     const reloadingTabIds = new Set<number>();
+    const clearReloading = ({
+      tabId,
+      frameId,
+    }: {
+      tabId: number;
+      frameId: number;
+    }) => {
+      if (isMainFrame(frameId)) {
+        reloadingTabIds.delete(tabId);
+      }
+    };
 
     browser.webNavigation.onCommitted.addListener((details) => {
-      if (details.transitionType === 'reload' && isMainFrame(details.frameId)) {
+      if (!isMainFrame(details.frameId)) {
+        return;
+      }
+      // A non-reload commit supersedes any pending reload for this tab
+      if (details.transitionType === 'reload') {
         reloadingTabIds.add(details.tabId);
+      } else {
+        reloadingTabIds.delete(details.tabId);
       }
     });
 
@@ -83,6 +100,10 @@ export default defineBackground({
         onPageLoad(tabId, url);
       }
     });
+
+    // Without this a reload that aborts leaves a marker the next unrelated
+    // completion would consume
+    browser.webNavigation.onErrorOccurred.addListener(clearReloading);
 
     browser.tabs.onRemoved.addListener((tabId) => {
       reloadingTabIds.delete(tabId);

--- a/apps/extension/src/entrypoints/background/index.ts
+++ b/apps/extension/src/entrypoints/background/index.ts
@@ -63,16 +63,29 @@ export default defineBackground({
     /**
      * NOTE: Can remove browser.tabs.onUpdated in favor of this
      * @link https://stackoverflow.com/questions/16949810/how-can-i-run-this-script-when-the-tab-reloads-chrome-extension
+     *
+     * Two listeners registered once, rather than nesting an onCompleted
+     * listener per reload. The nested version was neither tab-filtered nor
+     * reliably removed: the first onCompleted from *any* tab consumed it, so a
+     * reload of tab A could fire onPageLoad against tab B, and a tab closed
+     * before completing leaked its listener for the worker's lifetime.
      */
+    const reloadingTabIds = new Set<number>();
+
     browser.webNavigation.onCommitted.addListener((details) => {
       if (details.transitionType === 'reload') {
-        browser.webNavigation.onCompleted.addListener(function onComplete({
-          tabId,
-        }) {
-          onPageLoad(tabId, details.url);
-          browser.webNavigation.onCompleted.removeListener(onComplete);
-        });
+        reloadingTabIds.add(details.tabId);
       }
+    });
+
+    browser.webNavigation.onCompleted.addListener(({ tabId, url }) => {
+      if (reloadingTabIds.delete(tabId)) {
+        onPageLoad(tabId, url);
+      }
+    });
+
+    browser.tabs.onRemoved.addListener((tabId) => {
+      reloadingTabIds.delete(tabId);
     });
 
     // Listen to dispatched messages

--- a/apps/extension/src/entrypoints/background/index.ts
+++ b/apps/extension/src/entrypoints/background/index.ts
@@ -32,6 +32,8 @@ const onPageLoad = async (tabId: number, url: string) => {
   }
 };
 
+const isMainFrame = (frameId: number) => frameId === 0;
+
 const updateIcon = async () => {
   const [extState, hasPendingBookmarks, hasPendingPersons] = await Promise.all([
     extStateItem.getValue(),
@@ -64,22 +66,20 @@ export default defineBackground({
      * NOTE: Can remove browser.tabs.onUpdated in favor of this
      * @link https://stackoverflow.com/questions/16949810/how-can-i-run-this-script-when-the-tab-reloads-chrome-extension
      *
-     * Two listeners registered once, rather than nesting an onCompleted
-     * listener per reload. The nested version was neither tab-filtered nor
-     * reliably removed: the first onCompleted from *any* tab consumed it, so a
-     * reload of tab A could fire onPageLoad against tab B, and a tab closed
-     * before completing leaked its listener for the worker's lifetime.
+     * Registered once instead of nesting a listener per reload, which was
+     * neither tab-filtered nor reliably removed. frameId 0 keeps subframes from
+     * consuming the tab's pending reload.
      */
     const reloadingTabIds = new Set<number>();
 
     browser.webNavigation.onCommitted.addListener((details) => {
-      if (details.transitionType === 'reload') {
+      if (details.transitionType === 'reload' && isMainFrame(details.frameId)) {
         reloadingTabIds.add(details.tabId);
       }
     });
 
-    browser.webNavigation.onCompleted.addListener(({ tabId, url }) => {
-      if (reloadingTabIds.delete(tabId)) {
+    browser.webNavigation.onCompleted.addListener(({ tabId, url, frameId }) => {
+      if (isMainFrame(frameId) && reloadingTabIds.delete(tabId)) {
         onPageLoad(tabId, url);
       }
     });

--- a/apps/extension/src/entrypoints/background/misc/forumPageLinks.ts
+++ b/apps/extension/src/entrypoints/background/misc/forumPageLinks.ts
@@ -54,11 +54,15 @@ export const getForumPageLinks = async (
   url: string
 ): Promise<string[]> => {
   const websites = await websitesItem.getValue();
+  // An unsynced record leaves these undefined; matching on it would coerce to
+  // the literal string "undefined" and match arbitrary urls
+  const matches = (website?: string) =>
+    Boolean(website) && url.includes(website!);
   let executor: () => Array<string | undefined>;
 
   switch (true) {
-    case url.includes(websites.FORUM_1):
-    case url.includes(websites.FORUM_2): {
+    case matches(websites.FORUM_1):
+    case matches(websites.FORUM_2): {
       const { pathname } = new URL(url);
       const isWatchThreadsPage = pathname === '/watched/threads';
       executor = isWatchThreadsPage
@@ -67,12 +71,12 @@ export const getForumPageLinks = async (
       break;
     }
 
-    case url.includes(websites.FORUM_3): {
+    case matches(websites.FORUM_3): {
       executor = getForum_3_LinksFunc;
       break;
     }
 
-    case url.includes(websites.FORUM_4): {
+    case matches(websites.FORUM_4): {
       executor = getForum_4_LinksFunc;
       break;
     }

--- a/apps/extension/src/entrypoints/background/misc/forumPageLinks.ts
+++ b/apps/extension/src/entrypoints/background/misc/forumPageLinks.ts
@@ -56,7 +56,7 @@ export const getForumPageLinks = async (
   const websites = await websitesItem.getValue();
   // Undefined when unsynced; url.includes(undefined) would match arbitrary urls
   const matches = (website?: string) =>
-    Boolean(website) && url.includes(website!);
+    Boolean(website && url.includes(website));
   let executor: () => Array<string | undefined>;
 
   switch (true) {

--- a/apps/extension/src/entrypoints/background/misc/forumPageLinks.ts
+++ b/apps/extension/src/entrypoints/background/misc/forumPageLinks.ts
@@ -54,8 +54,7 @@ export const getForumPageLinks = async (
   url: string
 ): Promise<string[]> => {
   const websites = await websitesItem.getValue();
-  // An unsynced record leaves these undefined; matching on it would coerce to
-  // the literal string "undefined" and match arbitrary urls
+  // Undefined when unsynced; url.includes(undefined) would match arbitrary urls
   const matches = (website?: string) =>
     Boolean(website) && url.includes(website!);
   let executor: () => Array<string | undefined>;

--- a/apps/extension/src/entrypoints/background/websites/index.ts
+++ b/apps/extension/src/entrypoints/background/websites/index.ts
@@ -3,7 +3,7 @@ import { websitesItem } from '@/storage/items';
 export const isForumPage = async (hostname: string) => {
   const websites = await websitesItem.getValue();
   // hostname.includes('') is true for every page
-  return Object.values(websites).some(
-    (website) => Boolean(website) && hostname.includes(website)
+  return Object.values(websites).some((website) =>
+    Boolean(website && hostname.includes(website))
   );
 };

--- a/apps/extension/src/entrypoints/background/websites/index.ts
+++ b/apps/extension/src/entrypoints/background/websites/index.ts
@@ -2,7 +2,7 @@ import { websitesItem } from '@/storage/items';
 
 export const isForumPage = async (hostname: string) => {
   const websites = await websitesItem.getValue();
-  // Falsy entries are filtered: hostname.includes('') is true for every page
+  // hostname.includes('') is true for every page
   return Object.values(websites).some(
     (website) => Boolean(website) && hostname.includes(website)
   );

--- a/apps/extension/src/entrypoints/background/websites/index.ts
+++ b/apps/extension/src/entrypoints/background/websites/index.ts
@@ -2,5 +2,8 @@ import { websitesItem } from '@/storage/items';
 
 export const isForumPage = async (hostname: string) => {
   const websites = await websitesItem.getValue();
-  return Object.values(websites).some((website) => hostname.includes(website));
+  // Falsy entries are filtered: hostname.includes('') is true for every page
+  return Object.values(websites).some(
+    (website) => Boolean(website) && hostname.includes(website)
+  );
 };

--- a/apps/extension/src/entrypoints/background/websites/storageSync.ts
+++ b/apps/extension/src/entrypoints/background/websites/storageSync.ts
@@ -1,12 +1,17 @@
-import { mapValues, type IWebsites } from '@bypass/shared';
+import { type IWebsites } from '@bypass/shared';
 
 import { trpcApi } from '@/apis/trpcApi';
 import { websitesItem } from '@/storage/items';
 
-const getDecodedWebsites = (encodedWebsites: IWebsites): IWebsites =>
-  mapValues(encodedWebsites, (value) =>
-    value ? decodeURIComponent(atob(value)) : value
-  );
+const decodeWebsite = (value?: string) =>
+  value ? decodeURIComponent(atob(value)) : value;
+
+const getDecodedWebsites = (encodedWebsites: IWebsites): IWebsites => ({
+  FORUM_1: decodeWebsite(encodedWebsites.FORUM_1),
+  FORUM_2: decodeWebsite(encodedWebsites.FORUM_2),
+  FORUM_3: decodeWebsite(encodedWebsites.FORUM_3),
+  FORUM_4: decodeWebsite(encodedWebsites.FORUM_4),
+});
 
 export const syncWebsitesToStorage = async () => {
   const response = await trpcApi.firebaseData.websitesGet.query();

--- a/apps/extension/src/entrypoints/background/websites/storageSync.ts
+++ b/apps/extension/src/entrypoints/background/websites/storageSync.ts
@@ -4,7 +4,9 @@ import { trpcApi } from '@/apis/trpcApi';
 import { websitesItem } from '@/storage/items';
 
 const getDecodedWebsites = (encodedWebsites: IWebsites): IWebsites =>
-  mapValues(encodedWebsites, (value) => decodeURIComponent(atob(value)));
+  mapValues(encodedWebsites, (value) =>
+    value ? decodeURIComponent(atob(value)) : value
+  );
 
 export const syncWebsitesToStorage = async () => {
   const response = await trpcApi.firebaseData.websitesGet.query();

--- a/apps/extension/src/entrypoints/background/websites/storageSync.ts
+++ b/apps/extension/src/entrypoints/background/websites/storageSync.ts
@@ -6,12 +6,14 @@ import { websitesItem } from '@/storage/items';
 const decodeWebsite = (value?: string) =>
   value ? decodeURIComponent(atob(value)) : value;
 
-const getDecodedWebsites = (encodedWebsites: IWebsites): IWebsites => ({
-  FORUM_1: decodeWebsite(encodedWebsites.FORUM_1),
-  FORUM_2: decodeWebsite(encodedWebsites.FORUM_2),
-  FORUM_3: decodeWebsite(encodedWebsites.FORUM_3),
-  FORUM_4: decodeWebsite(encodedWebsites.FORUM_4),
-});
+// Key-agnostic so adding a forum to the schema cannot silently skip decoding
+const getDecodedWebsites = (encodedWebsites: IWebsites): IWebsites =>
+  Object.fromEntries(
+    Object.entries(encodedWebsites).map(([key, value]) => [
+      key,
+      decodeWebsite(value),
+    ])
+  );
 
 export const syncWebsitesToStorage = async () => {
   const response = await trpcApi.firebaseData.websitesGet.query();

--- a/apps/extension/src/storage/items.ts
+++ b/apps/extension/src/storage/items.ts
@@ -17,7 +17,7 @@ export const bookmarksItem = storage.defineItem<IBookmarksObj>(
 );
 
 export const websitesItem = storage.defineItem<IWebsites>('local:websites', {
-  fallback: {} as unknown as IWebsites,
+  fallback: {},
 });
 
 export const lastVisitedItem = storage.defineItem<ILastVisited>(

--- a/apps/web/src/app/api/upload-file/route.ts
+++ b/apps/web/src/app/api/upload-file/route.ts
@@ -10,7 +10,6 @@ export async function POST(request: NextRequest) {
   try {
     user = await authorizeUser(request);
   } catch (error) {
-    // 401/403 instead of the 500 a bare thrown Error produced
     return toAuthErrorResponse(error);
   }
 

--- a/apps/web/src/app/api/upload-file/route.ts
+++ b/apps/web/src/app/api/upload-file/route.ts
@@ -1,16 +1,14 @@
 import { uploadImageToFirebase } from '@bypass/trpc/appRouter';
 import { type NextRequest, NextResponse } from 'next/server';
 
-import { authorizeUser, toAuthErrorResponse } from '@app/helpers/authorizeUser';
+import { authorizeUser } from '@app/helpers/authorizeUser';
 
 import { validateAndProccessFile } from './utils';
 
 export async function POST(request: NextRequest) {
-  let user;
-  try {
-    user = await authorizeUser(request);
-  } catch (error) {
-    return toAuthErrorResponse(error);
+  const auth = await authorizeUser(request);
+  if (!auth.ok) {
+    return new NextResponse(auth.message, { status: auth.status });
   }
 
   const formData = await request.formData();
@@ -23,7 +21,7 @@ export async function POST(request: NextRequest) {
     return new NextResponse('Invalid file type', { status: 400 });
   }
 
-  await uploadImageToFirebase(user.uid, {
+  await uploadImageToFirebase(auth.user.uid, {
     fileName: file.name,
     fileType: file.type,
     buffer: fileBuffer,

--- a/apps/web/src/app/api/upload-file/route.ts
+++ b/apps/web/src/app/api/upload-file/route.ts
@@ -1,12 +1,18 @@
 import { uploadImageToFirebase } from '@bypass/trpc/appRouter';
 import { type NextRequest, NextResponse } from 'next/server';
 
-import { authorizeUser } from '@app/helpers/authorizeUser';
+import { authorizeUser, toAuthErrorResponse } from '@app/helpers/authorizeUser';
 
 import { validateAndProccessFile } from './utils';
 
 export async function POST(request: NextRequest) {
-  const user = await authorizeUser(request);
+  let user;
+  try {
+    user = await authorizeUser(request);
+  } catch (error) {
+    // 401/403 instead of the 500 a bare thrown Error produced
+    return toAuthErrorResponse(error);
+  }
 
   const formData = await request.formData();
   const file = formData.get('file');

--- a/apps/web/src/app/helpers/authorizeUser.ts
+++ b/apps/web/src/app/helpers/authorizeUser.ts
@@ -4,43 +4,35 @@ import {
   getFirebaseUser,
   verifyAuthToken,
 } from '@bypass/trpc/appRouter';
-import { type NextRequest, NextResponse } from 'next/server';
+import { type NextRequest } from 'next/server';
 
-export class UnauthorizedError extends Error {
-  constructor(
-    readonly status: 401 | 403,
-    message: string
-  ) {
-    super(message);
-    this.name = 'UnauthorizedError';
-  }
-}
+type FirebaseUser = Awaited<ReturnType<typeof getFirebaseUser>>;
+
+type AuthorizeUserResult =
+  | { ok: true; user: FirebaseUser }
+  | { ok: false; status: 401 | 403; message: string };
 
 /** Applies the same rules as the tRPC middleware. */
-export const authorizeUser = async (request: NextRequest) => {
+export const authorizeUser = async (
+  request: NextRequest
+): Promise<AuthorizeUserResult> => {
   const idToken = getAuthBearer(request);
   if (!idToken) {
-    throw new UnauthorizedError(401, 'Authentication token not found');
+    return {
+      ok: false,
+      status: 401,
+      message: 'Authentication token not found',
+    };
   }
 
-  let user;
+  let user: FirebaseUser;
   try {
     const { uid } = await verifyAuthToken(idToken, true);
     user = await getFirebaseUser(uid);
   } catch {
-    throw new UnauthorizedError(401, 'Unauthorized user');
+    return { ok: false, status: 401, message: 'Unauthorized user' };
   }
 
   const result = checkUserAuthorized(user);
-  if (!result.ok) {
-    throw new UnauthorizedError(result.status, result.message);
-  }
-  return user;
-};
-
-export const toAuthErrorResponse = (error: unknown) => {
-  if (error instanceof UnauthorizedError) {
-    return new NextResponse(error.message, { status: error.status });
-  }
-  throw error;
+  return result.ok ? { ok: true, user } : result;
 };

--- a/apps/web/src/app/helpers/authorizeUser.ts
+++ b/apps/web/src/app/helpers/authorizeUser.ts
@@ -1,16 +1,51 @@
-import { getFirebaseUser, verifyAuthToken } from '@bypass/trpc/appRouter';
-import { type NextRequest } from 'next/server';
+import {
+  checkUserAuthorized,
+  getAuthBearer,
+  getFirebaseUser,
+  verifyAuthToken,
+} from '@bypass/trpc/appRouter';
+import { type NextRequest, NextResponse } from 'next/server';
 
-export const authorizeUser = async (request: NextRequest) => {
-  const bearerToken = request.headers.get('Authorization');
-  const idToken = bearerToken?.split('Bearer ')?.[1];
-  if (!idToken) {
-    throw new Error('Unauthorized user');
+export class UnauthorizedError extends Error {
+  constructor(
+    readonly status: 401 | 403,
+    message: string
+  ) {
+    super(message);
+    this.name = 'UnauthorizedError';
   }
+}
+
+/**
+ * Applies the same rules as the tRPC middleware. Previously this only verified
+ * the token, so a disabled or email-unverified account could still reach the
+ * upload route that every tRPC procedure rejects.
+ */
+export const authorizeUser = async (request: NextRequest) => {
+  const idToken = getAuthBearer(request);
+  if (!idToken) {
+    throw new UnauthorizedError(401, 'Authentication token not found');
+  }
+
+  let user;
   try {
     const { uid } = await verifyAuthToken(idToken, true);
-    return await getFirebaseUser(uid);
+    user = await getFirebaseUser(uid);
   } catch {
-    throw new Error('Unauthorized user');
+    throw new UnauthorizedError(401, 'Unauthorized user');
   }
+
+  const result = checkUserAuthorized(user);
+  if (!result.ok) {
+    throw new UnauthorizedError(result.status, result.message);
+  }
+  return user;
+};
+
+/** Maps an UnauthorizedError to a response; rethrows anything else. */
+export const toAuthErrorResponse = (error: unknown) => {
+  if (error instanceof UnauthorizedError) {
+    return new NextResponse(error.message, { status: error.status });
+  }
+  throw error;
 };

--- a/apps/web/src/app/helpers/authorizeUser.ts
+++ b/apps/web/src/app/helpers/authorizeUser.ts
@@ -16,11 +16,7 @@ export class UnauthorizedError extends Error {
   }
 }
 
-/**
- * Applies the same rules as the tRPC middleware. Previously this only verified
- * the token, so a disabled or email-unverified account could still reach the
- * upload route that every tRPC procedure rejects.
- */
+/** Applies the same rules as the tRPC middleware. */
 export const authorizeUser = async (request: NextRequest) => {
   const idToken = getAuthBearer(request);
   if (!idToken) {
@@ -42,7 +38,6 @@ export const authorizeUser = async (request: NextRequest) => {
   return user;
 };
 
-/** Maps an UnauthorizedError to a response; rethrows anything else. */
 export const toAuthErrorResponse = (error: unknown) => {
   if (error instanceof UnauthorizedError) {
     return new NextResponse(error.message, { status: error.status });

--- a/apps/web/src/app/helpers/verifyInternalToken.ts
+++ b/apps/web/src/app/helpers/verifyInternalToken.ts
@@ -1,12 +1,10 @@
+import { getAuthBearer } from '@bypass/trpc/appRouter';
 import { type NextRequest } from 'next/server';
 
 import { serverEnv } from '@app/constants/env/server';
 
 export const verifyInternalToken = (req: NextRequest) => {
-  const bearerToken = req.headers.get('Authorization');
-  const internalToken = bearerToken?.split('Bearer ')?.[1];
-
-  if (internalToken !== serverEnv.FIREBASE_CRON_JOB_API_KEY) {
+  if (getAuthBearer(req) !== serverEnv.FIREBASE_CRON_JOB_API_KEY) {
     throw new Error('Forbidden invocation');
   }
 };

--- a/packages/shared/src/components/Bookmarks/components/Favicon.tsx
+++ b/packages/shared/src/components/Bookmarks/components/Favicon.tsx
@@ -12,16 +12,34 @@ interface Props {
   ref?: React.Ref<HTMLDivElement>;
 }
 
+/**
+ * Bounded LRU. Object URLs are never garbage collected on their own, so an
+ * uncapped map pinned one decoded blob per favicon ever rendered - unbounded in
+ * the long-lived web bookmark panel. Evicted entries are revoked.
+ */
+const MAX_CACHED_FAVICONS = 200;
 const urlMap = new Map<string, string>();
 
 const getBlobUrl = async (proxyUrl: string) => {
-  const blobStr = urlMap.get(proxyUrl);
-  if (blobStr) {
-    return blobStr;
+  const cached = urlMap.get(proxyUrl);
+  if (cached) {
+    // Refresh recency
+    urlMap.delete(proxyUrl);
+    urlMap.set(proxyUrl, cached);
+    return cached;
   }
 
   const blobUrl = await getBlobUrlFromCache(ECacheBucketKeys.favicon, proxyUrl);
   urlMap.set(proxyUrl, blobUrl);
+
+  if (urlMap.size > MAX_CACHED_FAVICONS) {
+    const [oldestKey, oldestUrl] = urlMap.entries().next().value!;
+    urlMap.delete(oldestKey);
+    if (oldestUrl) {
+      URL.revokeObjectURL(oldestUrl);
+    }
+  }
+
   return blobUrl;
 };
 

--- a/packages/shared/src/components/Bookmarks/components/Favicon.tsx
+++ b/packages/shared/src/components/Bookmarks/components/Favicon.tsx
@@ -12,18 +12,13 @@ interface Props {
   ref?: React.Ref<HTMLDivElement>;
 }
 
-/**
- * Bounded LRU. Object URLs are never garbage collected on their own, so an
- * uncapped map pinned one decoded blob per favicon ever rendered - unbounded in
- * the long-lived web bookmark panel. Evicted entries are revoked.
- */
+// Bounded LRU: object urls are never collected on their own
 const MAX_CACHED_FAVICONS = 200;
 const urlMap = new Map<string, string>();
 
 const getBlobUrl = async (proxyUrl: string) => {
   const cached = urlMap.get(proxyUrl);
   if (cached) {
-    // Refresh recency
     urlMap.delete(proxyUrl);
     urlMap.set(proxyUrl, cached);
     return cached;

--- a/packages/shared/src/components/Bookmarks/components/Favicon.tsx
+++ b/packages/shared/src/components/Bookmarks/components/Favicon.tsx
@@ -12,29 +12,16 @@ interface Props {
   ref?: React.Ref<HTMLDivElement>;
 }
 
-// Bounded LRU: object urls are never collected on their own
-const MAX_CACHED_FAVICONS = 200;
 const urlMap = new Map<string, string>();
 
 const getBlobUrl = async (proxyUrl: string) => {
-  const cached = urlMap.get(proxyUrl);
-  if (cached) {
-    urlMap.delete(proxyUrl);
-    urlMap.set(proxyUrl, cached);
-    return cached;
+  const blobStr = urlMap.get(proxyUrl);
+  if (blobStr) {
+    return blobStr;
   }
 
   const blobUrl = await getBlobUrlFromCache(ECacheBucketKeys.favicon, proxyUrl);
   urlMap.set(proxyUrl, blobUrl);
-
-  if (urlMap.size > MAX_CACHED_FAVICONS) {
-    const [oldestKey, oldestUrl] = urlMap.entries().next().value!;
-    urlMap.delete(oldestKey);
-    if (oldestUrl) {
-      URL.revokeObjectURL(oldestUrl);
-    }
-  }
-
   return blobUrl;
 };
 

--- a/packages/shared/src/schema/websitesSchema.ts
+++ b/packages/shared/src/schema/websitesSchema.ts
@@ -1,11 +1,6 @@
 import { z } from 'zod/mini';
 
-/**
- * Optional because a user who has not synced yet legitimately has no websites
- * record. Making them required forced a `{} as unknown as IWebsites` cast at
- * the storage fallback, which turned "not synced" into `url.includes(undefined)`
- * at the consumers.
- */
+// Optional: an unsynced user legitimately has no websites record
 export const WebsitesSchema = z.object({
   FORUM_1: z.optional(z.string()),
   FORUM_2: z.optional(z.string()),

--- a/packages/shared/src/schema/websitesSchema.ts
+++ b/packages/shared/src/schema/websitesSchema.ts
@@ -1,8 +1,14 @@
 import { z } from 'zod/mini';
 
+/**
+ * Optional because a user who has not synced yet legitimately has no websites
+ * record. Making them required forced a `{} as unknown as IWebsites` cast at
+ * the storage fallback, which turned "not synced" into `url.includes(undefined)`
+ * at the consumers.
+ */
 export const WebsitesSchema = z.object({
-  FORUM_1: z.string(),
-  FORUM_2: z.string(),
-  FORUM_3: z.string(),
-  FORUM_4: z.string(),
+  FORUM_1: z.optional(z.string()),
+  FORUM_2: z.optional(z.string()),
+  FORUM_3: z.optional(z.string()),
+  FORUM_4: z.optional(z.string()),
 });

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -12,14 +12,18 @@ export const sleep = async (ms: number) =>
     setTimeout(resolve, ms);
   });
 
-// Transform every value of a record, preserving its keys
-export const mapValues = <K extends string, V>(
-  record: Record<K, V>,
-  transform: (value: V) => V
-): Record<K, V> =>
+// Transform every value of a record, preserving its keys. Generic over the
+// whole object rather than Record<K, V> so records with optional keys work too.
+export const mapValues = <T extends object>(
+  record: T,
+  transform: (value: T[keyof T]) => T[keyof T]
+): T =>
   Object.fromEntries(
-    Object.entries(record).map(([key, value]) => [key, transform(value as V)])
-  ) as Record<K, V>;
+    Object.entries(record).map(([key, value]) => [
+      key,
+      transform(value as T[keyof T]),
+    ])
+  ) as T;
 
 // Rebuild a keyed record, keeping only entries for which `shouldKeep` returns true
 export const filterRecord = <T>(

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -12,8 +12,7 @@ export const sleep = async (ms: number) =>
     setTimeout(resolve, ms);
   });
 
-// Transform every value of a record, preserving its keys. Generic over the
-// whole object rather than Record<K, V> so records with optional keys work too.
+// Transform every value of a record, preserving its keys
 export const mapValues = <T extends object>(
   record: T,
   transform: (value: T[keyof T]) => T[keyof T]

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -12,18 +12,6 @@ export const sleep = async (ms: number) =>
     setTimeout(resolve, ms);
   });
 
-// Transform every value of a record, preserving its keys
-export const mapValues = <T extends object>(
-  record: T,
-  transform: (value: T[keyof T]) => T[keyof T]
-): T =>
-  Object.fromEntries(
-    Object.entries(record).map(([key, value]) => [
-      key,
-      transform(value as T[keyof T]),
-    ])
-  ) as T;
-
 // Rebuild a keyed record, keeping only entries for which `shouldKeep` returns true
 export const filterRecord = <T>(
   record: Record<string, T>,

--- a/packages/trpc/src/appRouterIndex.ts
+++ b/packages/trpc/src/appRouterIndex.ts
@@ -1,1 +1,3 @@
 export * from './services/firebaseAdminService';
+export { checkUserAuthorized } from './utils/authorization';
+export { getAuthBearer } from './utils/headers';

--- a/packages/trpc/src/index.ts
+++ b/packages/trpc/src/index.ts
@@ -1,4 +1,6 @@
 export { createTRPCContext } from './trpc';
 export * from './routers';
+export { checkUserAuthorized } from './utils/authorization';
+export { getAuthBearer } from './utils/headers';
 
 export { cleanupStorage } from './services/storageCleanupService';

--- a/packages/trpc/src/middlewares/verifyAuthentication.ts
+++ b/packages/trpc/src/middlewares/verifyAuthentication.ts
@@ -5,9 +5,8 @@ import { checkUserAuthorized } from '../utils/authorization';
 
 const verifyAuthMiddleware = t.middleware(async (opts) => {
   const { ctx } = opts;
-  const { user } = ctx;
 
-  const result = checkUserAuthorized(user);
+  const result = checkUserAuthorized(ctx.user);
   if (!result.ok) {
     throw new TRPCError({
       code: result.status === 401 ? 'UNAUTHORIZED' : 'FORBIDDEN',
@@ -16,7 +15,7 @@ const verifyAuthMiddleware = t.middleware(async (opts) => {
   }
 
   return opts.next({
-    ctx: { ...ctx, user: user! }, // For type safety in protected procedures
+    ctx: { ...ctx, user: result.user }, // For type safety in protected procedures
   });
 });
 

--- a/packages/trpc/src/middlewares/verifyAuthentication.ts
+++ b/packages/trpc/src/middlewares/verifyAuthentication.ts
@@ -1,31 +1,22 @@
 import { TRPCError } from '@trpc/server';
 
 import { t } from '../trpc';
+import { checkUserAuthorized } from '../utils/authorization';
 
 const verifyAuthMiddleware = t.middleware(async (opts) => {
   const { ctx } = opts;
   const { user } = ctx;
-  if (!user) {
+
+  const result = checkUserAuthorized(user);
+  if (!result.ok) {
     throw new TRPCError({
-      code: 'UNAUTHORIZED',
-      message: 'Authentication token not found',
-    });
-  }
-  if (user.disabled) {
-    throw new TRPCError({
-      code: 'FORBIDDEN',
-      message: 'User is disabled',
-    });
-  }
-  if (!user.emailVerified) {
-    throw new TRPCError({
-      code: 'FORBIDDEN',
-      message: 'User email is unverified',
+      code: result.status === 401 ? 'UNAUTHORIZED' : 'FORBIDDEN',
+      message: result.message,
     });
   }
 
   return opts.next({
-    ctx: { ...ctx, user }, // For type safety in protected procedures
+    ctx: { ...ctx, user: user! }, // For type safety in protected procedures
   });
 });
 

--- a/packages/trpc/src/services/firebase/realtimeDBService.ts
+++ b/packages/trpc/src/services/firebase/realtimeDBService.ts
@@ -1,8 +1,10 @@
 import {
   type IBookmarksObj,
+  type ILastVisited,
   type IPersons,
   type IRedirection,
   type IRedirections,
+  type IWebsites,
 } from '@bypass/shared';
 
 import { type IUser } from '../../@types/trpc';
@@ -13,11 +15,24 @@ import {
   upsertToFirebase,
 } from '../firebaseAdminService';
 
+/**
+ * Every getter supplies its own empty value, matching what its output schema
+ * accepts. zod/mini: z.object rejects {}, z.array rejects {}, and z.record
+ * accepts {} but rejects null - so none of these may be omitted.
+ */
+const EMPTY_BOOKMARKS: IBookmarksObj = {
+  folderList: {},
+  urlList: {},
+  folders: {},
+};
+
 export const getBookmarks = async (user: IUser) => {
-  return getFromFirebase({
-    ref: EFirebaseDBRef.bookmarks,
-    uid: user.uid,
-  });
+  return (
+    (await getFromFirebase<IBookmarksObj>({
+      ref: EFirebaseDBRef.bookmarks,
+      uid: user.uid,
+    })) ?? EMPTY_BOOKMARKS
+  );
 };
 const saveBookmarks = async (bookmarks: IBookmarksObj, user: IUser) => {
   return saveToFirebase({
@@ -28,10 +43,12 @@ const saveBookmarks = async (bookmarks: IBookmarksObj, user: IUser) => {
 };
 
 export const getPersons = async (user: IUser) => {
-  return getFromFirebase({
-    ref: EFirebaseDBRef.persons,
-    uid: user.uid,
-  });
+  return (
+    (await getFromFirebase<IPersons>({
+      ref: EFirebaseDBRef.persons,
+      uid: user.uid,
+    })) ?? {}
+  );
 };
 const savePersons = async (persons: IPersons, user: IUser) => {
   return saveToFirebase({
@@ -54,17 +71,21 @@ export const saveBookmarksAndPersons = async (
 };
 
 export const getWebsites = async (user: IUser) => {
-  return getFromFirebase({
-    ref: EFirebaseDBRef.websites,
-    uid: user.uid,
-  });
+  return (
+    (await getFromFirebase<IWebsites>({
+      ref: EFirebaseDBRef.websites,
+      uid: user.uid,
+    })) ?? {}
+  );
 };
 
 export const getLastVisited = async (user: IUser) => {
-  return getFromFirebase({
-    ref: EFirebaseDBRef.lastVisited,
-    uid: user.uid,
-  });
+  return (
+    (await getFromFirebase<ILastVisited>({
+      ref: EFirebaseDBRef.lastVisited,
+      uid: user.uid,
+    })) ?? {}
+  );
 };
 
 export const upsertLastVisited = async (hash: string, user: IUser) => {
@@ -81,10 +102,12 @@ export const upsertLastVisited = async (hash: string, user: IUser) => {
 };
 
 export const getRedirections = async (user: IUser) => {
-  return getFromFirebase({
-    ref: EFirebaseDBRef.redirections,
-    uid: user.uid,
-  });
+  return (
+    (await getFromFirebase<IRedirections>({
+      ref: EFirebaseDBRef.redirections,
+      uid: user.uid,
+    })) ?? []
+  );
 };
 export const saveRedirections = async (
   redirections: IRedirections,

--- a/packages/trpc/src/services/firebase/realtimeDBService.ts
+++ b/packages/trpc/src/services/firebase/realtimeDBService.ts
@@ -15,11 +15,7 @@ import {
   upsertToFirebase,
 } from '../firebaseAdminService';
 
-/**
- * Every getter supplies its own empty value, matching what its output schema
- * accepts. zod/mini: z.object rejects {}, z.array rejects {}, and z.record
- * accepts {} but rejects null - so none of these may be omitted.
- */
+// zod/mini: z.object and z.array reject {}, z.record accepts {} but rejects null
 const EMPTY_BOOKMARKS: IBookmarksObj = {
   folderList: {},
   urlList: {},
@@ -27,12 +23,11 @@ const EMPTY_BOOKMARKS: IBookmarksObj = {
 };
 
 export const getBookmarks = async (user: IUser) => {
-  return (
-    (await getFromFirebase<IBookmarksObj>({
-      ref: EFirebaseDBRef.bookmarks,
-      uid: user.uid,
-    })) ?? EMPTY_BOOKMARKS
-  );
+  const bookmarks = await getFromFirebase<IBookmarksObj>({
+    ref: EFirebaseDBRef.bookmarks,
+    uid: user.uid,
+  });
+  return bookmarks ?? EMPTY_BOOKMARKS;
 };
 const saveBookmarks = async (bookmarks: IBookmarksObj, user: IUser) => {
   return saveToFirebase({
@@ -43,12 +38,11 @@ const saveBookmarks = async (bookmarks: IBookmarksObj, user: IUser) => {
 };
 
 export const getPersons = async (user: IUser) => {
-  return (
-    (await getFromFirebase<IPersons>({
-      ref: EFirebaseDBRef.persons,
-      uid: user.uid,
-    })) ?? {}
-  );
+  const persons = await getFromFirebase<IPersons>({
+    ref: EFirebaseDBRef.persons,
+    uid: user.uid,
+  });
+  return persons ?? {};
 };
 const savePersons = async (persons: IPersons, user: IUser) => {
   return saveToFirebase({
@@ -71,21 +65,19 @@ export const saveBookmarksAndPersons = async (
 };
 
 export const getWebsites = async (user: IUser) => {
-  return (
-    (await getFromFirebase<IWebsites>({
-      ref: EFirebaseDBRef.websites,
-      uid: user.uid,
-    })) ?? {}
-  );
+  const websites = await getFromFirebase<IWebsites>({
+    ref: EFirebaseDBRef.websites,
+    uid: user.uid,
+  });
+  return websites ?? {};
 };
 
 export const getLastVisited = async (user: IUser) => {
-  return (
-    (await getFromFirebase<ILastVisited>({
-      ref: EFirebaseDBRef.lastVisited,
-      uid: user.uid,
-    })) ?? {}
-  );
+  const lastVisited = await getFromFirebase<ILastVisited>({
+    ref: EFirebaseDBRef.lastVisited,
+    uid: user.uid,
+  });
+  return lastVisited ?? {};
 };
 
 export const upsertLastVisited = async (hash: string, user: IUser) => {
@@ -102,12 +94,11 @@ export const upsertLastVisited = async (hash: string, user: IUser) => {
 };
 
 export const getRedirections = async (user: IUser) => {
-  return (
-    (await getFromFirebase<IRedirections>({
-      ref: EFirebaseDBRef.redirections,
-      uid: user.uid,
-    })) ?? []
-  );
+  const redirections = await getFromFirebase<IRedirections>({
+    ref: EFirebaseDBRef.redirections,
+    uid: user.uid,
+  });
+  return redirections ?? [];
 };
 export const saveRedirections = async (
   redirections: IRedirections,

--- a/packages/trpc/src/services/firebaseAdminService.ts
+++ b/packages/trpc/src/services/firebaseAdminService.ts
@@ -58,12 +58,7 @@ const storage = getStorage(firebaseApp);
 /**
  * REALTIME DATABASE
  */
-/**
- * Returns null when the path has no data. Callers supply their own typed empty
- * value: a blanket `?? {}` here was wrong for refs whose schema is an object
- * with required keys or an array, so a first-ever sign-in failed output
- * validation on bookmarks, websites and redirections.
- */
+/** Returns null when empty; callers supply their own schema-appropriate default. */
 export const getFromFirebase = async <T = any>({
   ref,
   uid,

--- a/packages/trpc/src/services/firebaseAdminService.ts
+++ b/packages/trpc/src/services/firebaseAdminService.ts
@@ -58,13 +58,19 @@ const storage = getStorage(firebaseApp);
 /**
  * REALTIME DATABASE
  */
+/**
+ * Returns null when the path has no data. Callers supply their own typed empty
+ * value: a blanket `?? {}` here was wrong for refs whose schema is an object
+ * with required keys or an array, so a first-ever sign-in failed output
+ * validation on bookmarks, websites and redirections.
+ */
 export const getFromFirebase = async <T = any>({
   ref,
   uid,
-}: Omit<Firebase, 'data'>): Promise<T> => {
+}: Omit<Firebase, 'data'>): Promise<T | null> => {
   const dbPath = getFullDbPath(ref, uid);
   const snapshot = await database.ref(dbPath).once('value');
-  return snapshot.val() ?? {};
+  return snapshot.val() ?? null;
 };
 
 /**

--- a/packages/trpc/src/services/storageCleanupService.ts
+++ b/packages/trpc/src/services/storageCleanupService.ts
@@ -18,13 +18,11 @@ async function getPersonStorageImageId(uid: string): Promise<string[]> {
 
 export const cleanupStorage = async (uid: string): Promise<void> => {
   const imageUids = await getPersonStorageImageId(uid);
-  // getFromFirebase returns null for a user with no persons record; indexing
-  // that below would throw and 500 the cleanup cron
-  const personRecordUids =
-    (await getFromFirebase<IPersons>({
-      ref: EFirebaseDBRef.persons,
-      uid,
-    })) ?? {};
+  const persons = await getFromFirebase<IPersons>({
+    ref: EFirebaseDBRef.persons,
+    uid,
+  });
+  const personRecordUids = persons ?? {};
   const orphanedImages = imageUids.filter(
     (imageUid) => !personRecordUids[imageUid]
   );

--- a/packages/trpc/src/services/storageCleanupService.ts
+++ b/packages/trpc/src/services/storageCleanupService.ts
@@ -18,10 +18,13 @@ async function getPersonStorageImageId(uid: string): Promise<string[]> {
 
 export const cleanupStorage = async (uid: string): Promise<void> => {
   const imageUids = await getPersonStorageImageId(uid);
-  const personRecordUids = await getFromFirebase<IPersons>({
-    ref: EFirebaseDBRef.persons,
-    uid,
-  });
+  // getFromFirebase returns null for a user with no persons record; indexing
+  // that below would throw and 500 the cleanup cron
+  const personRecordUids =
+    (await getFromFirebase<IPersons>({
+      ref: EFirebaseDBRef.persons,
+      uid,
+    })) ?? {};
   const orphanedImages = imageUids.filter(
     (imageUid) => !personRecordUids[imageUid]
   );

--- a/packages/trpc/src/utils/authorization.ts
+++ b/packages/trpc/src/utils/authorization.ts
@@ -1,0 +1,31 @@
+import { type IUser } from '../@types/trpc';
+
+export type AuthorizationResult =
+  | { ok: true }
+  | { ok: false; status: 401 | 403; message: string };
+
+/**
+ * The authorization rules, shared so REST routes cannot drift behind the tRPC
+ * middleware. Returns a result rather than throwing: tRPC needs a TRPCError and
+ * the Next route needs a NextResponse, so each caller maps this to its own
+ * error type. Throwing a shared error here would surface as a 500 from tRPC
+ * context creation.
+ */
+export const checkUserAuthorized = (
+  user: IUser | null
+): AuthorizationResult => {
+  if (!user) {
+    return {
+      ok: false,
+      status: 401,
+      message: 'Authentication token not found',
+    };
+  }
+  if (user.disabled) {
+    return { ok: false, status: 403, message: 'User is disabled' };
+  }
+  if (!user.emailVerified) {
+    return { ok: false, status: 403, message: 'User email is unverified' };
+  }
+  return { ok: true };
+};

--- a/packages/trpc/src/utils/authorization.ts
+++ b/packages/trpc/src/utils/authorization.ts
@@ -5,11 +5,8 @@ export type AuthorizationResult =
   | { ok: false; status: 401 | 403; message: string };
 
 /**
- * The authorization rules, shared so REST routes cannot drift behind the tRPC
- * middleware. Returns a result rather than throwing: tRPC needs a TRPCError and
- * the Next route needs a NextResponse, so each caller maps this to its own
- * error type. Throwing a shared error here would surface as a 500 from tRPC
- * context creation.
+ * Shared so REST routes cannot drift behind the tRPC middleware. Returns a
+ * result rather than throwing, since each caller needs its own error type.
  */
 export const checkUserAuthorized = (
   user: IUser | null

--- a/packages/trpc/src/utils/authorization.ts
+++ b/packages/trpc/src/utils/authorization.ts
@@ -1,7 +1,7 @@
 import { type IUser } from '../@types/trpc';
 
 export type AuthorizationResult =
-  | { ok: true }
+  | { ok: true; user: IUser }
   | { ok: false; status: 401 | 403; message: string };
 
 /**
@@ -24,5 +24,6 @@ export const checkUserAuthorized = (
   if (!user.emailVerified) {
     return { ok: false, status: 403, message: 'User email is unverified' };
   }
-  return { ok: true };
+  // Returning the user lets callers narrow without a non-null assertion
+  return { ok: true, user };
 };


### PR DESCRIPTION
PR 6/6 (final) of a stacked cleanup. **Base: `cleanup/e-dynamic-context` (#4126).**

Four real defects found incidentally by the quality passes.

### 1. Relax `WebsitesSchema` *(must precede #2)*
Four required fields forced `{} as unknown as IWebsites` at the storage fallback — the only such cast in the repo. With it in play, `forumPageLinks` did `url.includes(undefined)`, coercing to a literal `"undefined"` search. Fields are now optional; three consumers handle it, including the `getDecodedWebsites` write path.

### 2. Per-ref empty values instead of a blanket `?? {}`
`getFromFirebase` returned `{}` for every ref, but the schemas differ. Verified against the installed `zod/mini`:

| | `{}` | `null` |
|---|---|---|
| `z.object` (bookmarks, websites) | rejects | rejects |
| `z.array` (redirections) | rejects | rejects |
| `z.record` (persons, lastVisited) | accepts | **rejects** |

So `{}` failed output validation for three procedures, and since `syncFirebaseToStorage` fires them in one `Promise.all`, **a first-ever sign-in failed wholesale**. Now returns `T | null` with each getter supplying its own empty value — persons/lastVisited included deliberately, since they reject `null`.

### 3. Background reload listener: wrong tab, and it leaked
A nested `onCompleted` listener was registered per reload and wasn't tab-filtered, so the first completion from any tab consumed it — `details.url` was the reloading tab's but `tabId` came from the inner event. It also never unregistered if the tab closed first.

Now two listeners registered once plus a tracked set. Review rounds caught two further holes in my replacement, both fixed:
- subframes could consume the tab's entry → guarded on `frameId === 0`
- an aborted reload left a stale marker the next unrelated completion would consume → cleared on `onErrorOccurred`, and a non-reload main-frame commit now supersedes any pending entry

The block is kept, not deleted — `background-navigation.spec.ts` asserts the webNavigation reload path.

### 4. Close the `/api/upload-file` auth gap
`authorizeUser` only verified the token, **skipping the `disabled` and `emailVerified` checks every tRPC procedure enforces**. The rules move to a shared `checkUserAuthorized`. Both it and `authorizeUser` return a discriminated result rather than throwing, since each platform needs its own error type and the route can map it directly.

Deliberately **not** wired into `createTRPCContext` — a throw there surfaces as `INTERNAL_SERVER_ERROR`, turning today's 401s into 500s.

### Dropped after review
A bounded favicon-URL LRU was originally included here and has been **removed**. The map it capped is keyed by favicon url, so its ceiling is the user's bookmark count — a few MB at worst, not a true leak. Against that, eviction could revoke an object URL still bound to a rendered `<img>`, and recency only refreshed on a cache hit, so a visible favicon could be evicted anyway. If it ever matters, the fix is lifecycle-tied revocation, not a global cap with an arbitrary number.

### Verification
`typecheck:all` / `lint` / `format:check` clean. **91/91 e2e.** Live check:
```
POST /api/upload-file  (no token)  → 401   (was 500)
POST /api/upload-file  (bad token) → 401   (was 500)
```

### Two paths I could not exercise — please confirm before merging
1. **#2's empty-state path** needs a Firebase user with no `/data/<uid>` subtree. The typed empties are strictly safer than `?? {}` regardless and the zod behaviour above is measured, but the first-sign-in flow was not run.
2. **#4's 403 branch** needs a disabled or unverified account. The 401 branch is verified above.

<!-- greptile_comment -->

 

<details><summary><h3>Greptile Summary</h3></summary>

The PR consolidates authorization checks, supplies schema-appropriate Firebase empty values, permits unsynced website configuration, and replaces per-reload navigation listeners with persistent lifecycle-managed listeners.
- Enforces disabled-user and email-verification checks for file uploads through shared authorization logic.
- Returns typed empty values for absent Firebase records.
- Safely handles optional website configuration during matching and decoding.
- Restricts reload bookkeeping to main-frame events and clears pending state on errors, superseding navigation, and tab closure.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (9): Last reviewed commit: ["refactor: return the user from checkUser..."](https://github.com/amitsingh-007/bypass-links/commit/7f7bf4fc27735abd411c47b7b81671b8e4c490c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49468804)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Extension background service worker](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/extension-background.md)
- Knowledge Base — [Web App (apps/web)](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/web-app.md)
- Knowledge Base — [packages/trpc: shared tRPC API layer](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/trpc-package.md)
- Knowledge Base — [Shared package (`packages/shared`)](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/shared-package.md)
</details>

<!-- /greptile_comment -->