### PR TITLE
docs: note react compiler usage in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ Playwright tests use setup/teardown projects for both web and extension flows:
 ## Key Technologies
 
 - **Frontend**: React, Next.js (web)
+- **React Compiler**: Enabled in both apps (`reactCompiler: true` in web, `reactCompilerPreset()` in extension); enforced by the `react/react-compiler` oxlint rule — avoid manual `useMemo`/`useCallback` unless needed
 - **UI**: shadcn/ui (Base UI) via `packages/ui` and `@bypass/ui`
 - **Styling**: Tailwind CSS v4
 - **Icons**: Hugeicons (`@hugeicons/core-free-icons`, `@hugeicons/react`)


### PR DESCRIPTION
Adds a Key Technologies bullet to AGENTS.md documenting that React Compiler is enabled in both apps (`reactCompiler: true` in web, `reactCompilerPreset()` in extension), enforced by the `react/react-compiler` oxlint rule, with a note to avoid manual `useMemo`/`useCallback` unless needed.

<!-- greptile_comment -->

 

<details><summary><h3>Greptile Summary</h3></summary>

Adds contributor guidance documenting React Compiler usage and lint enforcement across the web and extension apps.
- Notes the compiler configuration used by each app.
- Advises avoiding unnecessary manual `useMemo` and `useCallback`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only change appears safe to merge.

The documented compiler settings and lint rule match the repository configuration, and the memoization guidance retains an explicit exception for cases where manual memoization is needed.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: note react compiler usage in AGENT..."](https://github.com/amitsingh-007/bypass-links/commit/423f80240a7c48859ca2f6c998b7ce715b8e8053) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49479300)</sub>

<!-- /greptile_comment -->