### PR TITLE
ci: name extension artifacts by purpose and drop redundant re-upload

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Uploading Chrome extension
         uses: actions/upload-artifact@v7
         with:
-          name: chrome-extension-folder
+          name: extension-e2e
           path: ./apps/extension/.output/chrome-mv3
 
   Playwright:
@@ -97,7 +97,7 @@ jobs:
       - name: Download Chrome extension
         uses: actions/download-artifact@v8
         with:
-          name: chrome-extension-folder
+          name: extension-e2e
           path: ./apps/extension/.output/chrome-mv3/
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Uploading extensions
         uses: actions/upload-artifact@v7
         with:
-          name: extensions-folder
+          name: extension-release
           path: ./apps/extension/.output
           include-hidden-files: true
 
@@ -61,7 +61,7 @@ jobs:
       - name: Uploading e2e extension
         uses: actions/upload-artifact@v7
         with:
-          name: chrome-extension-folder
+          name: extension-e2e
           path: ./apps/extension/.output/chrome-mv3
 
   Playwright:
@@ -98,7 +98,7 @@ jobs:
       - name: Download extension
         uses: actions/download-artifact@v8
         with:
-          name: chrome-extension-folder
+          name: extension-e2e
           path: ./apps/extension/.output/chrome-mv3/
 
       - name: Install dependencies
@@ -170,19 +170,6 @@ jobs:
           env_url: ${{ steps.vercel-action.outputs.preview-url }}
           env: ${{ steps.deployment.outputs.env }}
 
-      - name: Download extensions
-        uses: actions/download-artifact@v8
-        with:
-          name: extensions-folder
-          path: ./apps/extension/.output
-
-      - name: Uploading extensions
-        uses: actions/upload-artifact@v7
-        with:
-          name: packaged-extensions
-          path: ./apps/extension/.output
-          include-hidden-files: true
-
   Create_Release:
     runs-on: ubuntu-latest
     needs: [Deploy]
@@ -192,10 +179,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Download packaged extensions
+      - name: Download extension
         uses: actions/download-artifact@v8
         with:
-          name: packaged-extensions
+          name: extension-release
           path: ./apps/extension/.output
 
       - name: Generate Release Tag


### PR DESCRIPTION
Closes #4080

## Why two artifacts?

The Deploy CI run showed `chrome-extension-folder` (290 KB) and `extensions-folder` (579 KB) and it wasn't obvious why. They hold **genuinely different builds**: the `Build` job builds the extension twice — once against the pulled `.env` (the zip attached to the GitHub release) and again after pointing `NEXT_PUBLIC_HOST_NAME` at the Vercel preview URL (the unpacked build Playwright loads, since e2e gates the prod deploy). Both builds write to the same `apps/extension/.output`, so the first has to be uploaded before the rebuild overwrites it.

So two artifacts are correct — the names just didn't say so. WXT emits exactly one zip (`browser: 'chrome'` ⇒ no sources zip), and releases have always carried a single asset.

## Changes

**`release.yml`**
- `extensions-folder` → `extension-release` — the prod-host build whose zip becomes the release asset
- `chrome-extension-folder` → `extension-e2e` — the preview-host unpacked build for Playwright
- Removed the `Deploy` job's `Download extensions` + `Uploading extensions` pair, which downloaded `extensions-folder` only to re-upload byte-identical content as `packaged-extensions`. `Create_Release` now takes `extension-release` straight from `Build` — one fewer artifact and one fewer upload/download round trip per run.

**`playwright.yml`**
- Same `chrome-extension-folder` → `extension-e2e` rename, so the preview-host build has one name across both workflows.

Paths, `include-hidden-files`, the `needs` graph, and the release glob (`./apps/extension/.output/chrome-*.zip`) are unchanged.

`build.yml`'s `chrome-extension-file` is deliberately left alone — `.github/webext.yml` pins that name for the bundle-size bot.

## Verification

- No references to the old names remain under `.github/`; every `download-artifact` name has a matching `upload-artifact` in the same workflow.
- Both files re-parse as valid YAML after the step deletion.
- Full confirmation is the next run on `main`: expect `extension-release` + `extension-e2e` + `playwright-report`, no `packaged-extensions`, and still exactly one `chrome-bypass-links-*.zip` on the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

 

<details><summary><h3>Greptile Summary</h3></summary>

The PR gives release and end-to-end extension artifacts purpose-specific names and removes a redundant artifact relay from the deployment job.

- Renames the Playwright extension artifact to `extension-e2e` in both workflows.
- Renames the production-host build artifact to `extension-release`.
- Makes `Create_Release` consume the Build artifact directly instead of a byte-identical re-upload.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with artifact producers and consumers consistently renamed and the release artifact remaining available through the existing job dependency chain.

The Build job uploads the complete release output before the dependent jobs run, and Create_Release downloads that same artifact to the unchanged path consumed by the release glob; no blocking or actionable failure remains.
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: name extension artifacts by purpose ..."](https://github.com/amitsingh-007/bypass-links/commit/cc4c4a11362030276aee972c9ec7feb47611f3e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49663245)</sub>

<!-- /greptile_comment -->