### PR TITLE
fix: centre extension panels when popup.html opens as a page

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bypass/extension",
-  "version": "25.2.0",
+  "version": "25.3.0",
   "private": true,
   "description": "Bypass links from various sites to required links, with added functionality of Bookmarks Manager, Tagging Panel.",
   "type": "module",

--- a/apps/extension/src/entrypoints/popup/components/Panel.tsx
+++ b/apps/extension/src/entrypoints/popup/components/Panel.tsx
@@ -1,0 +1,16 @@
+import { type PropsWithChildren } from 'react';
+
+import { MAX_PANEL_SIZE } from '@/constants';
+
+function Panel({ children }: PropsWithChildren) {
+  return (
+    <div
+      className="relative flex flex-col"
+      style={{ width: MAX_PANEL_SIZE.WIDTH, height: MAX_PANEL_SIZE.HEIGHT }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export default Panel;

--- a/apps/extension/src/entrypoints/popup/index.tsx
+++ b/apps/extension/src/entrypoints/popup/index.tsx
@@ -4,6 +4,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import './fonts.css';
+import './layout.css';
 import Global from './components/Global';
 import PopupRoutes from './components/PopupRoutes';
 import DynamicProvider from './provider/DynamicProvider';

--- a/apps/extension/src/entrypoints/popup/layout.css
+++ b/apps/extension/src/entrypoints/popup/layout.css
@@ -1,0 +1,5 @@
+/* Centres the panel when popup.html is opened as a tab; a no-op in the content-sized popup. */
+#root {
+  width: fit-content;
+  margin-inline: auto;
+}

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksPanel.tsx
@@ -13,6 +13,7 @@ import { use, useCallback, useEffect, useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 
 import { MAX_PANEL_SIZE } from '@/constants';
+import Panel from '@popup/components/Panel';
 
 import useBookmarkRouteStore from '../store/useBookmarkRouteStore';
 import useBookmarkStore from '../store/useBookmarkStore';
@@ -92,53 +93,48 @@ function BookmarksPanel({ folderId, operation, bmUrl }: BMPanelQueryParams) {
   const curBookmarksCount = filteredContextBookmarks.length;
 
   return (
-    <>
+    <Panel>
       <ScrollButton itemsSize={curBookmarksCount} onScroll={handleScroll} />
-      <div
-        className="flex flex-col"
-        style={{ width: MAX_PANEL_SIZE.WIDTH, height: MAX_PANEL_SIZE.HEIGHT }}
+      <BookmarksHeader folderId={folderId} onSearchChange={setSearchText} />
+      <BookmarkAddEditDialog
+        curFolderId={folderId}
+        handleScroll={handleScroll}
+      />
+      <BookmarkContextMenu
+        handleOpenSelectedBookmarks={handleOpenSelectedBookmarks}
       >
-        <BookmarksHeader folderId={folderId} onSearchChange={setSearchText} />
-        <BookmarkAddEditDialog
-          curFolderId={folderId}
-          handleScroll={handleScroll}
-        />
-        <BookmarkContextMenu
-          handleOpenSelectedBookmarks={handleOpenSelectedBookmarks}
+        <ScrollArea
+          viewportRef={scrollAreaRef}
+          className="w-full"
+          style={{ height: MAX_PANEL_SIZE.HEIGHT - HEADER_HEIGHT }}
         >
-          <ScrollArea
-            viewportRef={scrollAreaRef}
-            className="w-full"
-            style={{ height: MAX_PANEL_SIZE.HEIGHT - HEADER_HEIGHT }}
-          >
-            {filteredContextBookmarks.length > 0 ? (
-              <div
-                className="relative w-full"
-                style={{ height: virtualizer.getTotalSize() }}
-              >
-                {virtualizer.getVirtualItems().map((virtualRow) => (
-                  <div
-                    key={virtualRow.key}
-                    className="absolute top-0 left-0 w-full"
-                    style={{
-                      transform: `translateY(${virtualRow.start}px)`,
-                      height: virtualRow.size,
-                    }}
-                  >
-                    <VirtualRow
-                      bookmark={filteredContextBookmarks[virtualRow.index]}
-                      pos={virtualRow.index}
-                      isSelected={selectedBookmarks[virtualRow.index]}
-                      isCut={cutBookmarks[virtualRow.index]}
-                    />
-                  </div>
-                ))}
-              </div>
-            ) : null}
-          </ScrollArea>
-        </BookmarkContextMenu>
-      </div>
-    </>
+          {filteredContextBookmarks.length > 0 ? (
+            <div
+              className="relative w-full"
+              style={{ height: virtualizer.getTotalSize() }}
+            >
+              {virtualizer.getVirtualItems().map((virtualRow) => (
+                <div
+                  key={virtualRow.key}
+                  className="absolute top-0 left-0 w-full"
+                  style={{
+                    transform: `translateY(${virtualRow.start}px)`,
+                    height: virtualRow.size,
+                  }}
+                >
+                  <VirtualRow
+                    bookmark={filteredContextBookmarks[virtualRow.index]}
+                    pos={virtualRow.index}
+                    isSelected={selectedBookmarks[virtualRow.index]}
+                    isCut={cutBookmarks[virtualRow.index]}
+                  />
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </ScrollArea>
+      </BookmarkContextMenu>
+    </Panel>
   );
 }
 

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/PersonsPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/PersonsPanel.tsx
@@ -22,6 +22,7 @@ import { useLocation } from 'wouter';
 import { trpcApi } from '@/apis/trpcApi';
 import { MAX_PANEL_SIZE } from '@/constants';
 import { personsItem } from '@/storage/items';
+import Panel from '@popup/components/Panel';
 
 import { getPersonPos, setPersonsInStorage } from '../utils';
 import { updatePersonCacheAndImageUrls } from '../utils/sync';
@@ -117,13 +118,7 @@ function PersonsPanel() {
   const toggleOrderByRecency = () => setOrderByRecency((prev) => !prev);
 
   return (
-    <div
-      className="flex flex-col"
-      style={{
-        width: MAX_PANEL_SIZE.WIDTH,
-        height: MAX_PANEL_SIZE.HEIGHT,
-      }}
-    >
+    <Panel>
       <PersonHeader
         isFetching={isFetching}
         handleAddPerson={handleAddOrEditPerson}
@@ -170,7 +165,7 @@ function PersonsPanel() {
           />
         ) : null}
       </div>
-    </div>
+    </Panel>
   );
 }
 

--- a/apps/extension/src/entrypoints/popup/panels/ShortcutsPanel/components/ShortcutsPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/ShortcutsPanel/components/ShortcutsPanel.tsx
@@ -6,9 +6,9 @@ import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 
 import { trpcApi } from '@/apis/trpcApi';
-import { MAX_PANEL_SIZE } from '@/constants';
 import { redirectionsItem } from '@/storage/items';
 import { syncRedirectionsToStorage } from '@background/redirections';
+import Panel from '@popup/components/Panel';
 
 import { DEFAULT_RULE_ALIAS } from '../constants';
 import { getValidRules, isMatchingRule } from '../utils';
@@ -89,13 +89,7 @@ function ShortcutsPanel() {
   };
 
   return (
-    <div
-      className="flex flex-col"
-      style={{
-        width: MAX_PANEL_SIZE.WIDTH,
-        height: MAX_PANEL_SIZE.HEIGHT,
-      }}
-    >
+    <Panel>
       <Header onSearchChange={setSearchText}>
         <Button
           disabled={isFetching}
@@ -143,7 +137,7 @@ function ShortcutsPanel() {
           </div>
         )}
       </div>
-    </div>
+    </Panel>
   );
 }
 

--- a/packages/shared/src/components/ScrollButton.tsx
+++ b/packages/shared/src/components/ScrollButton.tsx
@@ -13,7 +13,10 @@ export function ScrollButton({ itemsSize, onScroll }: Props) {
   }
 
   return (
-    <ButtonGroup orientation="vertical" className="fixed right-3 bottom-3 z-10">
+    <ButtonGroup
+      orientation="vertical"
+      className="absolute right-3 bottom-3 z-10"
+    >
       <Button
         variant="secondary"
         size="sm"


### PR DESCRIPTION
#### Check if the Pull Request fulfils these requirements

- [x] Does the extension require a version change?

Closes #4131

<!-- greptile_comment -->

 

<details><summary><h3>Greptile Summary</h3></summary>

The PR centers fixed-size extension panels when `popup.html` is opened as a browser tab.

- Adds a shared 800×600 positioned panel wrapper for the Bookmarks, Persons, and Shortcuts routes.
- Shrink-wraps and horizontally centers the popup root.
- Changes shared scroll controls from viewport-fixed to container-absolute positioning.
- Bumps the extension version from 25.2.0 to 25.3.0.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete regressions identified.

The affected routes retain explicit dimensions, container-relative scroll controls remain visible in current callers, and portal or locally positioned UI elements are not disrupted by the new wrapper.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: centre extension panels when popup...."](https://github.com/amitsingh-007/bypass-links/commit/b7024bda5bbfdb86d59a258ec24f537b2caf39e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50056901)</sub>

**Context used:**

- Knowledge Base — [Extension Popup UI](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/extension-popup.md)
- Knowledge Base — [Shared package (`packages/shared`)](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/shared-package.md)

<!-- /greptile_comment -->