### PR TITLE
refactor: delete dead code and collapse trivial duplication (1/5)

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bypass/extension",
-  "version": "25.3.0",
+  "version": "25.4.0",
   "private": true,
   "description": "Bypass links from various sites to required links, with added functionality of Bookmarks Manager, Tagging Panel.",
   "type": "module",

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/utils/sync.ts
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/utils/sync.ts
@@ -48,7 +48,6 @@ const cachePersonImages = async (personImageUrls: PersonImageUrls) => {
 };
 
 export const cachePersonImagesInStorage = async () => {
-  await refreshPersonImageUrlsCache();
   const persons = await getAllDecodedPersons();
   const personImagesList = await Promise.all(
     persons.map(async (person) => resolveImageFromPerson(person.uid))

--- a/apps/extension/src/interfaces/firebase.ts
+++ b/apps/extension/src/interfaces/firebase.ts
@@ -3,7 +3,6 @@ export interface IAuthResponse {
   readonly email: string;
   readonly photoUrl?: string;
   readonly displayName?: string;
-  readonly expiresIn: number;
   readonly expiresAtMs: number;
   readonly idToken: string;
   readonly refreshToken: string;

--- a/apps/extension/src/store/firebase/api.ts
+++ b/apps/extension/src/store/firebase/api.ts
@@ -35,7 +35,7 @@ export const signInWithCredential = async (accessToken: string) => {
       photoUrl: res.photoUrl,
       displayName: res.displayName,
       idToken: res.idToken,
-      expiresAtMs: getExpiresAtMs(res.expiresIn),
+      expiresAtMs: getExpiresAtMs(Number(res.expiresIn)),
       refreshToken: res.refreshToken,
     }));
 };

--- a/apps/extension/src/store/firebase/api.ts
+++ b/apps/extension/src/store/firebase/api.ts
@@ -35,7 +35,6 @@ export const signInWithCredential = async (accessToken: string) => {
       photoUrl: res.photoUrl,
       displayName: res.displayName,
       idToken: res.idToken,
-      expiresIn: Number(res.expiresIn),
       expiresAtMs: getExpiresAtMs(res.expiresIn),
       refreshToken: res.refreshToken,
     }));

--- a/apps/extension/src/store/firebase/useFirebaseStore.ts
+++ b/apps/extension/src/store/firebase/useFirebaseStore.ts
@@ -85,8 +85,7 @@ const useFirebaseStore = create<State>()(
           );
           return null;
         }
-        // expiresIn is not part of IAuthResponse; spreads bypass excess-property
-        // checks, so drop it explicitly or it gets persisted into __fbOAuth
+        // Spreads bypass excess-property checks, so drop it or it lands in __fbOAuth
         const { expiresIn, ...refreshed } = refreshedTokenData;
         const newIdpAuth: IAuthResponse = {
           ...idpAuth,

--- a/apps/extension/src/store/firebase/useFirebaseStore.ts
+++ b/apps/extension/src/store/firebase/useFirebaseStore.ts
@@ -85,7 +85,6 @@ const useFirebaseStore = create<State>()(
           );
           return null;
         }
-        // Spreads bypass excess-property checks, so drop it or it lands in __fbOAuth
         const { expiresIn, ...refreshed } = refreshedTokenData;
         const newIdpAuth: IAuthResponse = {
           ...idpAuth,

--- a/apps/extension/src/store/firebase/useFirebaseStore.ts
+++ b/apps/extension/src/store/firebase/useFirebaseStore.ts
@@ -85,10 +85,13 @@ const useFirebaseStore = create<State>()(
           );
           return null;
         }
+        // expiresIn is not part of IAuthResponse; spreads bypass excess-property
+        // checks, so drop it explicitly or it gets persisted into __fbOAuth
+        const { expiresIn, ...refreshed } = refreshedTokenData;
         const newIdpAuth: IAuthResponse = {
           ...idpAuth,
-          ...refreshedTokenData,
-          expiresAtMs: getExpiresAtMs(refreshedTokenData.expiresIn),
+          ...refreshed,
+          expiresAtMs: getExpiresAtMs(expiresIn),
         };
         setIdpAuth(newIdpAuth);
         return newIdpAuth.idToken;

--- a/apps/extension/src/store/firebase/utils.ts
+++ b/apps/extension/src/store/firebase/utils.ts
@@ -1,3 +1,3 @@
-export const getExpiresAtMs = (expiresIn: any) => {
+export const getExpiresAtMs = (expiresIn: string | number) => {
   return Date.now() + Number(expiresIn) * 1000;
 };

--- a/apps/extension/src/store/firebase/utils.ts
+++ b/apps/extension/src/store/firebase/utils.ts
@@ -1,3 +1,3 @@
-export const getExpiresAtMs = (expiresIn: string | number) => {
-  return Date.now() + Number(expiresIn) * 1000;
+export const getExpiresAtMs = (expiresIn: number) => {
+  return Date.now() + expiresIn * 1000;
 };

--- a/apps/extension/tests/auth.setup.ts
+++ b/apps/extension/tests/auth.setup.ts
@@ -45,7 +45,7 @@ const signInWithEmailAndPassword = async (): Promise<IAuthResponse> => {
       photoUrl: '',
       displayName: res.displayName,
       idToken: res.idToken,
-      expiresAtMs: getExpiresAtMs(res.expiresIn),
+      expiresAtMs: getExpiresAtMs(Number(res.expiresIn)),
       refreshToken: res.refreshToken,
     }));
 };

--- a/apps/extension/tests/auth.setup.ts
+++ b/apps/extension/tests/auth.setup.ts
@@ -45,7 +45,6 @@ const signInWithEmailAndPassword = async (): Promise<IAuthResponse> => {
       photoUrl: '',
       displayName: res.displayName,
       idToken: res.idToken,
-      expiresIn: Number(res.expiresIn),
       expiresAtMs: getExpiresAtMs(res.expiresIn),
       refreshToken: res.refreshToken,
     }));

--- a/apps/extension/tests/fixtures/base-fixture.ts
+++ b/apps/extension/tests/fixtures/base-fixture.ts
@@ -108,60 +108,6 @@ export const getExtensionId = async (
 };
 
 /**
- * Navigate to a panel. Since we're using the cached Chrome profile,
- * the extension should already be logged in with all data loaded.
- */
-export const authenticateAndNavigate = async (
-  sharedContext: BrowserContext,
-  sharedExtensionId: string,
-  panelName?: 'bookmarks' | 'persons' | 'shortcuts' | 'home'
-): Promise<Page> => {
-  const cachedData = await loadCachedStorageData();
-
-  // Step 1: Inject localStorage via addInitScript (runs before any page script)
-  await sharedContext.addInitScript(
-    ({ localStorageData }) => {
-      for (const [key, value] of Object.entries(localStorageData)) {
-        window.localStorage.setItem(key, value);
-      }
-    },
-    { localStorageData: cachedData.localStorage }
-  );
-
-  // Step 2: Create page and navigate to extension
-  const page = await sharedContext.newPage();
-  await page.goto(getPopupUrl(sharedExtensionId), {
-    waitUntil: 'domcontentloaded',
-  });
-
-  // Step 3: Inject chrome.storage.local via extension page (avoid MV3 worker hangs)
-  await page.evaluate(async (chromeStorageData) => {
-    await chrome.storage.local.set(chromeStorageData);
-  }, cachedData.chromeStorage);
-
-  // Step 4: Reload to ensure storage is applied before UI checks
-  await page.reload({ waitUntil: 'domcontentloaded' });
-
-  // Step 5: Verify we're logged in (logout button should be visible)
-  const logoutButton = page.getByRole('button', { name: 'Logout' });
-  await logoutButton.waitFor({
-    state: 'visible',
-    timeout: TEST_TIMEOUTS.AUTH,
-  });
-
-  // Step 6: Navigate to requested panel
-  if (panelName && panelName !== 'home') {
-    const panelButton = page.getByRole('button', {
-      name: new RegExp(panelName, 'i'),
-    });
-    await panelButton.click();
-    await page.waitForLoadState('domcontentloaded');
-  }
-
-  return page;
-};
-
-/**
  * Open extension popup (or a panel) using existing authenticated context state.
  */
 export const openExtensionPanelPage = async (

--- a/apps/extension/tests/utils/home-panel.ts
+++ b/apps/extension/tests/utils/home-panel.ts
@@ -30,7 +30,7 @@ export class PopupHomePanel {
   }
 
   async verifyHistoryStartTime() {
-    const historyStartTime = await getStorageItem<string>(
+    const historyStartTime = await getStorageItem<number>(
       this.page,
       'historyStartTime'
     );
@@ -39,7 +39,7 @@ export class PopupHomePanel {
   }
 
   async verifyHistoryStartTimeNotExists() {
-    const historyStartTime = await getStorageItem<string>(
+    const historyStartTime = await getStorageItem<number>(
       this.page,
       'historyStartTime'
     );

--- a/apps/web/src/app/components/SalientFeatures.tsx
+++ b/apps/web/src/app/components/SalientFeatures.tsx
@@ -1,8 +1,6 @@
 import { HugeiconsIcon } from '@hugeicons/react';
 
-import { firstColumn, secondColumn } from '@app/constants/features';
-
-const allFeatures = [...firstColumn, ...secondColumn];
+import { FEATURES } from '@app/constants/features';
 
 function SalientFeatures() {
   return (
@@ -11,7 +9,7 @@ function SalientFeatures() {
         Core features at a glance
       </h2>
       <div className="grid grid-cols-1 gap-x-12 gap-y-8 md:grid-cols-2 lg:grid-cols-3">
-        {allFeatures.map(({ title, content, icon }) => (
+        {FEATURES.map(({ title, content, icon }) => (
           <div key={title} className="flex gap-4">
             <div className="shrink-0 text-primary">
               <HugeiconsIcon icon={icon} size={28} />

--- a/apps/web/src/app/constants/features.ts
+++ b/apps/web/src/app/constants/features.ts
@@ -9,7 +9,7 @@ import {
 
 import type Feature from '../components/types/feature';
 
-export const firstColumn: Feature[] = [
+export const FEATURES: Feature[] = [
   {
     icon: Touch01Icon,
     title: 'Simple to Use',
@@ -28,9 +28,6 @@ export const firstColumn: Feature[] = [
     content:
       'Browse supported forums and open only links you have not visited yet',
   },
-];
-
-export const secondColumn: Feature[] = [
   {
     icon: Shield01Icon,
     title: 'Privacy-First Sync',

--- a/apps/web/src/app/helpers/authorizeUser.ts
+++ b/apps/web/src/app/helpers/authorizeUser.ts
@@ -30,7 +30,6 @@ export const authorizeUser = async (
     return { ok: false, status: 401, message: 'Unauthorized user' };
   }
 
-  // Return the shared result directly: rebuilding it would put the wider
-  // firebase-admin UserRecord in a slot typed as the narrower IUser
+  // Rebuilding this would put the wider UserRecord in an IUser-typed slot
   return checkUserAuthorized(user);
 };

--- a/apps/web/src/app/helpers/authorizeUser.ts
+++ b/apps/web/src/app/helpers/authorizeUser.ts
@@ -1,4 +1,5 @@
 import {
+  type AuthorizationResult,
   checkUserAuthorized,
   getAuthBearer,
   getFirebaseUser,
@@ -8,14 +9,10 @@ import { type NextRequest } from 'next/server';
 
 type FirebaseUser = Awaited<ReturnType<typeof getFirebaseUser>>;
 
-type AuthorizeUserResult =
-  | { ok: true; user: FirebaseUser }
-  | { ok: false; status: 401 | 403; message: string };
-
 /** Applies the same rules as the tRPC middleware. */
 export const authorizeUser = async (
   request: NextRequest
-): Promise<AuthorizeUserResult> => {
+): Promise<AuthorizationResult> => {
   const idToken = getAuthBearer(request);
   if (!idToken) {
     return {

--- a/apps/web/src/app/helpers/authorizeUser.ts
+++ b/apps/web/src/app/helpers/authorizeUser.ts
@@ -30,6 +30,7 @@ export const authorizeUser = async (
     return { ok: false, status: 401, message: 'Unauthorized user' };
   }
 
-  const result = checkUserAuthorized(user);
-  return result.ok ? { ok: true, user } : result;
+  // Return the shared result directly: rebuilding it would put the wider
+  // firebase-admin UserRecord in a slot typed as the narrower IUser
+  return checkUserAuthorized(user);
 };

--- a/apps/web/src/app/helpers/authorizeUser.ts
+++ b/apps/web/src/app/helpers/authorizeUser.ts
@@ -30,6 +30,5 @@ export const authorizeUser = async (
     return { ok: false, status: 401, message: 'Unauthorized user' };
   }
 
-  // Rebuilding this would put the wider UserRecord in an IUser-typed slot
   return checkUserAuthorized(user);
 };

--- a/packages/shared/src/components/Bookmarks/hooks/useBookmark.ts
+++ b/packages/shared/src/components/Bookmarks/hooks/useBookmark.ts
@@ -7,17 +7,6 @@ import { getDecryptedFolder, getDefaultFolder } from '../utils';
 const useBookmark = () => {
   const { getBookmarks } = useStorage();
 
-  const getBookmarkFromHash = useCallback(
-    async (hash: string) => {
-      const bookmarks = await getBookmarks();
-      if (!bookmarks) {
-        throw new Error('No bookmarks found for getBookmarkFromHash');
-      }
-      return bookmarks.urlList[hash];
-    },
-    [getBookmarks]
-  );
-
   const getFolderFromHash = useCallback(
     async (hash: string) => {
       const bookmarks = await getBookmarks();
@@ -44,7 +33,6 @@ const useBookmark = () => {
   }, [getBookmarks]);
 
   return {
-    getBookmarkFromHash,
     getFolderFromHash,
     getDefaultOrRootFolderUrls,
   };

--- a/packages/trpc/src/appRouterIndex.ts
+++ b/packages/trpc/src/appRouterIndex.ts
@@ -1,3 +1,6 @@
 export * from './services/firebaseAdminService';
-export { checkUserAuthorized } from './utils/authorization';
+export {
+  type AuthorizationResult,
+  checkUserAuthorized,
+} from './utils/authorization';
 export { getAuthBearer } from './utils/headers';

--- a/packages/trpc/src/routers/extension.ts
+++ b/packages/trpc/src/routers/extension.ts
@@ -4,10 +4,19 @@ import { protectedProcedure } from '../procedures';
 import { getLatestExtension } from '../services/extensionService';
 import { t } from '../trpc';
 
+const ExtensionAssetSchema = z.object({
+  downloadLink: z.string(),
+  version: z.string(),
+  date: z.string(),
+});
+
 const extensionRouter = t.router({
-  latest: protectedProcedure.input(z.void()).query(async () => {
-    return getLatestExtension();
-  }),
+  latest: protectedProcedure
+    .input(z.void())
+    .output(z.object({ chrome: ExtensionAssetSchema }))
+    .query(async () => {
+      return getLatestExtension();
+    }),
 });
 
 export default extensionRouter;

--- a/packages/trpc/src/routers/firebaseStorage.ts
+++ b/packages/trpc/src/routers/firebaseStorage.ts
@@ -10,12 +10,14 @@ import { t } from '../trpc';
 const firebaseStorageRouter = t.router({
   getDownloadUrl: protectedProcedure
     .input(z.string())
+    .output(z.string())
     .query(async ({ input, ctx }) => {
       return getFileFromFirebase(ctx.user.uid, input);
     }),
 
   removeFile: protectedProcedure
     .input(z.string())
+    .output(z.void())
     .mutation(async ({ input, ctx }) => {
       await removeFileFromFirebase(ctx.user.uid, input);
     }),

--- a/packages/trpc/src/services/firebaseAdminService.ts
+++ b/packages/trpc/src/services/firebaseAdminService.ts
@@ -155,10 +155,3 @@ export const listFilesFromFirebase = async (uid: string) => {
 
   return files;
 };
-
-export const deletePersonImageFromFirebase = async (
-  uid: string,
-  imageUid: string
-): Promise<void> => {
-  await storage.bucket().file(getFilePath(uid, imageUid)).delete();
-};

--- a/packages/trpc/src/services/storageCleanupService.ts
+++ b/packages/trpc/src/services/storageCleanupService.ts
@@ -2,9 +2,9 @@ import { getPersonImageName, type IPersons } from '@bypass/shared';
 
 import { EFirebaseDBRef } from '../constants/firebase';
 import {
-  deletePersonImageFromFirebase,
   getFromFirebase,
   listFilesFromFirebase,
+  removeFileFromFirebase,
 } from './firebaseAdminService';
 
 async function getPersonStorageImageId(uid: string): Promise<string[]> {
@@ -32,7 +32,7 @@ export const cleanupStorage = async (uid: string): Promise<void> => {
   }
 
   const deletePromises = orphanedImages.map(async (imageUid) =>
-    deletePersonImageFromFirebase(uid, getPersonImageName(imageUid))
+    removeFileFromFirebase(uid, getPersonImageName(imageUid))
   );
   await Promise.all(deletePromises);
 };


### PR DESCRIPTION
Ten mechanical cleanups from a repo-wide `/simplify` review. No behaviour change intended.

**Deleted as dead:** `getBookmarkFromHash` (zero callers), `authenticateAndNavigate` (zero callers, 49 lines whose tail duplicated `openExtensionPanelPage`), `deletePersonImageFromFirebase` (functionally identical to `removeFileFromFirebase`).

**`IAuthResponse.expiresIn`** was written three times and read never — all expiry logic goes through `expiresAtMs`. The third writer was the `...refreshedTokenData` spread in `getIdToken`; spreads bypass excess-property checks, so it is destructured out explicitly or the field keeps being persisted into `__fbOAuth` with typecheck staying green. `IRefreshTokenResponse.expiresIn` stays — it is the read source.

**Also:** collapsed the `firstColumn`/`secondColumn` split that its only consumer immediately undid; dropped a `refreshPersonImageUrlsCache()` call overwritten 12 lines later; added missing `.output(...)` to three tRPC procedures; typed `getExpiresAtMs`; fixed a `getStorageItem<string>` generic for a `number` item; replaced the local `AuthorizeUserResult` with the shared `AuthorizationResult`.

### Worth a reviewer's eye

- The `expiresIn` spread fix is the one non-obvious change — without it the field survives silently.
- Dropping the `refreshPersonImageUrlsCache()` call is **not** a pure no-op: if `getDownloadUrl` now fails, the item keeps its stale value instead of being left empty. That is the better of the two, but it is a change.
- `AuthorizationResult` **narrows** `auth.user` from firebase-admin's `UserRecord` to the six-field `IUser`. Safe because the only ok-branch consumer reads `.uid`.

### Verification

`pnpm lint`, `pnpm format:check`, `pnpm typecheck:all` clean.

---
### Stack

This is part of a 5-PR stack from a repo-wide `/simplify` pass. Merge in order — each PR is based on the previous one.

1. #4135 — dead code and trivial collapses
2. #4136 — single-use wrappers and helper reuse
3. #4137 — collapse duplicated mechanisms
4. #4138 — derivable state
5. #4139 — wasted work on hot paths

Every commit passes `pnpm lint`, `pnpm format:check`, `pnpm typecheck:all`, and all 91 Playwright tests still resolve.

A sixth PR (wrong-altitude fixes) was closed and dropped from the stack; its work is unshipped on `cleanup/batch-6-altitude`.

The extension minor version is bumped to `25.4.0` in #4135, the bottom of the stack, so it lands once for the whole series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

 

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes unused helpers and consolidates duplicated data paths while tightening auth and tRPC response types.
- Removes unused bookmark, authentication-test, and Firebase Storage deletion helpers.
- Stops persisting the unused Firebase `expiresIn` field and retains `expiresAtMs` as the expiry source.
- Adds explicit output schemas to extension and Firebase Storage tRPC procedures.
- Consolidates feature-list constants and updates test storage typing.
- Changes the extension package version from 25.3.0 to 25.4.0.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (5): Last reviewed commit: ["chore(extension): bump minor version to ..."](https://github.com/amitsingh-007/bypass-links/commit/0936d2444c82bce4e3da44c29305e572d1b9b087) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50447280)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Knowledge Base — [Extension background service worker](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/extension-background.md)
- Knowledge Base — [Extension Popup UI](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/extension-popup.md)
- Knowledge Base — [Web App (apps/web)](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/web-app.md)
- Knowledge Base — [packages/trpc: shared tRPC API layer](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/trpc-package.md)
- Knowledge Base — [Shared package (`packages/shared`)](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/shared-package.md)
</details>

<!-- /greptile_comment -->