### PR TITLE
refactor: collapse duplicated mechanisms onto one implementation each (3/5)

### DIFF
--- a/apps/extension/src/constants/index.ts
+++ b/apps/extension/src/constants/index.ts
@@ -13,10 +13,9 @@ export const TEST_AUTH_DATA_KEY = '__test_auth_data';
 export const POPUP_HOMEPAGE = '/popup.html';
 
 /**
- * Extension-only storage keys (the shared ones live in `STORAGE_KEYS`).
- * Kept here rather than in `storage/items.ts` because that module runs
- * `storage.defineItem` at import time, which touches `browser.runtime` and so
- * cannot be imported from a Playwright Node worker.
+ * Extension-only storage keys (shared ones live in `STORAGE_KEYS`). Not in
+ * `storage/items.ts`: `defineItem` touches `browser.runtime` at import time, so
+ * that module cannot be imported from a Playwright Node worker.
  */
 export const EXT_STORAGE_KEYS = {
   extState: 'extState',

--- a/apps/extension/src/constants/index.ts
+++ b/apps/extension/src/constants/index.ts
@@ -11,3 +11,23 @@ export const MAX_PANEL_SIZE = {
 export const TEST_AUTH_DATA_KEY = '__test_auth_data';
 
 export const POPUP_HOMEPAGE = '/popup.html';
+
+/**
+ * Extension-only storage keys (the shared ones live in `STORAGE_KEYS`).
+ * Kept here rather than in `storage/items.ts` because that module runs
+ * `storage.defineItem` at import time, which touches `browser.runtime` and so
+ * cannot be imported from a Playwright Node worker.
+ */
+export const EXT_STORAGE_KEYS = {
+  extState: 'extState',
+  hasPendingBookmarks: 'hasPendingBookmarks',
+  hasPendingPersons: 'hasPendingPersons',
+  historyStartTime: 'historyStartTime',
+} as const;
+
+/** Keys whose change should refresh the toolbar icon. */
+export const ICON_KEYS = [
+  EXT_STORAGE_KEYS.extState,
+  EXT_STORAGE_KEYS.hasPendingBookmarks,
+  EXT_STORAGE_KEYS.hasPendingPersons,
+] as const;

--- a/apps/extension/src/constants/index.ts
+++ b/apps/extension/src/constants/index.ts
@@ -12,21 +12,17 @@ export const TEST_AUTH_DATA_KEY = '__test_auth_data';
 
 export const POPUP_HOMEPAGE = '/popup.html';
 
-/**
- * Extension-only storage keys (shared ones live in `STORAGE_KEYS`). Not in
- * `storage/items.ts`: `defineItem` touches `browser.runtime` at import time, so
- * that module cannot be imported from a Playwright Node worker.
- */
-export const EXT_STORAGE_KEYS = {
-  extState: 'extState',
-  hasPendingBookmarks: 'hasPendingBookmarks',
-  hasPendingPersons: 'hasPendingPersons',
-  historyStartTime: 'historyStartTime',
-} as const;
+/** Not in `storage/items.ts`: that module cannot be imported from a Node worker. */
+export enum EExtStorageKey {
+  EXT_STATE = 'extState',
+  HAS_PENDING_BOOKMARKS = 'hasPendingBookmarks',
+  HAS_PENDING_PERSONS = 'hasPendingPersons',
+  HISTORY_START_TIME = 'historyStartTime',
+}
 
 /** Keys whose change should refresh the toolbar icon. */
 export const ICON_KEYS = [
-  EXT_STORAGE_KEYS.extState,
-  EXT_STORAGE_KEYS.hasPendingBookmarks,
-  EXT_STORAGE_KEYS.hasPendingPersons,
+  EExtStorageKey.EXT_STATE,
+  EExtStorageKey.HAS_PENDING_BOOKMARKS,
+  EExtStorageKey.HAS_PENDING_PERSONS,
 ] as const;

--- a/apps/extension/src/entrypoints/background/index.ts
+++ b/apps/extension/src/entrypoints/background/index.ts
@@ -1,6 +1,6 @@
 import { defineBackground } from 'wxt/utils/define-background';
 
-import { EExtensionState } from '@/constants';
+import { EExtensionState, ICON_KEYS } from '@/constants';
 import {
   extStateItem,
   hasPendingBookmarksItem,
@@ -119,12 +119,7 @@ export default defineBackground({
       if (areaName !== 'local') {
         return;
       }
-      const changedKeys = Object.keys(changes);
-      if (
-        changedKeys.includes('extState') ||
-        changedKeys.includes('hasPendingBookmarks') ||
-        changedKeys.includes('hasPendingPersons')
-      ) {
+      if (ICON_KEYS.some((key) => key in changes)) {
         void updateIcon();
       }
     });

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/PersonsPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/PersonsPanel.tsx
@@ -1,7 +1,6 @@
 import {
   EBookmarkOperation,
   getBookmarksPanelUrl,
-  getDecryptedPerson,
   getEncryptedPerson,
   getFilteredPersons,
   sortByRecency,
@@ -21,10 +20,13 @@ import { useLocation } from 'wouter';
 
 import { trpcApi } from '@/apis/trpcApi';
 import { MAX_PANEL_SIZE } from '@/constants';
-import { personsItem } from '@/storage/items';
 import Panel from '@popup/components/Panel';
 
-import { getPersonPos, setPersonsInStorage } from '../utils';
+import {
+  getAllDecodedPersons,
+  getPersonPos,
+  setPersonsInStorage,
+} from '../utils';
 import { updatePersonCacheAndImageUrls } from '../utils/sync';
 import PersonHeader from './PersonHeader';
 import PersonVirtualCell from './PersonVirtualCell';
@@ -50,11 +52,8 @@ function PersonsPanel() {
   const [orderByRecency, setOrderByRecency] = useState(true);
 
   useEffect(() => {
-    personsItem.getValue().then((_persons) => {
-      const decryptedPersons = Object.values(_persons || {}).map((x) =>
-        getDecryptedPerson(x)
-      );
-      setPersons(sortAlphabetically(decryptedPersons));
+    getAllDecodedPersons().then((decodedPersons) => {
+      setPersons(sortAlphabetically(decodedPersons));
       setIsFetching(false);
     });
   }, []);

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/utils/sync.ts
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/utils/sync.ts
@@ -1,10 +1,10 @@
 import {
-  addAllToCache,
   addToCache,
+  buildPersonImageUrls,
+  cachePersonImages,
   ECacheBucketKeys,
   getPersonImageName,
   type IPerson,
-  type PersonImageUrls,
 } from '@bypass/shared';
 
 import { trpcApi } from '@/apis/trpcApi';
@@ -28,36 +28,18 @@ export const resetPersons = async () => {
   await hasPendingPersonsItem.removeValue();
 };
 
-const resolveImageFromPerson = async (uid: string) => ({
-  uid,
-  imageUrl: await trpcApi.storage.getDownloadUrl.query(getPersonImageName(uid)),
-});
+const resolveDownloadUrl = async (fileName: string) =>
+  trpcApi.storage.getDownloadUrl.query(fileName);
 
 export const refreshPersonImageUrlsCache = async () => {
   await personImageUrlsItem.removeValue();
 };
 
-const cachePersonImages = async (personImageUrls: PersonImageUrls) => {
-  if (!personImageUrls) {
-    console.log('Unable to cache person images since no person urls');
-    return;
-  }
-  const imageUrls = Object.values(personImageUrls);
-  await addAllToCache(ECacheBucketKeys.person, imageUrls);
-  console.log('Initialized cache for all person urls');
-};
-
 export const cachePersonImagesInStorage = async () => {
   const persons = await getAllDecodedPersons();
-  const personImagesList = await Promise.all(
-    persons.map(async (person) => resolveImageFromPerson(person.uid))
-  );
-  const personImageUrls = personImagesList.reduce<PersonImageUrls>(
-    (obj, { uid, imageUrl }) => {
-      obj[uid] = imageUrl;
-      return obj;
-    },
-    {}
+  const personImageUrls = await buildPersonImageUrls(
+    persons.map((person) => person.uid),
+    resolveDownloadUrl
   );
   await personImageUrlsItem.setValue(personImageUrls);
   const { incrementProgress } = useProgressStore.getState();
@@ -69,8 +51,8 @@ export const cachePersonImagesInStorage = async () => {
 export const updatePersonCacheAndImageUrls = async (person: IPerson) => {
   // Update person image urls in storage
   const personImageUrls = await personImageUrlsItem.getValue();
-  const { uid, imageUrl } = await resolveImageFromPerson(person.uid);
-  personImageUrls[uid] = imageUrl;
+  const imageUrl = await resolveDownloadUrl(getPersonImageName(person.uid));
+  personImageUrls[person.uid] = imageUrl;
   await personImageUrlsItem.setValue(personImageUrls);
   // Update person image cache
   await addToCache(ECacheBucketKeys.person, imageUrl);

--- a/apps/extension/src/interfaces/firebase.ts
+++ b/apps/extension/src/interfaces/firebase.ts
@@ -8,6 +8,17 @@ export interface IAuthResponse {
   readonly refreshToken: string;
 }
 
+/** Raw shape returned by the Identity Toolkit sign-in endpoints. */
+export interface IIdentityAuthResponse {
+  readonly localId: string;
+  readonly email: string;
+  readonly photoUrl?: string;
+  readonly displayName?: string;
+  readonly idToken: string;
+  readonly expiresIn: string;
+  readonly refreshToken: string;
+}
+
 export interface IRefreshTokenResponse {
   readonly expiresIn: number;
   readonly idToken: string;

--- a/apps/extension/src/storage/items.ts
+++ b/apps/extension/src/storage/items.ts
@@ -9,59 +9,61 @@ import type {
 import { STORAGE_KEYS } from '@bypass/shared';
 import { storage } from 'wxt/utils/storage';
 
-import { EExtensionState, EXT_STORAGE_KEYS } from '@/constants';
+import { EExtensionState, EExtStorageKey } from '@/constants';
 import type { IMappedRedirections } from '@/entrypoints/background/interfaces/redirections';
 
-export const bookmarksItem = storage.defineItem<IBookmarksObj>(
-  `local:${STORAGE_KEYS.bookmarks}`,
-  { fallback: { folderList: {}, urlList: {}, folders: {} } }
+/** Every item lives in `local:` with a fallback; keeps the eleven call sites flat. */
+const defineLocalItem = <T>(key: string, fallback: T) =>
+  storage.defineItem<T>(`local:${key}`, { fallback });
+
+export const bookmarksItem = defineLocalItem<IBookmarksObj>(
+  STORAGE_KEYS.bookmarks,
+  { folderList: {}, urlList: {}, folders: {} }
 );
 
-export const websitesItem = storage.defineItem<IWebsites>(
-  `local:${STORAGE_KEYS.websites}`,
-  { fallback: {} }
+export const websitesItem = defineLocalItem<IWebsites>(
+  STORAGE_KEYS.websites,
+  {}
 );
 
-export const lastVisitedItem = storage.defineItem<ILastVisited>(
-  `local:${STORAGE_KEYS.lastVisited}`,
-  { fallback: {} }
+export const lastVisitedItem = defineLocalItem<ILastVisited>(
+  STORAGE_KEYS.lastVisited,
+  {}
 );
 
-export const personsItem = storage.defineItem<IPersons>(
-  `local:${STORAGE_KEYS.persons}`,
-  { fallback: {} }
+export const personsItem = defineLocalItem<IPersons>(STORAGE_KEYS.persons, {});
+
+export const redirectionsItem = defineLocalItem<IRedirections>(
+  STORAGE_KEYS.redirections,
+  []
 );
 
-export const redirectionsItem = storage.defineItem<IRedirections>(
-  `local:${STORAGE_KEYS.redirections}`,
-  { fallback: [] }
+export const mappedRedirectionsItem = defineLocalItem<IMappedRedirections>(
+  STORAGE_KEYS.mappedRedirections,
+  {}
 );
 
-export const mappedRedirectionsItem = storage.defineItem<IMappedRedirections>(
-  `local:${STORAGE_KEYS.mappedRedirections}`,
-  { fallback: {} }
+export const personImageUrlsItem = defineLocalItem<PersonImageUrls>(
+  STORAGE_KEYS.personImageUrls,
+  {}
 );
 
-export const personImageUrlsItem = storage.defineItem<PersonImageUrls>(
-  `local:${STORAGE_KEYS.personImageUrls}`,
-  { fallback: {} }
+export const extStateItem = defineLocalItem<EExtensionState>(
+  EExtStorageKey.EXT_STATE,
+  EExtensionState.ACTIVE
 );
 
-export const extStateItem = storage.defineItem<EExtensionState>(
-  `local:${EXT_STORAGE_KEYS.extState}`,
-  { fallback: EExtensionState.ACTIVE }
+export const hasPendingBookmarksItem = defineLocalItem<boolean>(
+  EExtStorageKey.HAS_PENDING_BOOKMARKS,
+  false
 );
 
-export const hasPendingBookmarksItem = storage.defineItem<boolean>(
-  `local:${EXT_STORAGE_KEYS.hasPendingBookmarks}`,
-  { fallback: false }
+export const hasPendingPersonsItem = defineLocalItem<boolean>(
+  EExtStorageKey.HAS_PENDING_PERSONS,
+  false
 );
 
-export const hasPendingPersonsItem = storage.defineItem<boolean>(
-  `local:${EXT_STORAGE_KEYS.hasPendingPersons}`,
-  { fallback: false }
-);
-
+// No fallback: absence is meaningful, so this one stays a direct call
 export const historyStartTimeItem = storage.defineItem<number>(
-  `local:${EXT_STORAGE_KEYS.historyStartTime}`
+  `local:${EExtStorageKey.HISTORY_START_TIME}`
 );

--- a/apps/extension/src/storage/items.ts
+++ b/apps/extension/src/storage/items.ts
@@ -12,8 +12,12 @@ import { storage } from 'wxt/utils/storage';
 import { EExtensionState, EExtStorageKey } from '@/constants';
 import type { IMappedRedirections } from '@/entrypoints/background/interfaces/redirections';
 
-/** Every item lives in `local:` with a fallback; keeps the eleven call sites flat. */
-const defineLocalItem = <T>(key: string, fallback: T) =>
+/** Constrained to the known key sets so a typo cannot open a new namespace. */
+type LocalStorageKey =
+  | (typeof STORAGE_KEYS)[keyof typeof STORAGE_KEYS]
+  | EExtStorageKey;
+
+const defineLocalItem = <T>(key: LocalStorageKey, fallback: T) =>
   storage.defineItem<T>(`local:${key}`, { fallback });
 
 export const bookmarksItem = defineLocalItem<IBookmarksObj>(

--- a/apps/extension/src/storage/items.ts
+++ b/apps/extension/src/storage/items.ts
@@ -6,59 +6,62 @@ import type {
   IRedirections,
   IWebsites,
 } from '@bypass/shared';
+import { STORAGE_KEYS } from '@bypass/shared';
 import { storage } from 'wxt/utils/storage';
 
-import { EExtensionState } from '@/constants';
+import { EExtensionState, EXT_STORAGE_KEYS } from '@/constants';
 import type { IMappedRedirections } from '@/entrypoints/background/interfaces/redirections';
 
 export const bookmarksItem = storage.defineItem<IBookmarksObj>(
-  'local:bookmarks',
+  `local:${STORAGE_KEYS.bookmarks}`,
   { fallback: { folderList: {}, urlList: {}, folders: {} } }
 );
 
-export const websitesItem = storage.defineItem<IWebsites>('local:websites', {
-  fallback: {},
-});
-
-export const lastVisitedItem = storage.defineItem<ILastVisited>(
-  'local:lastVisited',
+export const websitesItem = storage.defineItem<IWebsites>(
+  `local:${STORAGE_KEYS.websites}`,
   { fallback: {} }
 );
 
-export const personsItem = storage.defineItem<IPersons>('local:persons', {
-  fallback: {},
-});
+export const lastVisitedItem = storage.defineItem<ILastVisited>(
+  `local:${STORAGE_KEYS.lastVisited}`,
+  { fallback: {} }
+);
+
+export const personsItem = storage.defineItem<IPersons>(
+  `local:${STORAGE_KEYS.persons}`,
+  { fallback: {} }
+);
 
 export const redirectionsItem = storage.defineItem<IRedirections>(
-  'local:redirections',
+  `local:${STORAGE_KEYS.redirections}`,
   { fallback: [] }
 );
 
 export const mappedRedirectionsItem = storage.defineItem<IMappedRedirections>(
-  'local:mappedRedirections',
+  `local:${STORAGE_KEYS.mappedRedirections}`,
   { fallback: {} }
 );
 
 export const personImageUrlsItem = storage.defineItem<PersonImageUrls>(
-  'local:personImageUrls',
+  `local:${STORAGE_KEYS.personImageUrls}`,
   { fallback: {} }
 );
 
 export const extStateItem = storage.defineItem<EExtensionState>(
-  'local:extState',
+  `local:${EXT_STORAGE_KEYS.extState}`,
   { fallback: EExtensionState.ACTIVE }
 );
 
 export const hasPendingBookmarksItem = storage.defineItem<boolean>(
-  'local:hasPendingBookmarks',
+  `local:${EXT_STORAGE_KEYS.hasPendingBookmarks}`,
   { fallback: false }
 );
 
 export const hasPendingPersonsItem = storage.defineItem<boolean>(
-  'local:hasPendingPersons',
+  `local:${EXT_STORAGE_KEYS.hasPendingPersons}`,
   { fallback: false }
 );
 
 export const historyStartTimeItem = storage.defineItem<number>(
-  'local:historyStartTime'
+  `local:${EXT_STORAGE_KEYS.historyStartTime}`
 );

--- a/apps/extension/src/store/firebase/api.ts
+++ b/apps/extension/src/store/firebase/api.ts
@@ -8,7 +8,7 @@ import {
   type IRefreshTokenResponse,
 } from '@/interfaces/firebase';
 
-import { getExpiresAtMs } from './utils';
+import { mapAuthResponse } from './utils';
 
 const firebaseConfig = getFirebasePublicConfig(import.meta.env.PROD);
 
@@ -29,15 +29,7 @@ export const signInWithCredential = async (accessToken: string) => {
       returnSecureToken: true,
     })
     .fetchError((e) => console.error(e))
-    .json<IAuthResponse>((res) => ({
-      uid: res.localId,
-      email: res.email,
-      photoUrl: res.photoUrl,
-      displayName: res.displayName,
-      idToken: res.idToken,
-      expiresAtMs: getExpiresAtMs(Number(res.expiresIn)),
-      refreshToken: res.refreshToken,
-    }));
+    .json<IAuthResponse>(mapAuthResponse);
 };
 
 export const refreshIdToken = async (refreshToken: string) => {

--- a/apps/extension/src/store/firebase/utils.ts
+++ b/apps/extension/src/store/firebase/utils.ts
@@ -1,3 +1,23 @@
+import type {
+  IAuthResponse,
+  IIdentityAuthResponse,
+} from '@/interfaces/firebase';
+
 export const getExpiresAtMs = (expiresIn: number) => {
   return Date.now() + expiresIn * 1000;
 };
+
+/**
+ * Not in `api.ts`, so the Playwright auth setup can share it: `api.ts` reads
+ * `import.meta.env` at module scope, which is undefined in Node.
+ */
+export const mapAuthResponse = (res: IIdentityAuthResponse): IAuthResponse => ({
+  uid: res.localId,
+  email: res.email,
+  photoUrl: res.photoUrl,
+  displayName: res.displayName,
+  idToken: res.idToken,
+  // The wire format is a string; the helper takes a number
+  expiresAtMs: getExpiresAtMs(Number(res.expiresIn)),
+  refreshToken: res.refreshToken,
+});

--- a/apps/extension/tests/auth.setup.ts
+++ b/apps/extension/tests/auth.setup.ts
@@ -41,7 +41,6 @@ const signInWithEmailAndPassword = async (): Promise<IAuthResponse> => {
     })
     .json<IAuthResponse>((res) => ({
       ...mapAuthResponse(res),
-      // The email/password flow returns no photo; keep it empty rather than undefined
       photoUrl: '',
     }));
 };

--- a/apps/extension/tests/auth.setup.ts
+++ b/apps/extension/tests/auth.setup.ts
@@ -1,13 +1,13 @@
 import fs from 'node:fs';
 import process from 'node:process';
 
-import { TEST_TIMEOUTS } from '@bypass/shared/tests';
+import { dumpLocalStorage, TEST_TIMEOUTS } from '@bypass/shared/tests';
 import { expect, test as setup } from '@playwright/test';
 import wretch from 'wretch';
 import QueryStringAddon from 'wretch/addons/queryString';
 
 import type { IAuthResponse } from '@/interfaces/firebase';
-import { getExpiresAtMs } from '@/store/firebase/utils';
+import { mapAuthResponse } from '@/store/firebase/utils';
 
 import { getFirebasePublicConfig } from '../../../packages/configs/firebase.config';
 import { TEST_AUTH_DATA_KEY } from '../src/constants';
@@ -40,13 +40,9 @@ const signInWithEmailAndPassword = async (): Promise<IAuthResponse> => {
       returnSecureToken: true,
     })
     .json<IAuthResponse>((res) => ({
-      uid: res.localId,
-      email: res.email,
+      ...mapAuthResponse(res),
+      // The email/password flow returns no photo; keep it empty rather than undefined
       photoUrl: '',
-      displayName: res.displayName,
-      idToken: res.idToken,
-      expiresAtMs: getExpiresAtMs(Number(res.expiresIn)),
-      refreshToken: res.refreshToken,
     }));
 };
 
@@ -93,18 +89,9 @@ setup('authenticate and cache extension storage', async ({}, testInfo) => {
     chrome.storage.local.get(null)
   );
 
-  const localStorageData = await page.evaluate(() => {
-    const data: Record<string, string> = {};
-    for (let i = 0; i < window.localStorage.length; i++) {
-      const key = window.localStorage.key(i);
-      if (key) {
-        data[key] = window.localStorage.getItem(key) ?? '';
-      }
-    }
-    return data;
+  const localStorageData = await dumpLocalStorage(page, {
+    omitKeys: ['OUTDATED_EXT_CHECK'],
   });
-
-  delete localStorageData.OUTDATED_EXT_CHECK;
 
   await fs.promises.writeFile(
     EXTENSION_STORAGE_PATH,

--- a/apps/extension/tests/fixtures/auth-fixture.ts
+++ b/apps/extension/tests/fixtures/auth-fixture.ts
@@ -1,3 +1,5 @@
+import { injectLocalStorage } from '@bypass/shared/tests';
+
 import { getExtensionId, loadCachedStorageData } from './base-fixture';
 import { test as base } from './extension-fixture';
 
@@ -11,15 +13,9 @@ export const test = base.extend<{
   async login({ context }, use) {
     const cachedData = await loadCachedStorageData();
 
-    await context.addInitScript(
-      ({ localStorageData }) => {
-        for (const [key, value] of Object.entries(localStorageData)) {
-          window.localStorage.setItem(key, value);
-        }
-        window.localStorage.removeItem('OUTDATED_EXT_CHECK');
-      },
-      { localStorageData: cachedData.localStorage }
-    );
+    await injectLocalStorage(context, cachedData.localStorage, {
+      clearKeys: ['OUTDATED_EXT_CHECK'],
+    });
 
     await use();
   },

--- a/apps/extension/tests/fixtures/background-fixture.ts
+++ b/apps/extension/tests/fixtures/background-fixture.ts
@@ -1,7 +1,3 @@
-import fs from 'node:fs/promises';
-import os from 'node:os';
-import path from 'node:path';
-
 import { TEST_TIMEOUTS } from '@bypass/shared/tests';
 import {
   type BrowserContext,
@@ -10,13 +6,12 @@ import {
   type Worker,
 } from '@playwright/test';
 
-import { EExtensionState } from '@/constants';
+import { EExtensionState, EXT_STORAGE_KEYS } from '@/constants';
 
 import {
   createSharedBackgroundSW,
-  createSharedContext,
   getExtensionId,
-  launchExtensionContext,
+  withTempProfileContext,
 } from './base-fixture';
 
 interface BaseBackgroundEnv {
@@ -99,7 +94,7 @@ const createBackgroundEnv = async (
       ),
     clearHistoryStartTime: async () =>
       runWithBackground(async (backgroundSW) =>
-        removeStorageFromWorker(backgroundSW, 'historyStartTime')
+        removeStorageFromWorker(backgroundSW, EXT_STORAGE_KEYS.historyStartTime)
       ),
     setHistoryStartTime: async (value: number) =>
       runWithBackground(async (backgroundSW) =>
@@ -121,44 +116,34 @@ export const test = base.extend<
   { sharedBackground: BaseBackgroundEnv }
 >({
   async isolatedBackground({}, use, testInfo) {
-    const userDataDir = await fs.mkdtemp(
-      path.join(os.tmpdir(), 'chrome-background-profile-')
+    await withTempProfileContext(
+      {
+        prefix: 'chrome-background-profile-',
+        headless: testInfo.project.use?.headless ?? true,
+      },
+      async (context) => {
+        const backgroundSW = await createSharedBackgroundSW(context);
+        const extensionId = await getExtensionId(backgroundSW);
+        await use(await createBackgroundEnv(context, extensionId));
+      }
     );
-
-    const context = await launchExtensionContext({
-      userDataDir,
-      headless: testInfo.project.use?.headless ?? true,
-    });
-
-    try {
-      const backgroundSW = await createSharedBackgroundSW(context);
-      const extensionId = await getExtensionId(backgroundSW);
-      const env = await createBackgroundEnv(context, extensionId);
-
-      await use(env);
-    } finally {
-      await context.close();
-      await fs.rm(userDataDir, { recursive: true, force: true });
-    }
   },
 
   // Safe to share: the spec is describe.serial and each test resets its own state
   sharedBackground: [
     async ({}, use, testInfo) => {
-      const { browserContext, userDataDir } = await createSharedContext({
-        headless: testInfo.project.use?.headless ?? true,
-      });
-
-      try {
-        const backgroundSW = await createSharedBackgroundSW(browserContext);
-        const extensionId = await getExtensionId(backgroundSW);
-        const env = await createBackgroundEnv(browserContext, extensionId);
-
-        await use(env);
-      } finally {
-        await browserContext.close();
-        await fs.rm(userDataDir, { recursive: true, force: true });
-      }
+      await withTempProfileContext(
+        {
+          prefix: 'chrome-profile-',
+          headless: testInfo.project.use?.headless ?? true,
+          seedFromCachedProfile: true,
+        },
+        async (context) => {
+          const backgroundSW = await createSharedBackgroundSW(context);
+          const extensionId = await getExtensionId(backgroundSW);
+          await use(await createBackgroundEnv(context, extensionId));
+        }
+      );
     },
     { scope: 'worker' },
   ],

--- a/apps/extension/tests/fixtures/background-fixture.ts
+++ b/apps/extension/tests/fixtures/background-fixture.ts
@@ -6,7 +6,7 @@ import {
   type Worker,
 } from '@playwright/test';
 
-import { EExtensionState, EXT_STORAGE_KEYS } from '@/constants';
+import { EExtensionState, EExtStorageKey } from '@/constants';
 
 import {
   createSharedBackgroundSW,
@@ -94,7 +94,7 @@ const createBackgroundEnv = async (
       ),
     clearHistoryStartTime: async () =>
       runWithBackground(async (backgroundSW) =>
-        removeStorageFromWorker(backgroundSW, EXT_STORAGE_KEYS.historyStartTime)
+        removeStorageFromWorker(backgroundSW, EExtStorageKey.HISTORY_START_TIME)
       ),
     setHistoryStartTime: async (value: number) =>
       runWithBackground(async (backgroundSW) =>

--- a/apps/extension/tests/fixtures/base-fixture.ts
+++ b/apps/extension/tests/fixtures/base-fixture.ts
@@ -52,11 +52,9 @@ export const loadCachedStorageData = async (): Promise<CachedStorageData> => {
 };
 
 /**
- * Launch an extension context on a throwaway profile directory.
- *
  * `seedFromCachedProfile` copies the authenticated profile from auth setup,
- * which preserves its Cache Storage (person-cache, favicon-cache). Omit it for
- * unauthenticated tests so no auth state can leak in.
+ * preserving its Cache Storage. Omit it so no auth state leaks into
+ * unauthenticated tests.
  */
 export const createTempProfileContext = async ({
   prefix,
@@ -72,22 +70,26 @@ export const createTempProfileContext = async ({
   // Temp dir rather than the cached profile itself, to avoid locking issues
   const userDataDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), prefix));
 
-  if (seedFromCachedProfile) {
-    await fs.promises.cp(CHROME_PROFILE_DIR, userDataDir, { recursive: true });
+  try {
+    if (seedFromCachedProfile) {
+      await fs.promises.cp(CHROME_PROFILE_DIR, userDataDir, {
+        recursive: true,
+      });
+    }
+    const browserContext = await launchExtensionContext({
+      userDataDir,
+      extensionPath,
+      headless,
+    });
+    return { browserContext, userDataDir };
+  } catch (error) {
+    // No caller owns the dir yet, so it would leak if seeding or launch throws
+    await fs.promises.rm(userDataDir, { recursive: true, force: true });
+    throw error;
   }
-
-  const browserContext = await launchExtensionContext({
-    userDataDir,
-    extensionPath,
-    headless,
-  });
-  return { browserContext, userDataDir };
 };
 
-/**
- * Run `fn` against a fresh temp-profile context, always cleaning up the profile
- * directory afterwards (a launch failure would otherwise leak it).
- */
+/** Runs `fn` against a fresh temp-profile context, always cleaning up after. */
 export const withTempProfileContext = async <T>(
   options: Parameters<typeof createTempProfileContext>[0],
   fn: (context: BrowserContext) => Promise<T>

--- a/apps/extension/tests/fixtures/base-fixture.ts
+++ b/apps/extension/tests/fixtures/base-fixture.ts
@@ -52,45 +52,74 @@ export const loadCachedStorageData = async (): Promise<CachedStorageData> => {
 };
 
 /**
- * Create a shared browser context that reuses the cached Chrome profile.
- * This preserves Cache Storage data (person-cache, favicon-cache) from auth setup.
+ * Launch an extension context on a throwaway profile directory.
+ *
+ * `seedFromCachedProfile` copies the authenticated profile from auth setup,
+ * which preserves its Cache Storage (person-cache, favicon-cache). Omit it for
+ * unauthenticated tests so no auth state can leak in.
  */
-export const createSharedContext = async (
-  options: { headless?: boolean } = {}
-) => {
-  // Copy the cached profile to a temp directory (to avoid locking issues)
-  const userDataDir = await fs.promises.mkdtemp(
-    path.join(os.tmpdir(), 'chrome-profile-')
-  );
+export const createTempProfileContext = async ({
+  prefix,
+  extensionPath,
+  headless,
+  seedFromCachedProfile = false,
+}: {
+  prefix: string;
+  extensionPath?: string;
+  headless?: boolean;
+  seedFromCachedProfile?: boolean;
+}) => {
+  // Temp dir rather than the cached profile itself, to avoid locking issues
+  const userDataDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), prefix));
 
-  // Copy cached profile contents to temp dir
-  await fs.promises.cp(CHROME_PROFILE_DIR, userDataDir, { recursive: true });
+  if (seedFromCachedProfile) {
+    await fs.promises.cp(CHROME_PROFILE_DIR, userDataDir, { recursive: true });
+  }
 
   const browserContext = await launchExtensionContext({
     userDataDir,
-    headless: options.headless,
+    extensionPath,
+    headless,
   });
   return { browserContext, userDataDir };
 };
 
 /**
- * Create an isolated browser context for unauthenticated tests.
- * This ensures no auth state leaks from the shared context.
+ * Run `fn` against a fresh temp-profile context, always cleaning up the profile
+ * directory afterwards (a launch failure would otherwise leak it).
  */
+export const withTempProfileContext = async <T>(
+  options: Parameters<typeof createTempProfileContext>[0],
+  fn: (context: BrowserContext) => Promise<T>
+): Promise<T> => {
+  const { browserContext, userDataDir } =
+    await createTempProfileContext(options);
+  try {
+    return await fn(browserContext);
+  } finally {
+    await browserContext.close();
+    await fs.promises.rm(userDataDir, { recursive: true, force: true });
+  }
+};
+
+export const createSharedContext = async (
+  options: { headless?: boolean } = {}
+) =>
+  createTempProfileContext({
+    prefix: 'chrome-profile-',
+    headless: options.headless,
+    seedFromCachedProfile: true,
+  });
+
 export const createUnauthContext = async (
   extensionPath: string,
   options: { headless?: boolean } = {}
-) => {
-  const userDataDir = await fs.promises.mkdtemp(
-    path.join(os.tmpdir(), 'chrome-unauth-profile-')
-  );
-  const browserContext = await launchExtensionContext({
-    userDataDir,
+) =>
+  createTempProfileContext({
+    prefix: 'chrome-unauth-profile-',
     extensionPath,
     headless: options.headless,
   });
-  return { browserContext, userDataDir };
-};
 
 export const createSharedBackgroundSW = async (
   sharedContext: BrowserContext

--- a/apps/extension/tests/fixtures/base-fixture.ts
+++ b/apps/extension/tests/fixtures/base-fixture.ts
@@ -99,8 +99,12 @@ export const withTempProfileContext = async <T>(
   try {
     return await fn(browserContext);
   } finally {
-    await browserContext.close();
-    await fs.promises.rm(userDataDir, { recursive: true, force: true });
+    // Nested so a rejecting close() still cannot skip the removal
+    try {
+      await browserContext.close();
+    } finally {
+      await fs.promises.rm(userDataDir, { recursive: true, force: true });
+    }
   }
 };
 

--- a/apps/extension/tests/fixtures/extension-fixture.ts
+++ b/apps/extension/tests/fixtures/extension-fixture.ts
@@ -1,7 +1,3 @@
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
-
 import {
   type Worker,
   test as base,
@@ -10,7 +6,7 @@ import {
 
 import {
   createSharedBackgroundSW,
-  launchExtensionContext,
+  withTempProfileContext,
 } from './base-fixture';
 
 export const test = base.extend<{
@@ -18,16 +14,13 @@ export const test = base.extend<{
   backgroundSW: Worker;
 }>({
   async context({}, use, testInfo) {
-    const userDataDir = await fs.promises.mkdtemp(
-      path.join(os.tmpdir(), 'chrome-profile-')
+    await withTempProfileContext(
+      {
+        prefix: 'chrome-profile-',
+        headless: testInfo.project.use?.headless ?? true,
+      },
+      async (browserContext) => use(browserContext)
     );
-    const browserContext = await launchExtensionContext({
-      userDataDir,
-      headless: testInfo.project.use?.headless ?? true,
-    });
-    await use(browserContext);
-    await browserContext.close();
-    await fs.promises.rm(userDataDir, { recursive: true, force: true });
   },
   async backgroundSW({ context }, use) {
     await use(await createSharedBackgroundSW(context));

--- a/apps/extension/tests/specs/background-lifecycle.spec.ts
+++ b/apps/extension/tests/specs/background-lifecycle.spec.ts
@@ -1,4 +1,4 @@
-import { EExtensionState } from '@/constants';
+import { EExtensionState, EXT_STORAGE_KEYS } from '@/constants';
 
 import { test, expect } from '../fixtures/background-fixture';
 
@@ -7,7 +7,9 @@ test.describe('Background Service Worker Lifecycle', () => {
     isolatedBackground,
   }) => {
     await expect
-      .poll(async () => isolatedBackground.readStorage<string>('extState'))
+      .poll(async () =>
+        isolatedBackground.readStorage<string>(EXT_STORAGE_KEYS.extState)
+      )
       .toBe(EExtensionState.ACTIVE);
   });
 });

--- a/apps/extension/tests/specs/background-lifecycle.spec.ts
+++ b/apps/extension/tests/specs/background-lifecycle.spec.ts
@@ -1,4 +1,4 @@
-import { EExtensionState, EXT_STORAGE_KEYS } from '@/constants';
+import { EExtensionState, EExtStorageKey } from '@/constants';
 
 import { test, expect } from '../fixtures/background-fixture';
 
@@ -8,7 +8,7 @@ test.describe('Background Service Worker Lifecycle', () => {
   }) => {
     await expect
       .poll(async () =>
-        isolatedBackground.readStorage<string>(EXT_STORAGE_KEYS.extState)
+        isolatedBackground.readStorage<string>(EExtStorageKey.EXT_STATE)
       )
       .toBe(EExtensionState.ACTIVE);
   });

--- a/apps/extension/tests/specs/background-navigation.spec.ts
+++ b/apps/extension/tests/specs/background-navigation.spec.ts
@@ -1,6 +1,8 @@
 import { TEST_SHORTCUTS } from '@bypass/shared/tests';
 import type { Page } from '@playwright/test';
 
+import { EXT_STORAGE_KEYS } from '@/constants';
+
 import { test, expect } from '../fixtures/background-fixture';
 
 const allInputsAutocompleteOff = async (page: Page) => {
@@ -47,7 +49,9 @@ test.describe.serial('Background Service Worker Navigation', () => {
 
       await expect
         .poll(async () =>
-          sharedBackground.readStorage<number>('historyStartTime')
+          sharedBackground.readStorage<number>(
+            EXT_STORAGE_KEYS.historyStartTime
+          )
         )
         .toBeDefined();
     } finally {
@@ -127,7 +131,9 @@ test.describe.serial('Background Service Worker Navigation', () => {
     try {
       await expect
         .poll(async () =>
-          sharedBackground.readStorage<number>('historyStartTime')
+          sharedBackground.readStorage<number>(
+            EXT_STORAGE_KEYS.historyStartTime
+          )
         )
         .toBe(existingHistoryStartTime);
     } finally {
@@ -145,8 +151,9 @@ test.describe.serial('Background Service Worker Navigation', () => {
     try {
       await expect.poll(() => page.url()).toContain('https://example.com');
 
-      const historyStartTime =
-        await sharedBackground.readStorage<number>('historyStartTime');
+      const historyStartTime = await sharedBackground.readStorage<number>(
+        EXT_STORAGE_KEYS.historyStartTime
+      );
       expect(historyStartTime).toBeUndefined();
     } finally {
       await page.close();
@@ -165,8 +172,9 @@ test.describe.serial('Background Service Worker Navigation', () => {
         .poll(() => page.url())
         .not.toContain('https://html5test.com');
 
-      const historyStartTime =
-        await sharedBackground.readStorage<number>('historyStartTime');
+      const historyStartTime = await sharedBackground.readStorage<number>(
+        EXT_STORAGE_KEYS.historyStartTime
+      );
       expect(historyStartTime).toBeUndefined();
     } finally {
       await page.close();
@@ -184,8 +192,9 @@ test.describe.serial('Background Service Worker Navigation', () => {
     try {
       await expect.poll(() => page.url()).toContain(extensionUrl);
 
-      const historyStartTime =
-        await sharedBackground.readStorage<number>('historyStartTime');
+      const historyStartTime = await sharedBackground.readStorage<number>(
+        EXT_STORAGE_KEYS.historyStartTime
+      );
       expect(historyStartTime).toBeUndefined();
     } finally {
       await page.close();
@@ -207,8 +216,9 @@ test.describe.serial('Background Service Worker Navigation', () => {
 
       await expect.poll(() => page.url()).toContain('https://example.com');
 
-      const historyStartTime =
-        await sharedBackground.readStorage<number>('historyStartTime');
+      const historyStartTime = await sharedBackground.readStorage<number>(
+        EXT_STORAGE_KEYS.historyStartTime
+      );
       expect(historyStartTime).toBeUndefined();
     } finally {
       await page.close();
@@ -236,8 +246,9 @@ test.describe.serial('Background Service Worker Navigation', () => {
       }
     }
 
-    const historyStartTime =
-      await sharedBackground.readStorage<number>('historyStartTime');
+    const historyStartTime = await sharedBackground.readStorage<number>(
+      EXT_STORAGE_KEYS.historyStartTime
+    );
     expect(historyStartTime).toBeUndefined();
   });
 

--- a/apps/extension/tests/specs/background-navigation.spec.ts
+++ b/apps/extension/tests/specs/background-navigation.spec.ts
@@ -1,7 +1,7 @@
 import { TEST_SHORTCUTS } from '@bypass/shared/tests';
 import type { Page } from '@playwright/test';
 
-import { EXT_STORAGE_KEYS } from '@/constants';
+import { EExtStorageKey } from '@/constants';
 
 import { test, expect } from '../fixtures/background-fixture';
 
@@ -50,7 +50,7 @@ test.describe.serial('Background Service Worker Navigation', () => {
       await expect
         .poll(async () =>
           sharedBackground.readStorage<number>(
-            EXT_STORAGE_KEYS.historyStartTime
+            EExtStorageKey.HISTORY_START_TIME
           )
         )
         .toBeDefined();
@@ -132,7 +132,7 @@ test.describe.serial('Background Service Worker Navigation', () => {
       await expect
         .poll(async () =>
           sharedBackground.readStorage<number>(
-            EXT_STORAGE_KEYS.historyStartTime
+            EExtStorageKey.HISTORY_START_TIME
           )
         )
         .toBe(existingHistoryStartTime);
@@ -152,7 +152,7 @@ test.describe.serial('Background Service Worker Navigation', () => {
       await expect.poll(() => page.url()).toContain('https://example.com');
 
       const historyStartTime = await sharedBackground.readStorage<number>(
-        EXT_STORAGE_KEYS.historyStartTime
+        EExtStorageKey.HISTORY_START_TIME
       );
       expect(historyStartTime).toBeUndefined();
     } finally {
@@ -173,7 +173,7 @@ test.describe.serial('Background Service Worker Navigation', () => {
         .not.toContain('https://html5test.com');
 
       const historyStartTime = await sharedBackground.readStorage<number>(
-        EXT_STORAGE_KEYS.historyStartTime
+        EExtStorageKey.HISTORY_START_TIME
       );
       expect(historyStartTime).toBeUndefined();
     } finally {
@@ -193,7 +193,7 @@ test.describe.serial('Background Service Worker Navigation', () => {
       await expect.poll(() => page.url()).toContain(extensionUrl);
 
       const historyStartTime = await sharedBackground.readStorage<number>(
-        EXT_STORAGE_KEYS.historyStartTime
+        EExtStorageKey.HISTORY_START_TIME
       );
       expect(historyStartTime).toBeUndefined();
     } finally {
@@ -217,7 +217,7 @@ test.describe.serial('Background Service Worker Navigation', () => {
       await expect.poll(() => page.url()).toContain('https://example.com');
 
       const historyStartTime = await sharedBackground.readStorage<number>(
-        EXT_STORAGE_KEYS.historyStartTime
+        EExtStorageKey.HISTORY_START_TIME
       );
       expect(historyStartTime).toBeUndefined();
     } finally {
@@ -247,7 +247,7 @@ test.describe.serial('Background Service Worker Navigation', () => {
     }
 
     const historyStartTime = await sharedBackground.readStorage<number>(
-      EXT_STORAGE_KEYS.historyStartTime
+      EExtStorageKey.HISTORY_START_TIME
     );
     expect(historyStartTime).toBeUndefined();
   });

--- a/apps/extension/tests/specs/home-popup.spec.ts
+++ b/apps/extension/tests/specs/home-popup.spec.ts
@@ -1,8 +1,10 @@
+import { POPUP_HOMEPAGE } from '@/constants';
+
 import { expect, test } from '../fixtures/extension-fixture';
 
 test.describe('Home Popup', () => {
   test('load extension', async ({ page }) => {
-    await page.goto('/popup.html');
+    await page.goto(POPUP_HOMEPAGE);
     // Content script loaded
     await expect(page.getByTestId('home-popup-heading')).toBeVisible();
   });

--- a/apps/extension/tests/specs/quick-bookmark-button.spec.ts
+++ b/apps/extension/tests/specs/quick-bookmark-button.spec.ts
@@ -1,3 +1,5 @@
+import { POPUP_HOMEPAGE } from '@/constants';
+
 import { test, expect as homeExpect } from '../fixtures/home-popup-fixture';
 
 /**
@@ -65,7 +67,7 @@ test.describe('Signed In', () => {
       .click();
 
     // Navigate back to home to prepare for next test
-    await homePage.goto('/popup.html');
+    await homePage.goto(POPUP_HOMEPAGE);
     await homePage.waitForLoadState('domcontentloaded');
 
     // Wait for button to show Unpin state (bookmark saved)
@@ -118,7 +120,7 @@ test.describe('Signed In', () => {
       .click();
 
     // Navigate back to home and verify it shows Pin again (unpinned)
-    await homePage.goto('/popup.html');
+    await homePage.goto(POPUP_HOMEPAGE);
     await homePage.waitForLoadState('domcontentloaded');
 
     // Wait for button state to stabilize (bookmark deleted)

--- a/apps/extension/tests/utils/bookmarks-panel.ts
+++ b/apps/extension/tests/utils/bookmarks-panel.ts
@@ -6,6 +6,7 @@ import {
   closeDialog,
   fillDialogInput,
   getBadgeCount as getBadgeCountUtil,
+  gotoPanel,
   navigateBack as navigateBackUtil,
   openDialog,
   openFolder,
@@ -23,13 +24,7 @@ export class BookmarksPanel {
   }
 
   async ensureAtRoot() {
-    await this.page.goto('/popup.html');
-    const bookmarksButton = this.page.getByRole('button', {
-      name: 'Bookmarks',
-    });
-    await expect(bookmarksButton).toBeVisible();
-    await bookmarksButton.click();
-    await expect(this.getSearchInput()).toBeVisible();
+    await gotoPanel(this.page, 'Bookmarks');
   }
 
   async openAddFolderDialog() {
@@ -167,11 +162,7 @@ export class BookmarksPanel {
   }
 
   async navigateToPersonsPanel() {
-    await this.page.goto('/popup.html');
-    const personsButton = this.page.getByRole('button', { name: 'Persons' });
-    await expect(personsButton).toBeVisible();
-    await personsButton.click();
-    await expect(this.page.getByPlaceholder('Search')).toBeVisible();
+    await gotoPanel(this.page, 'Persons');
   }
 
   // ============ Verification Helpers ============

--- a/apps/extension/tests/utils/home-panel.ts
+++ b/apps/extension/tests/utils/home-panel.ts
@@ -1,5 +1,7 @@
 import { expect, type Page } from '@playwright/test';
 
+import { EXT_STORAGE_KEYS } from '@/constants';
+
 import { getStorageItem } from './test-utils';
 
 export class PopupHomePanel {
@@ -32,7 +34,7 @@ export class PopupHomePanel {
   async verifyHistoryStartTime() {
     const historyStartTime = await getStorageItem<number>(
       this.page,
-      'historyStartTime'
+      EXT_STORAGE_KEYS.historyStartTime
     );
     expect(historyStartTime).toBeDefined();
     return historyStartTime;
@@ -41,7 +43,7 @@ export class PopupHomePanel {
   async verifyHistoryStartTimeNotExists() {
     const historyStartTime = await getStorageItem<number>(
       this.page,
-      'historyStartTime'
+      EXT_STORAGE_KEYS.historyStartTime
     );
     expect(historyStartTime).toBeUndefined();
   }

--- a/apps/extension/tests/utils/home-panel.ts
+++ b/apps/extension/tests/utils/home-panel.ts
@@ -1,6 +1,6 @@
 import { expect, type Page } from '@playwright/test';
 
-import { EXT_STORAGE_KEYS } from '@/constants';
+import { EExtStorageKey } from '@/constants';
 
 import { getStorageItem } from './test-utils';
 
@@ -34,7 +34,7 @@ export class PopupHomePanel {
   async verifyHistoryStartTime() {
     const historyStartTime = await getStorageItem<number>(
       this.page,
-      EXT_STORAGE_KEYS.historyStartTime
+      EExtStorageKey.HISTORY_START_TIME
     );
     expect(historyStartTime).toBeDefined();
     return historyStartTime;
@@ -43,7 +43,7 @@ export class PopupHomePanel {
   async verifyHistoryStartTimeNotExists() {
     const historyStartTime = await getStorageItem<number>(
       this.page,
-      EXT_STORAGE_KEYS.historyStartTime
+      EExtStorageKey.HISTORY_START_TIME
     );
     expect(historyStartTime).toBeUndefined();
   }

--- a/apps/extension/tests/utils/persons-panel.ts
+++ b/apps/extension/tests/utils/persons-panel.ts
@@ -5,8 +5,9 @@ import {
   clickContextMenuItem,
   closeDialog,
   fillDialogInput,
-  getNumericBadgeValue,
   getBadgeCount,
+  getHeaderPersonCount,
+  gotoPanel,
   navigateBack,
   openDialog,
 } from './test-utils';
@@ -152,11 +153,7 @@ export class PersonsPanel {
   }
 
   async ensureAtRoot() {
-    await this.page.goto('/popup.html');
-    const personsButton = this.page.getByRole('button', { name: 'Persons' });
-    await expect(personsButton).toBeVisible();
-    await personsButton.click();
-    await expect(this.page.getByPlaceholder('Search')).toBeVisible();
+    await gotoPanel(this.page, 'Persons');
     // Wait for at least one person to be visible
     await expect(
       this.page.locator('[data-testid^="person-item-"]').first()
@@ -220,9 +217,7 @@ export class PersonsPanel {
   }
 
   async getHeaderPersonCount(): Promise<number> {
-    return getNumericBadgeValue(this.page, 'header-badge', {
-      fallbackToAnyNumber: true,
-    });
+    return getHeaderPersonCount(this.page);
   }
 
   async verifyBadgeVisible(badgeName: string) {

--- a/apps/extension/tests/utils/test-utils.ts
+++ b/apps/extension/tests/utils/test-utils.ts
@@ -1,7 +1,23 @@
 import { parseBadgeCount } from '@bypass/shared/tests';
 import { expect, type Page } from '@playwright/test';
 
+import { POPUP_HOMEPAGE } from '@/constants';
+
 // Re-export shared utilities for convenience
+
+/**
+ * Go to the popup root and open a panel from it.
+ */
+export const gotoPanel = async (
+  page: Page,
+  panelName: 'Bookmarks' | 'Persons' | 'Shortcuts'
+) => {
+  await page.goto(POPUP_HOMEPAGE);
+  const panelButton = page.getByRole('button', { name: panelName });
+  await expect(panelButton).toBeVisible();
+  await panelButton.click();
+  await expect(page.getByPlaceholder('Search')).toBeVisible();
+};
 
 /**
  * Navigate back from current folder or panel.
@@ -112,6 +128,7 @@ export {
   closeDialog,
   clearSearchInput,
   fillSearchInput,
+  getHeaderPersonCount,
   getNumericBadgeValue,
   parseBadgeCount,
 } from '@bypass/shared/tests';

--- a/apps/extension/tests/utils/test-utils.ts
+++ b/apps/extension/tests/utils/test-utils.ts
@@ -5,9 +5,6 @@ import { POPUP_HOMEPAGE } from '@/constants';
 
 // Re-export shared utilities for convenience
 
-/**
- * Go to the popup root and open a panel from it.
- */
 export const gotoPanel = async (
   page: Page,
   panelName: 'Bookmarks' | 'Persons' | 'Shortcuts'

--- a/apps/web/src/app/persons-panel/hooks/usePreloadPerson.ts
+++ b/apps/web/src/app/persons-panel/hooks/usePreloadPerson.ts
@@ -1,10 +1,9 @@
 import {
   ECacheBucketKeys,
-  addAllToCache,
-  type PersonImageUrls,
+  buildPersonImageUrls,
+  cachePersonImages,
   STORAGE_KEYS,
   deleteCache,
-  getPersonImageName,
   isCachePresent,
   usePerson,
 } from '@bypass/shared';
@@ -17,15 +16,6 @@ import {
   removeFromLocalStorage,
   setToLocalStorage,
 } from '@app/utils/storage';
-
-const cachePersonImages = async (personImageUrls: PersonImageUrls) => {
-  if (!personImageUrls) {
-    console.log('Unable to cache person images since no person urls');
-    return;
-  }
-  const imageUrls = Object.values(personImageUrls);
-  await addAllToCache(ECacheBucketKeys.person, imageUrls);
-};
 
 const syncPersonsToStorage = async () => {
   if (isExistsInLocalStorage(STORAGE_KEYS.persons)) {
@@ -49,22 +39,9 @@ const usePreloadPerson = () => {
       return;
     }
     const persons = await getAllDecodedPersons();
-    const personImagesList = await Promise.all(
-      persons.map(async (person) => {
-        return {
-          uid: person.uid,
-          imageUrl: await api.storage.getDownloadUrl.query(
-            getPersonImageName(person.uid)
-          ),
-        };
-      })
-    );
-    const personImageUrls = personImagesList.reduce<PersonImageUrls>(
-      (obj, { uid, imageUrl }) => {
-        obj[uid] = imageUrl;
-        return obj;
-      },
-      {}
+    const personImageUrls = await buildPersonImageUrls(
+      persons.map((person) => person.uid),
+      async (fileName) => api.storage.getDownloadUrl.query(fileName)
     );
     setToLocalStorage(STORAGE_KEYS.personImageUrls, personImageUrls);
     await cachePersonImages(personImageUrls);

--- a/apps/web/src/app/persons-panel/page.tsx
+++ b/apps/web/src/app/persons-panel/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import {
-  getDecryptedPerson,
+  decodePersons,
   getFilteredPersons,
   Header,
   type IPerson,
@@ -33,10 +33,9 @@ function PersonsPage() {
     if (!storedPersons) {
       return;
     }
-    const decryptedPersons = Object.values(storedPersons || {}).map((x) =>
-      getDecryptedPerson(x)
+    const alphabeticallySorted = sortAlphabetically(
+      decodePersons(storedPersons)
     );
-    const alphabeticallySorted = sortAlphabetically(decryptedPersons);
     // oxlint-disable-next-line react/react-compiler
     setPersons(alphabeticallySorted);
   }, []);

--- a/apps/web/tests/auth.setup.ts
+++ b/apps/web/tests/auth.setup.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 
-import { TEST_TIMEOUTS } from '@bypass/shared/tests';
+import { dumpLocalStorage, TEST_TIMEOUTS } from '@bypass/shared/tests';
 import { chromium, expect, test as setup } from '@playwright/test';
 
 import { TEST_CREDENTIALS_KEY } from '../src/app/constants';
@@ -67,16 +67,7 @@ setup('authenticate and cache web storage', async ({}, testInfo) => {
     { timeout: TEST_TIMEOUTS.AUTH }
   );
 
-  const localStorageData = await page.evaluate(() => {
-    const data: Record<string, string> = {};
-    for (let i = 0; i < window.localStorage.length; i++) {
-      const key = window.localStorage.key(i);
-      if (key) {
-        data[key] = window.localStorage.getItem(key) ?? '';
-      }
-    }
-    return data;
-  });
+  const localStorageData = await dumpLocalStorage(page);
 
   const cookies = await browserContext.cookies();
 

--- a/apps/web/tests/fixtures/base-fixture.ts
+++ b/apps/web/tests/fixtures/base-fixture.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { injectLocalStorage } from '@bypass/shared/tests';
 import { chromium, type BrowserContext, type Cookie } from '@playwright/test';
 
 import { AUTH_CACHE_DIR, WEB_STORAGE_PATH } from '../auth-constants';
@@ -31,15 +32,7 @@ export const createSharedContext = async (): Promise<{
   });
 
   // Inject cached localStorage data
-  await browserContext.addInitScript(
-    ({ storageJson }) => {
-      const data = JSON.parse(storageJson) as Record<string, string>;
-      for (const [key, value] of Object.entries(data)) {
-        window.localStorage.setItem(key, value);
-      }
-    },
-    { storageJson: JSON.stringify(storageData.localStorage) }
-  );
+  await injectLocalStorage(browserContext, storageData.localStorage);
 
   // Add cached cookies
   await browserContext.addCookies(storageData.cookies);

--- a/apps/web/tests/page-object-models/persons-panel.ts
+++ b/apps/web/tests/page-object-models/persons-panel.ts
@@ -1,5 +1,5 @@
 import {
-  getNumericBadgeValue,
+  getHeaderPersonCount,
   parseBadgeCount,
   verifyModalClosed,
   verifyModalVisible,
@@ -16,9 +16,7 @@ export class PersonsPanel {
   }
 
   async getHeaderPersonCount(): Promise<number> {
-    return getNumericBadgeValue(this.page, 'header-badge', {
-      fallbackToAnyNumber: true,
-    });
+    return getHeaderPersonCount(this.page);
   }
 
   async verifyPersonExists(name: string) {

--- a/packages/shared/src/components/Persons/utils/index.ts
+++ b/packages/shared/src/components/Persons/utils/index.ts
@@ -1,6 +1,12 @@
+import { ECacheBucketKeys } from '../../../constants/cache';
+import { addAllToCache } from '../../../utils/cache';
 import { hasText } from '../../../utils/search';
 import { type IEncodedBookmark } from '../../Bookmarks/interfaces';
-import { type IPerson, type IPersons } from '../interfaces/persons';
+import {
+  type IPerson,
+  type IPersons,
+  type PersonImageUrls,
+} from '../interfaces/persons';
 
 export const getDecryptedPerson = (person: IPerson): IPerson => {
   return {
@@ -51,3 +57,29 @@ export const getFilteredPersons = (persons: IPerson[], searchText: string) =>
 export const getColumnCount = (isMobile: boolean) => (isMobile ? 3 : 5);
 
 export const getPersonImageName = (uid: string) => `${uid}.jpeg`;
+
+/**
+ * Resolve a download url per person uid. Parameterised on the resolver so both
+ * apps can pass their own tRPC client.
+ */
+export const buildPersonImageUrls = async (
+  uids: string[],
+  getDownloadUrl: (fileName: string) => Promise<string>
+): Promise<PersonImageUrls> =>
+  Object.fromEntries(
+    await Promise.all(
+      uids.map(async (uid) => [
+        uid,
+        await getDownloadUrl(getPersonImageName(uid)),
+      ])
+    )
+  );
+
+export const cachePersonImages = async (personImageUrls: PersonImageUrls) => {
+  if (!personImageUrls) {
+    console.log('Unable to cache person images since no person urls');
+    return;
+  }
+  await addAllToCache(ECacheBucketKeys.person, Object.values(personImageUrls));
+  console.log('Initialized cache for all person urls');
+};

--- a/packages/shared/src/components/Persons/utils/index.ts
+++ b/packages/shared/src/components/Persons/utils/index.ts
@@ -58,10 +58,7 @@ export const getColumnCount = (isMobile: boolean) => (isMobile ? 3 : 5);
 
 export const getPersonImageName = (uid: string) => `${uid}.jpeg`;
 
-/**
- * Resolve a download url per person uid. Parameterised on the resolver so both
- * apps can pass their own tRPC client.
- */
+/** Parameterised on the resolver so each app can pass its own tRPC client. */
 export const buildPersonImageUrls = async (
   uids: string[],
   getDownloadUrl: (fileName: string) => Promise<string>

--- a/packages/shared/src/utils/test-helpers.ts
+++ b/packages/shared/src/utils/test-helpers.ts
@@ -8,6 +8,53 @@ import {
 type TestIdScope = Pick<Page, 'getByTestId'>;
 
 /**
+ * Snapshot every localStorage entry of the current page.
+ */
+export const dumpLocalStorage = async (
+  page: Page,
+  options?: { omitKeys?: string[] }
+): Promise<Record<string, string>> => {
+  const data = await page.evaluate(() => {
+    const entries: Record<string, string> = {};
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const key = window.localStorage.key(i);
+      if (key) {
+        entries[key] = window.localStorage.getItem(key) ?? '';
+      }
+    }
+    return entries;
+  });
+
+  for (const key of options?.omitKeys ?? []) {
+    delete data[key];
+  }
+  return data;
+};
+
+/**
+ * Replay a localStorage snapshot into every page of a context, before any page
+ * script runs. `clearKeys` are removed after seeding.
+ */
+export const injectLocalStorage = async (
+  context: BrowserContext,
+  data: Record<string, string>,
+  options?: { clearKeys?: string[] }
+) => {
+  await context.addInitScript(
+    ({ storageJson, clearKeys }) => {
+      const entries = JSON.parse(storageJson) as Record<string, string>;
+      for (const [key, value] of Object.entries(entries)) {
+        window.localStorage.setItem(key, value);
+      }
+      for (const key of clearKeys) {
+        window.localStorage.removeItem(key);
+      }
+    },
+    { storageJson: JSON.stringify(data), clearKeys: options?.clearKeys ?? [] }
+  );
+};
+
+/**
  * Close a shadcn dialog using the close button or Escape key.
  * This is the unified pattern for closing dialogs after Mantine migration.
  */
@@ -105,6 +152,14 @@ export const getNumericBadgeValue = async (
   const firstNumberMatch = /\b(\d+)\b/.exec(text);
   return firstNumberMatch ? Number.parseInt(firstNumberMatch[1], 10) : 0;
 };
+
+/**
+ * Read the person count from the panel header badge.
+ */
+export const getHeaderPersonCount = async (
+  scope: TestIdScope
+): Promise<number> =>
+  getNumericBadgeValue(scope, 'header-badge', { fallbackToAnyNumber: true });
 
 /**
  * Click the first person avatar in a dropdown and return person name.

--- a/packages/shared/src/utils/test-helpers.ts
+++ b/packages/shared/src/utils/test-helpers.ts
@@ -7,9 +7,6 @@ import {
 
 type TestIdScope = Pick<Page, 'getByTestId'>;
 
-/**
- * Snapshot every localStorage entry of the current page.
- */
 export const dumpLocalStorage = async (
   page: Page,
   options?: { omitKeys?: string[] }
@@ -31,10 +28,7 @@ export const dumpLocalStorage = async (
   return data;
 };
 
-/**
- * Replay a localStorage snapshot into every page of a context, before any page
- * script runs. `clearKeys` are removed after seeding.
- */
+/** Seeds localStorage before any page script runs; `clearKeys` are dropped after. */
 export const injectLocalStorage = async (
   context: BrowserContext,
   data: Record<string, string>,
@@ -153,9 +147,6 @@ export const getNumericBadgeValue = async (
   return firstNumberMatch ? Number.parseInt(firstNumberMatch[1], 10) : 0;
 };
 
-/**
- * Read the person count from the panel header badge.
- */
 export const getHeaderPersonCount = async (
   scope: TestIdScope
 ): Promise<number> =>


### PR DESCRIPTION
Seven duplicated mechanisms, each collapsed to one implementation. Mostly mechanical, but two items have real traps — see below.

- **3a Storage keys** had two independent sources of truth: `storage/items.ts` hardcoded `'local:bookmarks'`… while `STORAGE_KEYS` owned the same seven names, and shared code reads that namespace through `DynamicProvider`. Renaming one side would silently make shared components read an empty bucket. Items now derive from `STORAGE_KEYS`, and the four extension-only keys get `EXT_STORAGE_KEYS`/`ICON_KEYS`.
- **3b** Both persons panels inlined the decode loop instead of calling `decodePersons`, skipping its `.filter(Boolean)` — one null entry in the record would throw inside `atob`.
- **3c** Shared `dumpLocalStorage`/`injectLocalStorage` replace four copies that had already drifted (only one cleared `OUTDATED_EXT_CHECK`). Both strip sites are covered. Also moved the byte-identical `getHeaderPersonCount` into the shared helpers.
- **3e** One `withTempProfileContext` replaces five hand-rolled `mkdtemp`/launch/close/rm sequences. `extension-fixture` had no `try/finally`, so a launch failure leaked a profile dir.
- **3f** One `gotoPanel(page, panel)` on `POPUP_HOMEPAGE` replaces three copies and six hardcoded `'/popup.html'`.
- **3g** Shared `buildPersonImageUrls` + `cachePersonImages` replace per-app copies that had drifted three ways.

### Worth a reviewer's eye

**3a — where the consts live matters.** They are in `constants/index.ts`, *not* `storage/items.ts`. `items.ts` calls `storage.defineItem` at import time, which touches `browser.runtime`, so importing it from a Playwright Node worker dies immediately. No test imports it today, which is the only reason the suite is green; 3a would have had every background fixture import it.

**3d — this is why only the mapper is shared.** Importing `identityApi`/`mapAuthResponse` from `store/firebase/api.ts` would execute `import.meta.env` at module scope (in `api.ts` and transitively `constants/env.ts`) inside Playwright's Node runner — killing `extension-setup` and therefore every extension spec. Worse, shimming it would silently select the **dev** Firebase project in CI, where `auth.setup` deliberately picks prod. So the mapper moved to the pure `store/firebase/utils.ts` (verified: zero runtime imports) and the 3-line wretch client stays duplicated, because its API-key source genuinely differs.

### Verification

`pnpm lint`, `pnpm format:check`, `pnpm typecheck:all` clean. All 91 Playwright tests across 19 files still resolve (`playwright test --list`) — this is the check that catches fixture-wiring breakage, since 3c/3e/3f rewrote shared fixtures.

---
### Stack

This is part of a 5-PR stack from a repo-wide `/simplify` pass. Merge in order — each PR is based on the previous one.

1. #4135 — dead code and trivial collapses
2. #4136 — single-use wrappers and helper reuse
3. #4137 — collapse duplicated mechanisms
4. #4138 — derivable state
5. #4139 — wasted work on hot paths

Every commit passes `pnpm lint`, `pnpm format:check`, `pnpm typecheck:all`, and all 91 Playwright tests still resolve.

A sixth PR (wrong-altitude fixes) was closed and dropped from the stack; its work is unshipped on `cleanup/batch-6-altitude`.

The extension minor version is bumped to `25.4.0` in #4135, the bottom of the stack, so it lands once for the whole series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

 

<details><summary><h3>Greptile Summary</h3></summary>

The PR consolidates duplicated storage keys, person decoding and image caching, authentication mapping, popup navigation, local-storage test helpers, and temporary-profile fixture setup.
- Centralizes extension and shared storage-key definitions.
- Reuses shared person decoding, image URL construction, and cache population.
- Introduces common Playwright storage, navigation, and profile-context helpers.
- Moves Firebase response mapping into a Node-safe utility.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because a browser-context close failure can still leak the shared extension fixture’s temporary profile.

The launch-failure path now removes its temporary directory, but sharedExtensionTest still awaits browserContext.close() before rm without a nested finally, leaving the previously reported teardown leak reachable when close rejects.

**Files Needing Attention:** apps/extension/tests/fixtures/base-fixture.ts
</details>

<sub>Reviews (8): Last reviewed commit: ["fix: guarantee temp profile removal, and..."](https://github.com/amitsingh-007/bypass-links/commit/e7c76ce5a5680a386c4d42b07acc594d75f17f26) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50447310)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Extension background service worker](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/extension-background.md)
- Knowledge Base — [Extension Popup UI](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/extension-popup.md)
- Knowledge Base — [Web App (apps/web)](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/web-app.md)
- Knowledge Base — [Shared package (`packages/shared`)](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/shared-package.md)
</details>

<!-- /greptile_comment -->