### PR TITLE
perf: stop repeating work on hot paths (5/5)

### DIFF
--- a/apps/extension/src/entrypoints/background/index.ts
+++ b/apps/extension/src/entrypoints/background/index.ts
@@ -18,10 +18,8 @@ const onPageLoad = async (tabId: number, url: string) => {
   if (!isValidUrl(url)) {
     return;
   }
-  // The extState read and the tab read are independent; the previous code also
-  // called isValidTabUrl twice, but nothing is awaited between the two checks
-  // (redirect is fire-and-forget), so the second tabs.get could never observe a
-  // newer url. One live check before acting is what the guard was for.
+  // Independent reads. One live url check is enough: redirect is fire-and-forget,
+  // so the second tabs.get this replaced could never observe a newer url.
   const [extState, tab] = await Promise.all([
     extStateItem.getValue(),
     browser.tabs.get(tabId),

--- a/apps/extension/src/entrypoints/background/index.ts
+++ b/apps/extension/src/entrypoints/background/index.ts
@@ -11,25 +11,27 @@ import { type RuntimeInput } from '@/utils/sendRuntimeMessage';
 
 import turnOffInputSuggestions from './misc/turnOffInputSuggestions';
 import { redirect } from './redirections';
-import { isValidTabUrl, isValidUrl, setExtensionIcon } from './utils';
+import { isValidUrl, setExtensionIcon } from './utils';
 import { receiveRuntimeMessage } from './utils/receiveRuntimeMessage';
 
 const onPageLoad = async (tabId: number, url: string) => {
   if (!isValidUrl(url)) {
     return;
   }
-  const extState = await extStateItem.getValue();
-  if (!getIsExtensionActive(extState)) {
+  // The extState read and the tab read are independent; the previous code also
+  // called isValidTabUrl twice, but nothing is awaited between the two checks
+  // (redirect is fire-and-forget), so the second tabs.get could never observe a
+  // newer url. One live check before acting is what the guard was for.
+  const [extState, tab] = await Promise.all([
+    extStateItem.getValue(),
+    browser.tabs.get(tabId),
+  ]);
+  if (!getIsExtensionActive(extState) || !isValidUrl(tab.url)) {
     return;
   }
 
-  // Below if() checks avoid the scenario where url changes after the page is loaded
-  if (await isValidTabUrl(tabId)) {
-    redirect(tabId, new URL(url));
-  }
-  if (await isValidTabUrl(tabId)) {
-    turnOffInputSuggestions(tabId);
-  }
+  redirect(tabId, new URL(url));
+  turnOffInputSuggestions(tabId);
 };
 
 const isMainFrame = (frameId: number) => frameId === 0;

--- a/apps/extension/src/entrypoints/background/index.ts
+++ b/apps/extension/src/entrypoints/background/index.ts
@@ -18,8 +18,6 @@ const onPageLoad = async (tabId: number, url: string) => {
   if (!isValidUrl(url)) {
     return;
   }
-  // Independent reads. One live url check is enough: redirect is fire-and-forget,
-  // so the second tabs.get this replaced could never observe a newer url.
   const [extState, tab] = await Promise.all([
     extStateItem.getValue(),
     browser.tabs.get(tabId),

--- a/apps/extension/src/entrypoints/background/redirections/index.ts
+++ b/apps/extension/src/entrypoints/background/redirections/index.ts
@@ -17,12 +17,15 @@ export const redirect = async (tabId: number, url: URL) => {
 
 export const syncRedirectionsToStorage = async () => {
   const redirections = await trpcApi.firebaseData.redirectionsGet.query();
-  await redirectionsItem.setValue(redirections);
-  const mappedRedirections = mapRedirections(redirections);
-  await mappedRedirectionsItem.setValue(mappedRedirections);
+  await Promise.all([
+    redirectionsItem.setValue(redirections),
+    mappedRedirectionsItem.setValue(mapRedirections(redirections)),
+  ]);
 };
 
 export const resetRedirections = async () => {
-  await redirectionsItem.removeValue();
-  await mappedRedirectionsItem.removeValue();
+  await Promise.all([
+    redirectionsItem.removeValue(),
+    mappedRedirectionsItem.removeValue(),
+  ]);
 };

--- a/apps/extension/src/entrypoints/popup/hooks/usePersonsWithImages.ts
+++ b/apps/extension/src/entrypoints/popup/hooks/usePersonsWithImages.ts
@@ -6,15 +6,12 @@ import {
 } from '@bypass/shared';
 import useSWR from 'swr';
 
-/**
- * Sorts the shared all-persons entry; ordering is applied here so the shared
- * cache key stays stable across orderings.
- */
+/** Sorts here rather than in the fetcher, so the shared cache key stays stable. */
 const usePersonsWithImages = (orderByRecency: boolean) => {
   const { getDefaultOrRootFolderUrls } = useBookmark();
   const { data: personsWithImageUrl = [], ...rest } = useAllPersonsWithImages();
-  // `= []` matters: sortByRecency iterates urls unguarded, and this hook renders
-  // in the bookmark edit dialog where the persons panel never mounted
+  // `= []` is load-bearing: sortByRecency iterates urls unguarded, and this also
+  // renders in the bookmark edit dialog, where nothing else populates this key
   const { data: urls = [] } = useSWR(
     'default-folder-urls',
     getDefaultOrRootFolderUrls

--- a/apps/extension/src/entrypoints/popup/hooks/usePersonsWithImages.ts
+++ b/apps/extension/src/entrypoints/popup/hooks/usePersonsWithImages.ts
@@ -10,8 +10,6 @@ import useSWR from 'swr';
 const usePersonsWithImages = (orderByRecency: boolean) => {
   const { getDefaultOrRootFolderUrls } = useBookmark();
   const { data: personsWithImageUrl = [], ...rest } = useAllPersonsWithImages();
-  // `= []` is load-bearing: sortByRecency iterates urls unguarded, and this also
-  // renders in the bookmark edit dialog, where nothing else populates this key
   const { data: urls = [] } = useSWR(
     'default-folder-urls',
     getDefaultOrRootFolderUrls

--- a/apps/extension/src/entrypoints/popup/hooks/usePersonsWithImages.ts
+++ b/apps/extension/src/entrypoints/popup/hooks/usePersonsWithImages.ts
@@ -1,24 +1,30 @@
 import {
   sortAlphabetically,
   sortByRecency,
+  useAllPersonsWithImages,
   useBookmark,
-  usePerson,
 } from '@bypass/shared';
 import useSWR from 'swr';
 
+/**
+ * Sorts the shared all-persons entry; ordering is applied here so the shared
+ * cache key stays stable across orderings.
+ */
 const usePersonsWithImages = (orderByRecency: boolean) => {
-  const { getAllDecodedPersons, getPersonsWithImageUrl } = usePerson();
   const { getDefaultOrRootFolderUrls } = useBookmark();
+  const { data: personsWithImageUrl = [], ...rest } = useAllPersonsWithImages();
+  // `= []` matters: sortByRecency iterates urls unguarded, and this hook renders
+  // in the bookmark edit dialog where the persons panel never mounted
+  const { data: urls = [] } = useSWR(
+    'default-folder-urls',
+    getDefaultOrRootFolderUrls
+  );
 
-  return useSWR(['persons-with-images', orderByRecency], async () => {
-    const decodedPersons = await getAllDecodedPersons();
-    const urls = await getDefaultOrRootFolderUrls();
-    const personsWithImageUrl = await getPersonsWithImageUrl(decodedPersons);
+  const data = orderByRecency
+    ? sortByRecency(personsWithImageUrl, urls)
+    : sortAlphabetically(personsWithImageUrl);
 
-    return orderByRecency
-      ? sortByRecency(personsWithImageUrl, urls)
-      : sortAlphabetically(personsWithImageUrl);
-  });
+  return { ...rest, data };
 };
 
 export default usePersonsWithImages;

--- a/apps/extension/src/entrypoints/popup/hooks/usePersonsWithImages.ts
+++ b/apps/extension/src/entrypoints/popup/hooks/usePersonsWithImages.ts
@@ -6,7 +6,6 @@ import {
 } from '@bypass/shared';
 import useSWR from 'swr';
 
-/** Sorts here rather than in the fetcher, so the shared cache key stays stable. */
 const usePersonsWithImages = (orderByRecency: boolean) => {
   const { getDefaultOrRootFolderUrls } = useBookmark();
   const { data: personsWithImageUrl = [], ...rest } = useAllPersonsWithImages();

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/PersonSelect.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/PersonSelect.tsx
@@ -78,7 +78,7 @@ function PersonSelect({ value, onChange }: PersonSelectProps) {
   const [orderByRecency, setOrderByRecency] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
   const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
-  const { data: persons = [] } = usePersonsWithImages(orderByRecency);
+  const { data: persons } = usePersonsWithImages(orderByRecency);
 
   const personList = persons.map<IOptionData>(({ imageUrl, name, uid }) => ({
     label: name,

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/utils/bookmark.ts
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/utils/bookmark.ts
@@ -1,7 +1,6 @@
 import {
   ECacheBucketKeys,
   addAllToCache,
-  getDecryptedBookmark,
   getBookmarkFaviconUrls,
   getGoogleFaviconUrl,
   type ContextBookmarks,
@@ -26,27 +25,35 @@ export const syncBookmarksToStorage = async () => {
 };
 
 export const syncBookmarksAndPersonsFirebaseWithStorage = async () => {
-  const hasPendingBookmarks = await hasPendingBookmarksItem.getValue();
-  const hasPendingPersons = await hasPendingPersonsItem.getValue();
+  const [hasPendingBookmarks, hasPendingPersons] = await Promise.all([
+    hasPendingBookmarksItem.getValue(),
+    hasPendingPersonsItem.getValue(),
+  ]);
   if (!hasPendingBookmarks && !hasPendingPersons) {
     return;
   }
-  const bookmarks = await bookmarksItem.getValue();
-  const persons = await personsItem.getValue();
+  const [bookmarks, persons] = await Promise.all([
+    bookmarksItem.getValue(),
+    personsItem.getValue(),
+  ]);
   const isSaveSuccess = await trpcApi.firebaseData.bookmarkAndPersonSave.mutate(
     { bookmarks, persons }
   );
   if (isSaveSuccess) {
-    await hasPendingBookmarksItem.removeValue();
-    await hasPendingPersonsItem.removeValue();
+    await Promise.all([
+      hasPendingBookmarksItem.removeValue(),
+      hasPendingPersonsItem.removeValue(),
+    ]);
   } else {
     throw new Error('Error while syncing bookmarks from storage to firebase');
   }
 };
 
 export const resetBookmarks = async () => {
-  await bookmarksItem.removeValue();
-  await hasPendingBookmarksItem.removeValue();
+  await Promise.all([
+    bookmarksItem.removeValue(),
+    hasPendingBookmarksItem.removeValue(),
+  ]);
 };
 
 export const cacheBookmarkFavicons = async () => {
@@ -75,8 +82,11 @@ export const findBookmarkById = (
 export const findBookmarkByUrl = (
   urlList: IBookmarksObj['urlList'],
   url: string
-) =>
-  Object.values(urlList).find((encodedBookmark) => {
-    const bookmark = getDecryptedBookmark(encodedBookmark);
-    return bookmark.url === url;
-  });
+) => {
+  // Encode the needle once rather than decrypting every stored bookmark; this is
+  // the exact inverse of getEncryptedBookmark, which is the only encoder
+  const encodedUrl = btoa(encodeURIComponent(url));
+  return Object.values(urlList).find(
+    (encodedBookmark) => encodedBookmark.url === encodedUrl
+  );
+};

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/utils/bookmark.ts
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/utils/bookmark.ts
@@ -1,6 +1,7 @@
 import {
   ECacheBucketKeys,
   addAllToCache,
+  encodeBookmarkField,
   getBookmarkFaviconUrls,
   getGoogleFaviconUrl,
   type ContextBookmarks,
@@ -83,9 +84,9 @@ export const findBookmarkByUrl = (
   urlList: IBookmarksObj['urlList'],
   url: string
 ) => {
-  // Encode the needle once rather than decrypting every stored bookmark; this is
-  // the exact inverse of getEncryptedBookmark, which is the only encoder
-  const encodedUrl = btoa(encodeURIComponent(url));
+  // Encode the needle once rather than decrypting every stored bookmark, using
+  // the same encoder getEncryptedBookmark writes with so they cannot diverge
+  const encodedUrl = encodeBookmarkField(url);
   return Object.values(urlList).find(
     (encodedBookmark) => encodedBookmark.url === encodedUrl
   );

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/utils/bookmark.ts
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/utils/bookmark.ts
@@ -84,7 +84,6 @@ export const findBookmarkByUrl = (
   urlList: IBookmarksObj['urlList'],
   url: string
 ) => {
-  // Encode the needle once instead of decrypting every stored bookmark
   const encodedUrl = encodeBookmarkField(url);
   return Object.values(urlList).find(
     (encodedBookmark) => encodedBookmark.url === encodedUrl

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/utils/bookmark.ts
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/utils/bookmark.ts
@@ -84,8 +84,7 @@ export const findBookmarkByUrl = (
   urlList: IBookmarksObj['urlList'],
   url: string
 ) => {
-  // Encode the needle once rather than decrypting every stored bookmark, using
-  // the same encoder getEncryptedBookmark writes with so they cannot diverge
+  // Encode the needle once instead of decrypting every stored bookmark
   const encodedUrl = encodeBookmarkField(url);
   return Object.values(urlList).find(
     (encodedBookmark) => encodedBookmark.url === encodedUrl

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/utils/index.ts
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/utils/index.ts
@@ -11,6 +11,8 @@ export const countTruthy = (bookmarks: ISelectedBookmarks) =>
   bookmarks.filter(Boolean).length;
 
 export const setBookmarksInStorage = async (bookmarksObj: IBookmarksObj) => {
-  await bookmarksItem.setValue(bookmarksObj);
-  await hasPendingBookmarksItem.setValue(true);
+  await Promise.all([
+    bookmarksItem.setValue(bookmarksObj),
+    hasPendingBookmarksItem.setValue(true),
+  ]);
 };

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/PersonsPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/PersonsPanel.tsx
@@ -30,6 +30,7 @@ import {
 } from '../utils';
 import {
   invalidatePersonCaches,
+  removePersonImageUrl,
   updatePersonCacheAndImageUrls,
 } from '../utils/sync';
 import PersonHeader from './PersonHeader';
@@ -109,6 +110,7 @@ function PersonsPanel() {
     newPersons.splice(pos, 1);
     setPersons(newPersons);
     await trpcApi.storage.removeFile.mutate(getPersonImageName(person.uid));
+    await removePersonImageUrl(person.uid);
     await handleSave(newPersons);
     await invalidatePersonCaches();
     setIsFetching(false);

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/PersonsPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/PersonsPanel.tsx
@@ -28,7 +28,10 @@ import {
   getPersonPos,
   setPersonsInStorage,
 } from '../utils';
-import { updatePersonCacheAndImageUrls } from '../utils/sync';
+import {
+  invalidatePersonCaches,
+  updatePersonCacheAndImageUrls,
+} from '../utils/sync';
 import PersonHeader from './PersonHeader';
 import PersonVirtualCell from './PersonVirtualCell';
 
@@ -107,6 +110,7 @@ function PersonsPanel() {
     setPersons(newPersons);
     await trpcApi.storage.removeFile.mutate(getPersonImageName(person.uid));
     await handleSave(newPersons);
+    await invalidatePersonCaches();
     setIsFetching(false);
     toast.success('Person deleted successfully');
   };

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/utils/index.ts
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/utils/index.ts
@@ -3,8 +3,10 @@ import { decodePersons, type IPerson, type IPersons } from '@bypass/shared';
 import { personsItem, hasPendingPersonsItem } from '@/storage/items';
 
 export const setPersonsInStorage = async (persons: IPersons) => {
-  await personsItem.setValue(persons);
-  await hasPendingPersonsItem.setValue(true);
+  await Promise.all([
+    personsItem.setValue(persons),
+    hasPendingPersonsItem.setValue(true),
+  ]);
 };
 
 export const getAllDecodedPersons = async () => {

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/utils/sync.ts
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/utils/sync.ts
@@ -1,11 +1,14 @@
 import {
   addToCache,
+  ALL_PERSONS_WITH_IMAGES_KEY,
   buildPersonImageUrls,
   cachePersonImages,
   ECacheBucketKeys,
+  evictBlobUrl,
   getPersonImageName,
   type IPerson,
 } from '@bypass/shared';
+import { mutate } from 'swr';
 
 import { trpcApi } from '@/apis/trpcApi';
 import {
@@ -24,12 +27,25 @@ export const syncPersonsToStorage = async () => {
 };
 
 export const resetPersons = async () => {
-  await personsItem.removeValue();
-  await hasPendingPersonsItem.removeValue();
+  await Promise.all([
+    personsItem.removeValue(),
+    hasPendingPersonsItem.removeValue(),
+  ]);
 };
 
 const resolveDownloadUrl = async (fileName: string) =>
   trpcApi.storage.getDownloadUrl.query(fileName);
+
+/**
+ * Global mutate (not useSWRConfig) — this module is not a hook. There is no
+ * SWRConfig provider, so this addresses the same default cache.
+ */
+export const invalidatePersonCaches = async () => {
+  await Promise.all([
+    mutate(ALL_PERSONS_WITH_IMAGES_KEY),
+    mutate((key) => Array.isArray(key) && key[0] === 'person-image'),
+  ]);
+};
 
 export const refreshPersonImageUrlsCache = async () => {
   await personImageUrlsItem.removeValue();
@@ -54,6 +70,8 @@ export const updatePersonCacheAndImageUrls = async (person: IPerson) => {
   const imageUrl = await resolveDownloadUrl(getPersonImageName(person.uid));
   personImageUrls[person.uid] = imageUrl;
   await personImageUrlsItem.setValue(personImageUrls);
-  // Update person image cache
+  // Update person image cache; drop any blob url still pointing at the old bytes
+  evictBlobUrl(ECacheBucketKeys.person, imageUrl);
   await addToCache(ECacheBucketKeys.person, imageUrl);
+  await invalidatePersonCaches();
 };

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/utils/sync.ts
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/utils/sync.ts
@@ -36,10 +36,7 @@ export const resetPersons = async () => {
 const resolveDownloadUrl = async (fileName: string) =>
   trpcApi.storage.getDownloadUrl.query(fileName);
 
-/**
- * Global mutate (not useSWRConfig) — this module is not a hook. There is no
- * SWRConfig provider, so this addresses the same default cache.
- */
+/** Global mutate, not useSWRConfig: this module is not a hook. */
 export const invalidatePersonCaches = async () => {
   await Promise.all([
     mutate(ALL_PERSONS_WITH_IMAGES_KEY),
@@ -71,8 +68,8 @@ export const updatePersonCacheAndImageUrls = async (person: IPerson) => {
   const imageUrl = await resolveDownloadUrl(getPersonImageName(person.uid));
   personImageUrls[person.uid] = imageUrl;
   await personImageUrlsItem.setValue(personImageUrls);
-  // Evict both: the previous url may still be handed out to mounted avatars, and
-  // if the download url did not change its cached bytes are being replaced
+  // Evict both: mounted avatars may still hold the previous url, and an unchanged
+  // url means these cached bytes are the ones being replaced
   evictBlobUrl(ECacheBucketKeys.person, previousImageUrl);
   evictBlobUrl(ECacheBucketKeys.person, imageUrl);
   await addToCache(ECacheBucketKeys.person, imageUrl);

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/utils/sync.ts
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/utils/sync.ts
@@ -67,10 +67,13 @@ export const cachePersonImagesInStorage = async () => {
 export const updatePersonCacheAndImageUrls = async (person: IPerson) => {
   // Update person image urls in storage
   const personImageUrls = await personImageUrlsItem.getValue();
+  const previousImageUrl = personImageUrls[person.uid];
   const imageUrl = await resolveDownloadUrl(getPersonImageName(person.uid));
   personImageUrls[person.uid] = imageUrl;
   await personImageUrlsItem.setValue(personImageUrls);
-  // Update person image cache; drop any blob url still pointing at the old bytes
+  // Evict both: the previous url may still be handed out to mounted avatars, and
+  // if the download url did not change its cached bytes are being replaced
+  evictBlobUrl(ECacheBucketKeys.person, previousImageUrl);
   evictBlobUrl(ECacheBucketKeys.person, imageUrl);
   await addToCache(ECacheBucketKeys.person, imageUrl);
   await invalidatePersonCaches();

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/utils/sync.ts
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/utils/sync.ts
@@ -61,6 +61,18 @@ export const cachePersonImagesInStorage = async () => {
   incrementProgress(SIGN_IN_TOTAL_STEPS);
 };
 
+/** Delete-path counterpart: without this the url and its blob url both linger. */
+export const removePersonImageUrl = async (uid: string) => {
+  const personImageUrls = await personImageUrlsItem.getValue();
+  const imageUrl = personImageUrls[uid];
+  if (!imageUrl) {
+    return;
+  }
+  evictBlobUrl(imageUrl);
+  delete personImageUrls[uid];
+  await personImageUrlsItem.setValue(personImageUrls);
+};
+
 export const updatePersonCacheAndImageUrls = async (person: IPerson) => {
   // Update person image urls in storage
   const personImageUrls = await personImageUrlsItem.getValue();

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/utils/sync.ts
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/utils/sync.ts
@@ -70,8 +70,8 @@ export const updatePersonCacheAndImageUrls = async (person: IPerson) => {
   await personImageUrlsItem.setValue(personImageUrls);
   // Evict both: mounted avatars may still hold the previous url, and an unchanged
   // url means these cached bytes are the ones being replaced
-  evictBlobUrl(ECacheBucketKeys.person, previousImageUrl);
-  evictBlobUrl(ECacheBucketKeys.person, imageUrl);
+  evictBlobUrl(previousImageUrl);
+  evictBlobUrl(imageUrl);
   await addToCache(ECacheBucketKeys.person, imageUrl);
   await invalidatePersonCaches();
 };

--- a/packages/shared/src/components/Bookmarks/components/Bookmark.tsx
+++ b/packages/shared/src/components/Bookmarks/components/Bookmark.tsx
@@ -34,7 +34,7 @@ function Bookmark({
   handleSelectedChange,
 }: BookmarkProps) {
   const { tabs } = use(DynamicContext);
-  const { data: personsWithImageUrls = [] } = useTaggedPersons(taggedPersons);
+  const { data: personsWithImageUrls } = useTaggedPersons(taggedPersons);
   const isMobile = useIsMobile();
 
   const handleOpenLink: React.MouseEventHandler<HTMLDivElement> = (event) => {

--- a/packages/shared/src/components/Bookmarks/components/Favicon.tsx
+++ b/packages/shared/src/components/Bookmarks/components/Favicon.tsx
@@ -12,26 +12,15 @@ interface Props {
   ref?: React.Ref<HTMLDivElement>;
 }
 
-const urlMap = new Map<string, string>();
-
-const getBlobUrl = async (proxyUrl: string) => {
-  const blobStr = urlMap.get(proxyUrl);
-  if (blobStr) {
-    return blobStr;
-  }
-
-  const blobUrl = await getBlobUrlFromCache(ECacheBucketKeys.favicon, proxyUrl);
-  urlMap.set(proxyUrl, blobUrl);
-  return blobUrl;
-};
-
 function Favicon({ url, ref }: Props) {
   const { favicon } = use(DynamicContext);
   const [faviconUrl, setFaviconUrl] = useState('');
 
   useEffect(() => {
     const initFavicon = async () => {
-      setFaviconUrl(await getBlobUrl(favicon.getUrl(url)));
+      setFaviconUrl(
+        await getBlobUrlFromCache(ECacheBucketKeys.favicon, favicon.getUrl(url))
+      );
     };
     initFavicon();
   }, [url, favicon]);

--- a/packages/shared/src/components/Bookmarks/utils/index.ts
+++ b/packages/shared/src/components/Bookmarks/utils/index.ts
@@ -38,12 +38,19 @@ export const getFilteredContextBookmarks = (
     return hasText(searchText, ctx.url) || hasText(searchText, ctx.title);
   });
 
+/**
+ * The single bookmark-field encoder. Exported so lookups can encode a needle
+ * instead of decoding every stored bookmark, without the two drifting apart.
+ */
+export const encodeBookmarkField = (value: string) =>
+  btoa(encodeURIComponent(value));
+
 export const getEncryptedBookmark = (
   bookmark: IEncodedBookmark
 ): IEncodedBookmark => ({
   ...bookmark,
-  url: btoa(encodeURIComponent(bookmark.url)),
-  title: btoa(encodeURIComponent(bookmark.title)),
+  url: encodeBookmarkField(bookmark.url),
+  title: encodeBookmarkField(bookmark.title),
 });
 
 export const getDecryptedBookmark = (

--- a/packages/shared/src/components/Bookmarks/utils/index.ts
+++ b/packages/shared/src/components/Bookmarks/utils/index.ts
@@ -38,10 +38,7 @@ export const getFilteredContextBookmarks = (
     return hasText(searchText, ctx.url) || hasText(searchText, ctx.title);
   });
 
-/**
- * The single bookmark-field encoder. Exported so lookups can encode a needle
- * instead of decoding every stored bookmark, without the two drifting apart.
- */
+/** The one bookmark-field encoder, so lookups can encode without drifting. */
 export const encodeBookmarkField = (value: string) =>
   btoa(encodeURIComponent(value));
 

--- a/packages/shared/src/components/Bookmarks/utils/index.ts
+++ b/packages/shared/src/components/Bookmarks/utils/index.ts
@@ -38,7 +38,6 @@ export const getFilteredContextBookmarks = (
     return hasText(searchText, ctx.url) || hasText(searchText, ctx.title);
   });
 
-/** The one bookmark-field encoder, so lookups can encode without drifting. */
 export const encodeBookmarkField = (value: string) =>
   btoa(encodeURIComponent(value));
 

--- a/packages/shared/src/components/Persons/hooks/useAllPersonsWithImages.ts
+++ b/packages/shared/src/components/Persons/hooks/useAllPersonsWithImages.ts
@@ -1,0 +1,20 @@
+import useSWR from 'swr';
+
+import usePerson from './usePerson';
+
+export const ALL_PERSONS_WITH_IMAGES_KEY = 'persons-with-images';
+
+/**
+ * One decode + image-resolve pass over the whole persons list, shared by every
+ * consumer. Deliberately unordered: callers sort the result themselves, so the
+ * cache key stays stable across different orderings.
+ */
+const useAllPersonsWithImages = () => {
+  const { getAllDecodedPersons, getPersonsWithImageUrl } = usePerson();
+
+  return useSWR(ALL_PERSONS_WITH_IMAGES_KEY, async () =>
+    getPersonsWithImageUrl(await getAllDecodedPersons())
+  );
+};
+
+export default useAllPersonsWithImages;

--- a/packages/shared/src/components/Persons/hooks/useAllPersonsWithImages.ts
+++ b/packages/shared/src/components/Persons/hooks/useAllPersonsWithImages.ts
@@ -4,10 +4,6 @@ import usePerson from './usePerson';
 
 export const ALL_PERSONS_WITH_IMAGES_KEY = 'persons-with-images';
 
-/**
- * One decode + image-resolve pass shared by every consumer. Deliberately
- * unordered: callers sort, so the cache key stays stable across orderings.
- */
 const useAllPersonsWithImages = () => {
   const { getAllDecodedPersons, getPersonsWithImageUrl } = usePerson();
 

--- a/packages/shared/src/components/Persons/hooks/useAllPersonsWithImages.ts
+++ b/packages/shared/src/components/Persons/hooks/useAllPersonsWithImages.ts
@@ -5,9 +5,8 @@ import usePerson from './usePerson';
 export const ALL_PERSONS_WITH_IMAGES_KEY = 'persons-with-images';
 
 /**
- * One decode + image-resolve pass over the whole persons list, shared by every
- * consumer. Deliberately unordered: callers sort the result themselves, so the
- * cache key stays stable across different orderings.
+ * One decode + image-resolve pass shared by every consumer. Deliberately
+ * unordered: callers sort, so the cache key stays stable across orderings.
  */
 const useAllPersonsWithImages = () => {
   const { getAllDecodedPersons, getPersonsWithImageUrl } = usePerson();

--- a/packages/shared/src/components/Persons/hooks/usePerson.ts
+++ b/packages/shared/src/components/Persons/hooks/usePerson.ts
@@ -65,7 +65,6 @@ const usePerson = () => {
         persons.map(async (person) => ({
           ...person,
           imageUrl: await getBlobUrlFromOpenCache(
-            ECacheBucketKeys.person,
             cache,
             personImages[person.uid]
           ),

--- a/packages/shared/src/components/Persons/hooks/usePerson.ts
+++ b/packages/shared/src/components/Persons/hooks/usePerson.ts
@@ -65,6 +65,7 @@ const usePerson = () => {
         persons.map(async (person) => ({
           ...person,
           imageUrl: await getBlobUrlFromOpenCache(
+            ECacheBucketKeys.person,
             cache,
             personImages[person.uid]
           ),

--- a/packages/shared/src/components/Persons/hooks/useTaggedPersons.ts
+++ b/packages/shared/src/components/Persons/hooks/useTaggedPersons.ts
@@ -1,17 +1,12 @@
 import { type IPersonWithImage } from '../interfaces/persons';
 import useAllPersonsWithImages from './useAllPersonsWithImages';
 
-/**
- * Selects a bookmark row's tagged persons out of the one shared all-persons
- * entry. Previously every row ran its own fetcher, re-reading storage and
- * re-decoding every person name per row.
- */
+/** Selects a row's tagged persons from the one shared all-persons entry. */
 const useTaggedPersons = (taggedPersons: string[]) => {
   const { data: allPersons = [], ...rest } = useAllPersonsWithImages();
 
   const tagged = new Set(taggedPersons);
-  // Filter the list rather than mapping over taggedPersons, to preserve the
-  // persons-storage ordering the previous implementation produced
+  // Filter rather than map over taggedPersons, to keep persons-storage ordering
   const data: IPersonWithImage[] = allPersons.filter((person) =>
     tagged.has(person.uid)
   );

--- a/packages/shared/src/components/Persons/hooks/useTaggedPersons.ts
+++ b/packages/shared/src/components/Persons/hooks/useTaggedPersons.ts
@@ -1,12 +1,10 @@
 import { type IPersonWithImage } from '../interfaces/persons';
 import useAllPersonsWithImages from './useAllPersonsWithImages';
 
-/** Selects a row's tagged persons from the one shared all-persons entry. */
 const useTaggedPersons = (taggedPersons: string[]) => {
   const { data: allPersons = [], ...rest } = useAllPersonsWithImages();
 
   const tagged = new Set(taggedPersons);
-  // Filter rather than map over taggedPersons, to keep persons-storage ordering
   const data: IPersonWithImage[] = allPersons.filter((person) =>
     tagged.has(person.uid)
   );

--- a/packages/shared/src/components/Persons/hooks/useTaggedPersons.ts
+++ b/packages/shared/src/components/Persons/hooks/useTaggedPersons.ts
@@ -1,23 +1,22 @@
-import useSWR from 'swr';
+import { type IPersonWithImage } from '../interfaces/persons';
+import useAllPersonsWithImages from './useAllPersonsWithImages';
 
-import { type IPerson } from '../interfaces/persons';
-import usePerson from './usePerson';
-
-const getPersonsFromUids = (uids: string[], persons: IPerson[]) => {
-  if (!uids || !persons) {
-    return [];
-  }
-  return persons.filter((person) => uids.includes(person.uid ?? ''));
-};
-
+/**
+ * Selects a bookmark row's tagged persons out of the one shared all-persons
+ * entry. Previously every row ran its own fetcher, re-reading storage and
+ * re-decoding every person name per row.
+ */
 const useTaggedPersons = (taggedPersons: string[]) => {
-  const { getAllDecodedPersons, getPersonsWithImageUrl } = usePerson();
+  const { data: allPersons = [], ...rest } = useAllPersonsWithImages();
 
-  return useSWR(['tagged-persons', taggedPersons], async () => {
-    const allPersons = await getAllDecodedPersons();
-    const persons = getPersonsFromUids(taggedPersons, allPersons);
-    return getPersonsWithImageUrl(persons);
-  });
+  const tagged = new Set(taggedPersons);
+  // Filter the list rather than mapping over taggedPersons, to preserve the
+  // persons-storage ordering the previous implementation produced
+  const data: IPersonWithImage[] = allPersons.filter((person) =>
+    tagged.has(person.uid)
+  );
+
+  return { ...rest, data };
 };
 
 export default useTaggedPersons;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -19,6 +19,10 @@ export type * from './components/Persons/interfaces/persons';
 export * from './components/Persons/utils';
 export * from './components/Persons/utils/bookmark';
 export * from './components/Persons/utils/urls';
+export {
+  ALL_PERSONS_WITH_IMAGES_KEY,
+  default as useAllPersonsWithImages,
+} from './components/Persons/hooks/useAllPersonsWithImages';
 export { default as usePerson } from './components/Persons/hooks/usePerson';
 export { default as usePersonImage } from './components/Persons/hooks/usePersonImage';
 

--- a/packages/shared/src/utils/cache.ts
+++ b/packages/shared/src/utils/cache.ts
@@ -42,25 +42,80 @@ export const addAllToCache = async (
   await Promise.all(cachePromises);
 };
 
+/**
+ * One blob url per cached entry. `URL.createObjectURL` pins its blob for the
+ * document lifetime and nothing revokes it, so minting a fresh url per call
+ * leaked a copy per render in the long-lived web document. Keyed by bucket as
+ * well as url, since the same url could live in more than one bucket and
+ * eviction is per bucket.
+ */
+const blobUrlCache = new Map<string, string>();
+
+const blobUrlKey = (cacheBucketKey: string, url: string) =>
+  `${cacheBucketKey}:${url}`;
+
+const evictBlobUrls = (cacheBucketKey: string) => {
+  const prefix = `${cacheBucketKey}:`;
+  for (const key of blobUrlCache.keys()) {
+    if (key.startsWith(prefix)) {
+      const blobUrl = blobUrlCache.get(key);
+      if (blobUrl) {
+        URL.revokeObjectURL(blobUrl);
+      }
+      blobUrlCache.delete(key);
+    }
+  }
+};
+
+/** Drop one entry, for when its underlying cached bytes are replaced. */
+export const evictBlobUrl = (cacheBucketKey: string, url?: string) => {
+  if (!url) {
+    return;
+  }
+  const key = blobUrlKey(cacheBucketKey, url);
+  const blobUrl = blobUrlCache.get(key);
+  if (blobUrl) {
+    URL.revokeObjectURL(blobUrl);
+  }
+  blobUrlCache.delete(key);
+};
+
 /** Variant taking an already-open Cache, to open the bucket once for many urls. */
-export const getBlobUrlFromOpenCache = async (cache: Cache, url?: string) => {
+export const getBlobUrlFromOpenCache = async (
+  cacheBucketKey: ECacheBucketKeys,
+  cache: Cache,
+  url?: string
+) => {
   if (!url) {
     return '';
+  }
+  const key = blobUrlKey(cacheBucketKey, url);
+  const existing = blobUrlCache.get(key);
+  if (existing) {
+    return existing;
   }
   const response = await cache.match(url);
   const blob = await response?.blob();
   if (!blob) {
     return '';
   }
-  return URL.createObjectURL(blob);
+  const blobUrl = URL.createObjectURL(blob);
+  blobUrlCache.set(key, blobUrl);
+  return blobUrl;
 };
 
 export const getBlobUrlFromCache = async (
   cacheBucketKey: ECacheBucketKeys,
   url: string
-) => getBlobUrlFromOpenCache(await getCacheObj(cacheBucketKey), url);
+) =>
+  getBlobUrlFromOpenCache(
+    cacheBucketKey,
+    await getCacheObj(cacheBucketKey),
+    url
+  );
 
 export const deleteCache = async (bucketKey: string) => {
+  evictBlobUrls(bucketKey);
   await caches.delete(bucketKey);
 };
 

--- a/packages/shared/src/utils/cache.ts
+++ b/packages/shared/src/utils/cache.ts
@@ -43,11 +43,8 @@ export const addAllToCache = async (
 };
 
 /**
- * One blob url per cached entry. `URL.createObjectURL` pins its blob for the
- * document lifetime and nothing revokes it, so minting a fresh url per call
- * leaked a copy per render in the long-lived web document. Keyed by bucket as
- * well as url, since the same url could live in more than one bucket and
- * eviction is per bucket.
+ * One blob url per cached entry — `createObjectURL` pins its blob for the
+ * document lifetime. Keyed by bucket too, since eviction is per bucket.
  */
 const blobUrlCache = new Map<string, string>();
 

--- a/packages/shared/src/utils/cache.ts
+++ b/packages/shared/src/utils/cache.ts
@@ -42,52 +42,30 @@ export const addAllToCache = async (
   await Promise.all(cachePromises);
 };
 
-/**
- * One blob url per cached entry — `createObjectURL` pins its blob for the
- * document lifetime. Keyed by bucket too, since eviction is per bucket.
- */
+/** One blob url per url; `createObjectURL` pins its blob for the document lifetime. */
 const blobUrlCache = new Map<string, string>();
 
-const blobUrlKey = (cacheBucketKey: string, url: string) =>
-  `${cacheBucketKey}:${url}`;
-
-const evictBlobUrls = (cacheBucketKey: string) => {
-  const prefix = `${cacheBucketKey}:`;
-  for (const key of blobUrlCache.keys()) {
-    if (key.startsWith(prefix)) {
-      const blobUrl = blobUrlCache.get(key);
-      if (blobUrl) {
-        URL.revokeObjectURL(blobUrl);
-      }
-      blobUrlCache.delete(key);
-    }
-  }
-};
-
-/** Drop one entry, for when its underlying cached bytes are replaced. */
-export const evictBlobUrl = (cacheBucketKey: string, url?: string) => {
-  if (!url) {
-    return;
-  }
-  const key = blobUrlKey(cacheBucketKey, url);
-  const blobUrl = blobUrlCache.get(key);
+const revokeBlobUrl = (url: string) => {
+  const blobUrl = blobUrlCache.get(url);
   if (blobUrl) {
     URL.revokeObjectURL(blobUrl);
   }
-  blobUrlCache.delete(key);
+  blobUrlCache.delete(url);
+};
+
+/** Drop one entry, for when its underlying cached bytes are replaced. */
+export const evictBlobUrl = (url?: string) => {
+  if (url) {
+    revokeBlobUrl(url);
+  }
 };
 
 /** Variant taking an already-open Cache, to open the bucket once for many urls. */
-export const getBlobUrlFromOpenCache = async (
-  cacheBucketKey: ECacheBucketKeys,
-  cache: Cache,
-  url?: string
-) => {
+export const getBlobUrlFromOpenCache = async (cache: Cache, url?: string) => {
   if (!url) {
     return '';
   }
-  const key = blobUrlKey(cacheBucketKey, url);
-  const existing = blobUrlCache.get(key);
+  const existing = blobUrlCache.get(url);
   if (existing) {
     return existing;
   }
@@ -97,22 +75,19 @@ export const getBlobUrlFromOpenCache = async (
     return '';
   }
   const blobUrl = URL.createObjectURL(blob);
-  blobUrlCache.set(key, blobUrl);
+  blobUrlCache.set(url, blobUrl);
   return blobUrl;
 };
 
 export const getBlobUrlFromCache = async (
   cacheBucketKey: ECacheBucketKeys,
   url: string
-) =>
-  getBlobUrlFromOpenCache(
-    cacheBucketKey,
-    await getCacheObj(cacheBucketKey),
-    url
-  );
+) => getBlobUrlFromOpenCache(await getCacheObj(cacheBucketKey), url);
 
 export const deleteCache = async (bucketKey: string) => {
-  evictBlobUrls(bucketKey);
+  const cache = await getCacheObj(bucketKey);
+  const keys = await cache.keys();
+  keys.forEach((request) => revokeBlobUrl(request.url));
   await caches.delete(bucketKey);
 };
 


### PR DESCRIPTION
Removes repeated work from paths that run on every navigation, every popup open, and every bookmark row.

- **5a** `Promise.all` for independent storage ops awaited in series — six round-trips become three on the sign-out path. Latency only.
- **5b** `onPageLoad` made three serialized IPC awaits per navigation, one provably redundant: `redirect()` is fire-and-forget, so nothing is awaited between the two `isValidTabUrl` calls and the second `tabs.get` could never observe a newer url.
- **5c** `findBookmarkByUrl` decrypted **every** stored bookmark to find one — ~8k `atob`/`decodeURIComponent` calls at 2k bookmarks, on popup open and again on every save. Now encodes the needle once.
- **5d** Every bookmark row ran its own fetcher: a storage read plus `atob` of every person name, then a second read, `caches.open`, and a `blob()` per tag. At 20 visible tagged rows over 200 persons that is ~40 storage reads and ~4k `atob` calls, repeated on every folder change. Consolidated onto one shared entry.
- **5e** `URL.createObjectURL` was the only blob-url mint in the repo and **nothing revoked it**, so every call pinned a decoded copy for the document lifetime.

### Worth a reviewer's eye

**5b narrows semantics rather than preserving them.** Previously `turnOffInputSuggestions` had its own gate that could skip it if the tab navigated between the two checks (including racing the unawaited `tabs.update`). It is now unconditional once the single live check passes. I think that is the right trade — the second check could not observe anything new — but it is a real change.

**5c narrows matching to the canonical encoding.** The old decrypt-then-compare tolerated any equivalent percent-encoding variant. `getEncryptedBookmark` is the only bookmark encoder in the repo (the server encodes redirections only), so exposure is legacy or externally-written data.

**5d reuses the existing `persons-with-images` key** rather than adding a second cache key; the extension hook became a sorting wrapper so ordering no longer forks the key. `useTaggedPersons` selects with a `Set` filter, not a uid-keyed `Map` lookup — that preserves the previous persons-storage ordering of avatars.

**5d also adds invalidation that never existed.** The repo had no `mutate()` call at all, so tagged-row avatars were already stale until remount. Both mutation paths now invalidate — person **edit** and person **delete**.

**5e required threading the bucket** through `getBlobUrlFromOpenCache`, because a `Cache` object carries no name and eviction is per bucket. `Favicon`'s private `urlMap` is folded in: it short-circuited *before* the cache helper, so favicon urls would otherwise have escaped eviction entirely.

### Verification

`pnpm lint`, `pnpm format:check`, `pnpm typecheck:all` clean; 91 Playwright tests resolve. Both hooks now return a guaranteed array, which let two consumer `= []` defaults go (oxlint flagged them).

**Needs manual e2e**: navigate + reload a redirect-mapped URL (redirect fires once, input suggestions still off); quick-bookmark button on popup open; edit a person image and confirm the avatar updates without reload; sign out and back in and confirm avatars still render.

Note the avatar-update check is contingent on the download token rotating on re-upload — `addToCache` early-returns on a cache hit, so if the URL is unchanged the old bytes are served regardless of eviction.

---
### Stack

This is part of a 5-PR stack from a repo-wide `/simplify` pass. Merge in order — each PR is based on the previous one.

1. #4135 — dead code and trivial collapses
2. #4136 — single-use wrappers and helper reuse
3. #4137 — collapse duplicated mechanisms
4. #4138 — derivable state
5. #4139 — wasted work on hot paths

Every commit passes `pnpm lint`, `pnpm format:check`, `pnpm typecheck:all`, and all 91 Playwright tests still resolve.

A sixth PR (wrong-altitude fixes) was closed and dropped from the stack; its work is unshipped on `cleanup/batch-6-altitude`.

The extension minor version is bumped to `25.4.0` in #4135, the bottom of the stack, so it lands once for the whole series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

 

<details><summary><h3>Greptile Summary</h3></summary>

This PR reduces repeated storage, decoding, cache, and IPC work across extension navigation and popup rendering.

- Parallelizes independent storage operations.
- Consolidates person-image loading behind a shared SWR entry with mutation invalidation.
- Reuses and explicitly evicts generated blob URLs.
- Matches bookmarks using one canonical encoded URL.
- Replaces repeated navigation checks with one concurrently fetched tab snapshot.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because the previously reported stale-navigation race can still redirect a tab after it has moved to a newer page.

`onPageLoad` takes only one tab snapshot, while `redirect` subsequently awaits storage and then updates whatever page currently occupies that tab ID; a navigation after the snapshot therefore leaves the obsolete event URL authorized to replace the newer page.

**Files Needing Attention:** apps/extension/src/entrypoints/background/index.ts and apps/extension/src/entrypoints/background/redirections/index.ts
</details>

<sub>Reviews (7): Last reviewed commit: ["fix: evict the blob url when a person is..."](https://github.com/amitsingh-007/bypass-links/commit/f0a2224c04daf758707ed09b92e9ceeb9a57bb27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50447339)</sub>

**Context used:**

- Knowledge Base — [Extension background service worker](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/extension-background.md)

<!-- /greptile_comment -->