### PR TITLE
refactor: fix four things at the wrong altitude (6/6)

### DIFF
--- a/apps/extension/src/constants/favicon.ts
+++ b/apps/extension/src/constants/favicon.ts
@@ -1,0 +1,8 @@
+import { getGoogleFaviconUrl } from '@bypass/shared';
+
+/**
+ * Single source for this app's favicon provider. `DynamicProvider` reads the
+ * cache and the cache-warming paths write it, so if they disagree every favicon
+ * silently renders the fallback — nothing throws and no request is made.
+ */
+export const faviconUrl = getGoogleFaviconUrl;

--- a/apps/extension/src/entrypoints/background/misc/forumPageLinks.ts
+++ b/apps/extension/src/entrypoints/background/misc/forumPageLinks.ts
@@ -69,12 +69,26 @@ const FORUM_EXTRACTORS: Record<string, ExtractorFor> = {
   FORUM_4: () => getForum_4_LinksFunc,
 };
 
+/**
+ * A page is only actionable if it matches a websites entry AND we have an
+ * extractor for that key. The schema accepts arbitrary keys, so a forum added in
+ * Firebase without a matching extractor here must not enable the popup action.
+ */
+const resolveExtractor = async (
+  url: string
+): Promise<ExtractorFor | undefined> => {
+  const forumKey = await matchForum(url);
+  return forumKey ? FORUM_EXTRACTORS[forumKey] : undefined;
+};
+
+export const isForumPage = async (url: string) =>
+  Boolean(await resolveExtractor(url));
+
 export const getForumPageLinks = async (
   tabId: number,
   url: string
 ): Promise<string[]> => {
-  const forumKey = await matchForum(url);
-  const selectExtractor = forumKey ? FORUM_EXTRACTORS[forumKey] : undefined;
+  const selectExtractor = await resolveExtractor(url);
   if (!selectExtractor) {
     throw new Error('Not a forum page');
   }

--- a/apps/extension/src/entrypoints/background/misc/forumPageLinks.ts
+++ b/apps/extension/src/entrypoints/background/misc/forumPageLinks.ts
@@ -1,4 +1,4 @@
-import { websitesItem } from '@/storage/items';
+import { matchForum } from '@background/websites';
 
 const getForum_1_2_LinksFunc = () => {
   const unreadRows = document.querySelectorAll(
@@ -49,45 +49,39 @@ const getForum_4_LinksFunc = () => {
   return [...unreadPosts].map((a) => a.href);
 };
 
+/**
+ * Extractor per websites key. The selector takes the url because FORUM_1/FORUM_2
+ * choose between two extractors at runtime based on the pathname, so a plain
+ * `Record<string, extractor>` could not express it.
+ */
+type ExtractorFor = (url: URL) => () => Array<string | undefined>;
+
+const FORUM_EXTRACTORS: Record<string, ExtractorFor> = {
+  FORUM_1: ({ pathname }) =>
+    pathname === '/watched/threads'
+      ? getForum_1_2_WatchedThreadsLinksFunc
+      : getForum_1_2_LinksFunc,
+  FORUM_2: ({ pathname }) =>
+    pathname === '/watched/threads'
+      ? getForum_1_2_WatchedThreadsLinksFunc
+      : getForum_1_2_LinksFunc,
+  FORUM_3: () => getForum_3_LinksFunc,
+  FORUM_4: () => getForum_4_LinksFunc,
+};
+
 export const getForumPageLinks = async (
   tabId: number,
   url: string
 ): Promise<string[]> => {
-  const websites = await websitesItem.getValue();
-  // Undefined when unsynced; url.includes(undefined) would match arbitrary urls
-  const matches = (website?: string) =>
-    Boolean(website && url.includes(website));
-  let executor: () => Array<string | undefined>;
-
-  switch (true) {
-    case matches(websites.FORUM_1):
-    case matches(websites.FORUM_2): {
-      const { pathname } = new URL(url);
-      const isWatchThreadsPage = pathname === '/watched/threads';
-      executor = isWatchThreadsPage
-        ? getForum_1_2_WatchedThreadsLinksFunc
-        : getForum_1_2_LinksFunc;
-      break;
-    }
-
-    case matches(websites.FORUM_3): {
-      executor = getForum_3_LinksFunc;
-      break;
-    }
-
-    case matches(websites.FORUM_4): {
-      executor = getForum_4_LinksFunc;
-      break;
-    }
-
-    default: {
-      throw new Error('Not a forum page');
-    }
+  const forumKey = await matchForum(url);
+  const selectExtractor = forumKey ? FORUM_EXTRACTORS[forumKey] : undefined;
+  if (!selectExtractor) {
+    throw new Error('Not a forum page');
   }
 
   const [{ result }] = await browser.scripting.executeScript({
     target: { tabId },
-    func: executor,
+    func: selectExtractor(new URL(url)),
   });
   return result?.filter(Boolean) ?? [];
 };

--- a/apps/extension/src/entrypoints/background/websites/index.ts
+++ b/apps/extension/src/entrypoints/background/websites/index.ts
@@ -13,6 +13,3 @@ export const matchForum = async (url: string): Promise<string | undefined> => {
     ([, website]) => Boolean(website && url.includes(website))
   )?.[0];
 };
-
-export const isForumPage = async (url: string) =>
-  Boolean(await matchForum(url));

--- a/apps/extension/src/entrypoints/background/websites/index.ts
+++ b/apps/extension/src/entrypoints/background/websites/index.ts
@@ -1,9 +1,18 @@
 import { websitesItem } from '@/storage/items';
 
-export const isForumPage = async (hostname: string) => {
+/**
+ * Returns the matching websites key, or undefined. One matcher for both the
+ * popup gate and link extraction — they previously tested different things
+ * (hostname vs full url), so a website value carrying a path disabled the
+ * button even though extraction would have worked.
+ */
+export const matchForum = async (url: string): Promise<string | undefined> => {
   const websites = await websitesItem.getValue();
-  // hostname.includes('') is true for every page
-  return Object.values(websites).some((website) =>
-    Boolean(website && hostname.includes(website))
-  );
+  return Object.entries(websites).find(
+    // Undefined when unsynced; url.includes(undefined) would match anything
+    ([, website]) => Boolean(website && url.includes(website))
+  )?.[0];
 };
+
+export const isForumPage = async (url: string) =>
+  Boolean(await matchForum(url));

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/store/useBookmarkStore.ts
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/store/useBookmarkStore.ts
@@ -8,12 +8,12 @@ import {
   bookmarksMapper,
   filterRecord,
   getEncryptedBookmark,
-  getGoogleFaviconUrl,
   getEncryptedFolder,
 } from '@bypass/shared';
 import { toast } from 'sonner';
 import { create } from 'zustand';
 
+import { faviconUrl } from '@/constants/favicon';
 import { bookmarksItem } from '@/storage/items';
 
 import { isFolderContainsDir, setBookmarksInStorage } from '../utils';
@@ -196,10 +196,7 @@ const useBookmarkStore = create<State>()((set, get) => ({
     }
 
     // Cache favicon for new URL
-    addToCache(
-      ECacheBucketKeys.favicon,
-      getGoogleFaviconUrl(updatedBookmark.url)
-    );
+    addToCache(ECacheBucketKeys.favicon, faviconUrl(updatedBookmark.url));
     set({ isSaveButtonActive: true });
     return true;
   },

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/utils/bookmark.ts
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/utils/bookmark.ts
@@ -3,13 +3,13 @@ import {
   addAllToCache,
   encodeBookmarkField,
   getBookmarkFaviconUrls,
-  getGoogleFaviconUrl,
   type ContextBookmarks,
   type IBookmarksObj,
   type ITransformedBookmark,
 } from '@bypass/shared';
 
 import { trpcApi } from '@/apis/trpcApi';
+import { faviconUrl } from '@/constants/favicon';
 import {
   bookmarksItem,
   personsItem,
@@ -62,10 +62,7 @@ export const cacheBookmarkFavicons = async () => {
   if (!bookmarks) {
     return;
   }
-  const faviconUrls = getBookmarkFaviconUrls(
-    bookmarks.urlList,
-    getGoogleFaviconUrl
-  );
+  const faviconUrls = getBookmarkFaviconUrls(bookmarks.urlList, faviconUrl);
   await addAllToCache(ECacheBucketKeys.favicon, faviconUrls);
   console.log('Bookmark favicons cached');
   const { incrementProgress } = useProgressStore.getState();

--- a/apps/extension/src/entrypoints/popup/panels/HomePopup/components/OpenForumLinks/index.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/HomePopup/components/OpenForumLinks/index.tsx
@@ -3,7 +3,7 @@ import { use, useEffect, useState } from 'react';
 
 import useFirebaseStore from '@/store/firebase/useFirebaseStore';
 import { sendRuntimeMessage } from '@/utils/sendRuntimeMessage';
-import { isForumPage } from '@background/websites';
+import { isForumPage } from '@background/misc/forumPageLinks';
 import useCurrentTab from '@popup/hooks/useCurrentTab';
 
 import ButtonWithFeedback from './ButtonWithFeedback';

--- a/apps/extension/src/entrypoints/popup/panels/HomePopup/components/OpenForumLinks/index.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/HomePopup/components/OpenForumLinks/index.tsx
@@ -8,11 +8,6 @@ import useCurrentTab from '@popup/hooks/useCurrentTab';
 
 import ButtonWithFeedback from './ButtonWithFeedback';
 
-const isCurrentPageForum = async (url = '') => {
-  const hostname = url && new URL(url).hostname;
-  return isForumPage(hostname);
-};
-
 function OpenForumLinks() {
   const { tabs } = use(DynamicContext);
   const isSignedIn = useFirebaseStore((state) => Boolean(state.idpAuth?.uid));
@@ -21,7 +16,8 @@ function OpenForumLinks() {
 
   useEffect(() => {
     const initIsActive = async () => {
-      const isForum = isSignedIn && (await isCurrentPageForum(currentTab?.url));
+      const url = currentTab?.url;
+      const isForum = Boolean(isSignedIn && url && (await isForumPage(url)));
       setIsOnForumPage(isForum);
     };
     initIsActive();

--- a/apps/extension/src/entrypoints/popup/panels/ShortcutsPanel/components/ShortcutsPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/ShortcutsPanel/components/ShortcutsPanel.tsx
@@ -45,21 +45,28 @@ function ShortcutsPanel() {
     const validRules = redirections.filter(getValidRules);
     const isSaveSuccess =
       await trpcApi.firebaseData.redirectionsPost.mutate(validRules);
-    if (isSaveSuccess) {
-      // Must be awaited: this is the only writer of mappedRedirections outside
-      // sign-in, and redirect() reads it on every navigation. Firing it
-      // unawaited meant a failed round-trip (or the popup closing first) left
-      // the pre-edit rule table live while the panel showed the new rules.
-      try {
-        await syncRedirectionsToStorage();
-        setRedirections(validRules);
-        toast.success('Saved successfully');
-      } catch (error) {
-        console.error('Failed to refresh redirections in storage', error);
-        toast.error('Saved, but could not refresh redirect rules');
-      }
+    if (!isSaveSuccess) {
+      setIsFetching(false);
+      return;
     }
-    setIsSaveActive(false);
+    // The server accepted these rules, so show them regardless of what happens
+    // below — this is now the persisted truth
+    setRedirections(validRules);
+
+    // Must be awaited: this is the only writer of mappedRedirections outside
+    // sign-in, and redirect() reads it on every navigation. Firing it unawaited
+    // meant a failed round-trip (or the popup closing first) left the pre-edit
+    // rule table live while the panel showed the new rules.
+    try {
+      await syncRedirectionsToStorage();
+      setIsSaveActive(false);
+      toast.success('Saved successfully');
+    } catch (error) {
+      console.error('Failed to refresh redirections in storage', error);
+      // Leave Save enabled: redirects are still using the stale rule table, so
+      // the user needs a way to retry the refresh
+      toast.error('Saved, but redirect rules are stale — press Save to retry');
+    }
     setIsFetching(false);
   };
 

--- a/apps/extension/src/entrypoints/popup/panels/ShortcutsPanel/components/ShortcutsPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/ShortcutsPanel/components/ShortcutsPanel.tsx
@@ -46,9 +46,18 @@ function ShortcutsPanel() {
     const isSaveSuccess =
       await trpcApi.firebaseData.redirectionsPost.mutate(validRules);
     if (isSaveSuccess) {
-      syncRedirectionsToStorage();
-      setRedirections(validRules);
-      toast.success('Saved successfully');
+      // Must be awaited: this is the only writer of mappedRedirections outside
+      // sign-in, and redirect() reads it on every navigation. Firing it
+      // unawaited meant a failed round-trip (or the popup closing first) left
+      // the pre-edit rule table live while the panel showed the new rules.
+      try {
+        await syncRedirectionsToStorage();
+        setRedirections(validRules);
+        toast.success('Saved successfully');
+      } catch (error) {
+        console.error('Failed to refresh redirections in storage', error);
+        toast.error('Saved, but could not refresh redirect rules');
+      }
     }
     setIsSaveActive(false);
     setIsFetching(false);

--- a/apps/extension/src/entrypoints/popup/provider/DynamicProvider.tsx
+++ b/apps/extension/src/entrypoints/popup/provider/DynamicProvider.tsx
@@ -1,7 +1,8 @@
-import { DynamicContext, getGoogleFaviconUrl } from '@bypass/shared';
+import { DynamicContext } from '@bypass/shared';
 import { type PropsWithChildren, useMemo } from 'react';
 import { useLocation, useSearch } from 'wouter';
 
+import { faviconUrl } from '@/constants/favicon';
 import useHistoryStore from '@store/history';
 
 import { getFromChromeStorage, setToChromeStorage } from './utils';
@@ -31,7 +32,7 @@ function DynamicProvider({ children }: PropsWithChildren) {
           browser.tabs.create({ url, active: false });
         },
       },
-      favicon: { getUrl: getGoogleFaviconUrl },
+      favicon: { getUrl: faviconUrl },
     }),
     [navigate, search, startHistoryMonitor]
   );

--- a/apps/web/src/app/api/storage-cleanup/route.ts
+++ b/apps/web/src/app/api/storage-cleanup/route.ts
@@ -5,7 +5,10 @@ import { serverEnv } from '@app/constants/env/server';
 import { verifyInternalToken } from '@app/helpers/verifyInternalToken';
 
 export async function POST(req: NextRequest) {
-  verifyInternalToken(req);
+  const auth = verifyInternalToken(req);
+  if (!auth.ok) {
+    return new NextResponse(auth.message, { status: auth.status });
+  }
 
   const testUserId = serverEnv.FIREBASE_TEST_USER_ID;
   if (!testUserId) {

--- a/apps/web/src/app/bookmark-panel/hooks/usePreloadBookmarks.ts
+++ b/apps/web/src/app/bookmark-panel/hooks/usePreloadBookmarks.ts
@@ -5,11 +5,11 @@ import {
   STORAGE_KEYS,
   deleteCache,
   getBookmarkFaviconUrls,
-  getYandexFaviconUrl,
   isCachePresent,
 } from '@bypass/shared';
 import { useState } from 'react';
 
+import { faviconUrl } from '@app/constants/favicon';
 import { useUser } from '@app/provider/AuthProvider';
 import { api } from '@app/utils/api';
 import {
@@ -36,10 +36,7 @@ const cacheBookmarkFavicons = async () => {
   if (!bookmarks) {
     return;
   }
-  const faviconUrls = getBookmarkFaviconUrls(
-    bookmarks.urlList,
-    getYandexFaviconUrl
-  );
+  const faviconUrls = getBookmarkFaviconUrls(bookmarks.urlList, faviconUrl);
   await addAllToCache(ECacheBucketKeys.favicon, faviconUrls);
 };
 

--- a/apps/web/src/app/constants/favicon.ts
+++ b/apps/web/src/app/constants/favicon.ts
@@ -1,0 +1,8 @@
+import { getYandexFaviconUrl } from '@bypass/shared';
+
+/**
+ * Single source for this app's favicon provider. `DynamicProvider` reads the
+ * cache and the cache-warming paths write it, so if they disagree every favicon
+ * silently renders the fallback — nothing throws and no request is made.
+ */
+export const faviconUrl = getYandexFaviconUrl;

--- a/apps/web/src/app/helpers/authorizeUser.ts
+++ b/apps/web/src/app/helpers/authorizeUser.ts
@@ -1,36 +1,19 @@
 import {
   type AuthorizationResult,
   checkUserAuthorized,
-  getAuthBearer,
-  getFirebaseUser,
-  verifyAuthToken,
+  resolveRequestUser,
 } from '@bypass/trpc/appRouter';
 import { type NextRequest } from 'next/server';
-
-type FirebaseUser = Awaited<ReturnType<typeof getFirebaseUser>>;
 
 /** Applies the same rules as the tRPC middleware. */
 export const authorizeUser = async (
   request: NextRequest
 ): Promise<AuthorizationResult> => {
-  const idToken = getAuthBearer(request);
-  if (!idToken) {
-    return {
-      ok: false,
-      status: 401,
-      message: 'Authentication token not found',
-    };
+  const resolved = await resolveRequestUser(request);
+  if (!resolved.ok) {
+    return resolved.reason === 'missing'
+      ? checkUserAuthorized(null)
+      : { ok: false, status: 401, message: 'Unauthorized user' };
   }
-
-  let user: FirebaseUser;
-  try {
-    const { uid } = await verifyAuthToken(idToken, true);
-    user = await getFirebaseUser(uid);
-  } catch {
-    return { ok: false, status: 401, message: 'Unauthorized user' };
-  }
-
-  // Return the shared result directly: rebuilding it would put the wider
-  // firebase-admin UserRecord in a slot typed as the narrower IUser
-  return checkUserAuthorized(user);
+  return checkUserAuthorized(resolved.user);
 };

--- a/apps/web/src/app/helpers/verifyInternalToken.ts
+++ b/apps/web/src/app/helpers/verifyInternalToken.ts
@@ -1,10 +1,21 @@
-import { getAuthBearer } from '@bypass/trpc/appRouter';
+import {
+  type AuthorizationResult,
+  getAuthBearer,
+} from '@bypass/trpc/appRouter';
 import { type NextRequest } from 'next/server';
 
 import { serverEnv } from '@app/constants/env/server';
 
-export const verifyInternalToken = (req: NextRequest) => {
+/**
+ * Returns a result rather than throwing, matching `checkUserAuthorized` and
+ * `authorizeUser`. Throwing produced an uncaught 500 with a stack, which the
+ * caller could not tell apart from a genuine server misconfiguration.
+ */
+export const verifyInternalToken = (
+  req: NextRequest
+): AuthorizationResult | { ok: true } => {
   if (getAuthBearer(req) !== serverEnv.FIREBASE_CRON_JOB_API_KEY) {
-    throw new Error('Forbidden invocation');
+    return { ok: false, status: 403, message: 'Forbidden invocation' };
   }
+  return { ok: true };
 };

--- a/apps/web/src/app/helpers/verifyInternalToken.ts
+++ b/apps/web/src/app/helpers/verifyInternalToken.ts
@@ -1,19 +1,22 @@
-import {
-  type AuthorizationResult,
-  getAuthBearer,
-} from '@bypass/trpc/appRouter';
+import { getAuthBearer } from '@bypass/trpc/appRouter';
 import { type NextRequest } from 'next/server';
 
 import { serverEnv } from '@app/constants/env/server';
+
+/**
+ * Deliberately not `AuthorizationResult`: this check has no user to hand back,
+ * and reusing that type would imply the ok branch carries one.
+ */
+type InternalTokenResult =
+  | { ok: true }
+  | { ok: false; status: 403; message: string };
 
 /**
  * Returns a result rather than throwing, matching `checkUserAuthorized` and
  * `authorizeUser`. Throwing produced an uncaught 500 with a stack, which the
  * caller could not tell apart from a genuine server misconfiguration.
  */
-export const verifyInternalToken = (
-  req: NextRequest
-): AuthorizationResult | { ok: true } => {
+export const verifyInternalToken = (req: NextRequest): InternalTokenResult => {
   if (getAuthBearer(req) !== serverEnv.FIREBASE_CRON_JOB_API_KEY) {
     return { ok: false, status: 403, message: 'Forbidden invocation' };
   }

--- a/apps/web/src/app/provider/DynamicProvider.tsx
+++ b/apps/web/src/app/provider/DynamicProvider.tsx
@@ -1,6 +1,8 @@
-import { DynamicContext, getYandexFaviconUrl } from '@bypass/shared';
+import { DynamicContext } from '@bypass/shared';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { type PropsWithChildren, useMemo } from 'react';
+
+import { faviconUrl } from '@app/constants/favicon';
 
 import { openNewTab } from '../utils';
 import { getFromLocalStorage, setToLocalStorage } from '../utils/storage';
@@ -21,7 +23,7 @@ function DynamicProvider({ children }: PropsWithChildren) {
         set: async (key: string, value: any) => setToLocalStorage(key, value),
       },
       tabs: { open: openNewTab },
-      favicon: { getUrl: getYandexFaviconUrl },
+      favicon: { getUrl: faviconUrl },
     }),
     [router, searchParams]
   );

--- a/packages/shared/src/schema/websitesSchema.ts
+++ b/packages/shared/src/schema/websitesSchema.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod/mini';
 
-// Optional: an unsynced user legitimately has no websites record
-export const WebsitesSchema = z.object({
-  FORUM_1: z.optional(z.string()),
-  FORUM_2: z.optional(z.string()),
-  FORUM_3: z.optional(z.string()),
-  FORUM_4: z.optional(z.string()),
-});
+/**
+ * A record rather than a fixed object: zod strips unknown keys, so enumerating
+ * the forums here meant a newly added one was silently dropped at the tRPC
+ * output boundary and surfaced far away as "Not a forum page".
+ * Values are optional — an unsynced user legitimately has no websites record.
+ */
+export const WebsitesSchema = z.record(z.string(), z.optional(z.string()));

--- a/packages/trpc/src/appRouterIndex.ts
+++ b/packages/trpc/src/appRouterIndex.ts
@@ -2,5 +2,6 @@ export * from './services/firebaseAdminService';
 export {
   type AuthorizationResult,
   checkUserAuthorized,
+  resolveRequestUser,
 } from './utils/authorization';
 export { getAuthBearer } from './utils/headers';

--- a/packages/trpc/src/trpc.ts
+++ b/packages/trpc/src/trpc.ts
@@ -1,34 +1,23 @@
 import { TRPCError, initTRPC } from '@trpc/server';
 
 import { type ITRPCContext } from './@types/trpc';
-import {
-  getFirebaseUser,
-  verifyAuthToken,
-} from './services/firebaseAdminService';
-import { getAuthBearer } from './utils/headers';
+import { resolveRequestUser } from './utils/authorization';
 
-const getLoggedInUser = async (idToken: string | undefined) => {
-  if (!idToken) {
-    return null;
+export const createTRPCContext = async (
+  req: Request
+): Promise<ITRPCContext> => {
+  const resolved = await resolveRequestUser(req);
+  if (resolved.ok) {
+    return { user: resolved.user };
   }
-  try {
-    const { uid } = await verifyAuthToken(idToken, true);
-    return await getFirebaseUser(uid);
-  } catch (error) {
-    console.error(error);
+  if (resolved.reason === 'invalid') {
     throw new TRPCError({
       code: 'UNAUTHORIZED',
       message: 'Firebase authorization failed',
     });
   }
-};
-
-export const createTRPCContext = async (
-  req: Request
-): Promise<ITRPCContext> => {
-  const user = await getLoggedInUser(getAuthBearer(req));
-
-  return { user };
+  // Missing token: let checkUserAuthorized produce the 401
+  return { user: null };
 };
 
 export const t = initTRPC

--- a/packages/trpc/src/utils/authorization.ts
+++ b/packages/trpc/src/utils/authorization.ts
@@ -1,4 +1,39 @@
 import { type IUser } from '../@types/trpc';
+import {
+  getFirebaseUser,
+  verifyAuthToken,
+} from '../services/firebaseAdminService';
+import { getAuthBearer } from './headers';
+
+export type ResolvedRequestUser =
+  | { ok: true; user: IUser }
+  | { ok: false; reason: 'missing' | 'invalid' };
+
+/**
+ * Single place that turns a request into a user. Shared so the tRPC context and
+ * the REST helper cannot drift on token verification.
+ *
+ * Keeps 'missing' and 'invalid' distinct: a missing token yields a 401 via
+ * `checkUserAuthorized(null)`, while an invalid one is an explicit UNAUTHORIZED
+ * error in the tRPC context. Collapsing both to null would change the
+ * client-visible error for bad tokens.
+ */
+export const resolveRequestUser = async (
+  req: Request
+): Promise<ResolvedRequestUser> => {
+  const idToken = getAuthBearer(req);
+  if (!idToken) {
+    return { ok: false, reason: 'missing' };
+  }
+  try {
+    const { uid } = await verifyAuthToken(idToken, true);
+    return { ok: true, user: await getFirebaseUser(uid) };
+  } catch (error) {
+    // The only server-side trace of an auth failure
+    console.error(error);
+    return { ok: false, reason: 'invalid' };
+  }
+};
 
 export type AuthorizationResult =
   | { ok: true; user: IUser }


### PR DESCRIPTION
Five fixes pulled down to the layer that should own them.

- **6a** `verifyInternalToken` threw a bare `Error`, so `POST /api/storage-cleanup` with a wrong bearer produced an uncaught **500 with a stack** — indistinguishable from the route's own deliberate misconfiguration 500. Now returns an `AuthorizationResult` and the route maps it to **403**.
- **6b** Token→user resolution existed twice (tRPC context and REST helper), with different failure behaviour. Only the *check* had been hoisted. Now one `resolveRequestUser`.
- **6c** The favicon provider was picked independently at five sites while `DynamicContext` already owned the decision.
- **6d** `ShortcutsPanel.handleSave` fired `syncRedirectionsToStorage()` unawaited and unchecked, then toasted success.
- **6e** The forum registry was enumerated at three different depths, and the schema layer defeated the generic ones.

### Worth a reviewer's eye

**6b keeps two failure modes distinct.** `resolveRequestUser` returns a discriminated result, not `IUser | null` — collapsing them would change the client-visible error for a bad token (a *missing* token yields 401 `'Authentication token not found'` via `checkUserAuthorized(null)`; an *invalid* one is an explicit `UNAUTHORIZED`). The `console.error` moved inside the resolver; it is the only server-side trace of an auth failure.

**6c is a silent-failure class.** `Favicon` only *reads* the cache — a miss returns `''` and never fetches. So if the provider and the cache-warming paths disagree, every favicon in that app renders the fallback forever: nothing throws, no request is made, and the `bookmark-favicon` visibility assertions still pass.

**6d was a real hole.** That call is the only writer of `mappedRedirections` outside sign-in, and `redirect()` reads it on **every navigation** — so a failed round-trip, or the popup closing first, left the pre-edit rule table live indefinitely while the panel showed the new rules.

**6e changes the popup gate's semantics.** It tested `hostname.includes(...)`; the unified matcher tests `url.includes(...)`, which is what extraction always did. The gate will therefore enable in cases it previously did not (website values carrying a path or query) — the intended direction, since extraction would have succeeded there anyway.

Also: the extractor table's value is a **selector taking the url**, not a bare extractor. FORUM_1/FORUM_2 choose between two extractors at runtime from the pathname, which a plain `Record<string, extractor>` cannot express.

Root cause on 6e worth stating: `WebsitesSchema` was a fixed zod object and zod strips unknown keys, so adding `FORUM_5` in Firebase got the key dropped **at the tRPC output boundary** and surfaced as `Not a forum page` nowhere near the cause. The key-agnostic decoder in `storageSync` could never see the key it was generalized for. It now can.

### Not included

**6f** (consolidating the test-side storage helpers and deleting `runWithBackground`'s 8×/100ms retry) is deliberately left out — it is flake-sensitive and the plan sequences it last. Worth a follow-up.

### Verification

`pnpm lint`, `pnpm format:check`, `pnpm typecheck:all` clean; 91 Playwright tests resolve.

**Needs manual checks** — none of these are covered by the suite:
- `curl -X POST $URL/api/storage-cleanup -H 'Authorization: Bearer wrong'` → expect **403**, not 500; correct key still succeeds.
- tRPC with no header → 401 `'Authentication token not found'`; with a malformed bearer → `UNAUTHORIZED`, and confirm it is still logged server-side. `POST /api/upload-file` with a bad bearer → 401; authenticated upload still works.
- Clear the favicon cache bucket, sign in, confirm favicons render in **both** apps.
- Save a shortcut rule with the network failing → expect the failure toast, not "Saved successfully".
- Add a `FORUM_5` entry with an extractor and confirm the button enables and extracts; confirm `FORUM_1..4` still work, including the FORUM_1/2 `/watched/threads` branch.

---
### Stack

This is part of a 6-PR stack from a repo-wide `/simplify` pass. Merge in order — each PR is based on the previous one.

1. #4135 — dead code and trivial collapses
2. #4136 — single-use wrappers and helper reuse
3. #4137 — collapse duplicated mechanisms
4. #4138 — derivable state
5. #4139 — wasted work on hot paths
6. #4140 — wrong-altitude fixes

Every commit passes `pnpm lint`, `pnpm format:check`, `pnpm typecheck:all`, and all 91 Playwright tests still resolve. **E2E has not been executed** — that needs a running dev server; see the checklist in each PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

 

<details><summary><h3>Greptile Summary</h3></summary>

The PR centralizes request-user resolution and favicon-provider selection, makes redirection synchronization awaitable and retryable, and consolidates forum matching with extraction capability.
- Maps invalid internal cleanup credentials to an explicit forbidden response.
- Shares token-to-user resolution between tRPC and REST authorization.
- Uses app-level favicon providers for cache reads and writes.
- Preserves arbitrary website keys while gating forum actions on available extractors.
- Awaits local redirection refresh and retains the Save retry path after failure.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until newly configured forum keys can obtain an extractor rather than being silently disabled.

The schema now preserves keys such as `FORUM_5`, but the fixed `FORUM_EXTRACTORS` registry recognizes only the first four keys, so a new Firebase forum entry reaches local configuration yet remains unusable in the popup.

**Files Needing Attention:** packages/shared/src/schema/websitesSchema.ts; apps/extension/src/entrypoints/background/misc/forumPageLinks.ts
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: gate forums on extractor presence, ..."](https://github.com/amitsingh-007/bypass-links/commit/1385b63362b4b841fd9d139c74cb5bbe78621fa0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50447477)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Extension background service worker](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/extension-background.md)
- Knowledge Base — [Extension Popup UI](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/extension-popup.md)
- Knowledge Base — [Shared package (`packages/shared`)](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/shared-package.md)
</details>

<!-- /greptile_comment -->