### PR TITLE
feat: better integrate SWR and tRPC

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bypass/extension",
-  "version": "25.4.0",
+  "version": "25.5.0",
   "private": true,
   "description": "Bypass links from various sites to required links, with added functionality of Bookmarks Manager, Tagging Panel.",
   "type": "module",

--- a/apps/extension/src/entrypoints/background/redirections/index.ts
+++ b/apps/extension/src/entrypoints/background/redirections/index.ts
@@ -1,3 +1,6 @@
+import { swrKeys } from '@bypass/shared';
+import { mutate } from 'swr';
+
 import { trpcApi } from '@/apis/trpcApi';
 import { redirectionsItem, mappedRedirectionsItem } from '@/storage/items';
 import { startHistoryWatch } from '@/utils/history';
@@ -21,6 +24,7 @@ export const syncRedirectionsToStorage = async () => {
     redirectionsItem.setValue(redirections),
     mappedRedirectionsItem.setValue(mapRedirections(redirections)),
   ]);
+  await mutate(swrKeys.redirections);
 };
 
 export const resetRedirections = async () => {

--- a/apps/extension/src/entrypoints/popup/hooks/useCurrentTab.ts
+++ b/apps/extension/src/entrypoints/popup/hooks/useCurrentTab.ts
@@ -1,23 +1,11 @@
-import { useEffect, useState } from 'react';
+import { swrKeys } from '@bypass/shared';
+import useSWR from 'swr';
 
 import { getCurrentTab } from '@popup/utils/tabs';
 
 const useCurrentTab = () => {
-  const [tab, setTab] = useState<Browser.tabs.Tab>();
-
-  useEffect(() => {
-    let ignore = false;
-    getCurrentTab().then((curTab) => {
-      if (!ignore) {
-        setTab(curTab);
-      }
-    });
-    return () => {
-      ignore = true;
-    };
-  }, []);
-
-  return tab;
+  const { data } = useSWR(swrKeys.currentTab, getCurrentTab);
+  return data;
 };
 
 export default useCurrentTab;

--- a/apps/extension/src/entrypoints/popup/hooks/useLastVisited.ts
+++ b/apps/extension/src/entrypoints/popup/hooks/useLastVisited.ts
@@ -1,8 +1,9 @@
+import { swrKeys } from '@bypass/shared';
 import useSWR from 'swr';
 
 import { getlastVisitedText } from '@popup/utils/lastVisited';
 
 const useLastVisited = (url = '') =>
-  useSWR(url ? ['last-visited', url] : null, () => getlastVisitedText(url));
+  useSWR(swrKeys.lastVisited(url), () => getlastVisitedText(url));
 
 export default useLastVisited;

--- a/apps/extension/src/entrypoints/popup/hooks/usePersonsWithImages.ts
+++ b/apps/extension/src/entrypoints/popup/hooks/usePersonsWithImages.ts
@@ -2,17 +2,12 @@ import {
   sortAlphabetically,
   sortByRecency,
   useAllPersonsWithImages,
-  useBookmark,
+  useDefaultFolderUrls,
 } from '@bypass/shared';
-import useSWR from 'swr';
 
 const usePersonsWithImages = (orderByRecency: boolean) => {
-  const { getDefaultOrRootFolderUrls } = useBookmark();
   const { data: personsWithImageUrl = [], ...rest } = useAllPersonsWithImages();
-  const { data: urls = [] } = useSWR(
-    'default-folder-urls',
-    getDefaultOrRootFolderUrls
-  );
+  const { data: urls = [] } = useDefaultFolderUrls();
 
   const data = orderByRecency
     ? sortByRecency(personsWithImageUrl, urls)

--- a/apps/extension/src/entrypoints/popup/hooks/useQuickBookmark.ts
+++ b/apps/extension/src/entrypoints/popup/hooks/useQuickBookmark.ts
@@ -5,7 +5,7 @@ import { bookmarksItem } from '@/storage/items';
 import { findBookmarkByUrl } from '@popup/panels/BookmarksPanel/utils/bookmark';
 
 const useQuickBookmark = (enabled: boolean, url = '') =>
-  useSWR(enabled && url ? swrKeys.quickBookmark : null, async () => {
+  useSWR(enabled ? swrKeys.quickBookmark(url) : null, async () => {
     const bookmarks = await bookmarksItem.getValue();
     if (!bookmarks) {
       return undefined;

--- a/apps/extension/src/entrypoints/popup/hooks/useQuickBookmark.ts
+++ b/apps/extension/src/entrypoints/popup/hooks/useQuickBookmark.ts
@@ -1,14 +1,11 @@
-import { getDecryptedBookmark } from '@bypass/shared';
+import { getDecryptedBookmark, swrKeys } from '@bypass/shared';
 import useSWR from 'swr';
 
 import { bookmarksItem } from '@/storage/items';
 import { findBookmarkByUrl } from '@popup/panels/BookmarksPanel/utils/bookmark';
-import { getCurrentTab } from '@popup/utils/tabs';
 
-const useQuickBookmark = (enabled: boolean) =>
-  useSWR(enabled ? 'quick-bookmark' : null, async () => {
-    const currentTab = await getCurrentTab();
-    const url = currentTab?.url ?? '';
+const useQuickBookmark = (enabled: boolean, url = '') =>
+  useSWR(enabled && url ? swrKeys.quickBookmark : null, async () => {
     const bookmarks = await bookmarksItem.getValue();
     if (!bookmarks) {
       return undefined;

--- a/apps/extension/src/entrypoints/popup/index.tsx
+++ b/apps/extension/src/entrypoints/popup/index.tsx
@@ -1,7 +1,9 @@
 import '@bypass/ui/styles/globals.css';
+import { swrConfig } from '@bypass/shared';
 import { TooltipProvider } from '@bypass/ui';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { SWRConfig } from 'swr';
 
 import './fonts.css';
 import './layout.css';
@@ -12,12 +14,14 @@ import DynamicProvider from './provider/DynamicProvider';
 function App() {
   return (
     <StrictMode>
-      <TooltipProvider>
-        <DynamicProvider>
-          <PopupRoutes />
-          <Global />
-        </DynamicProvider>
-      </TooltipProvider>
+      <SWRConfig value={swrConfig}>
+        <TooltipProvider>
+          <DynamicProvider>
+            <PopupRoutes />
+            <Global />
+          </DynamicProvider>
+        </TooltipProvider>
+      </SWRConfig>
     </StrictMode>
   );
 }

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/utils/index.ts
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/utils/index.ts
@@ -1,4 +1,8 @@
-import { type IBookmarksObj, type ISelectedBookmarks } from '@bypass/shared';
+import {
+  type IBookmarksObj,
+  type ISelectedBookmarks,
+  invalidateBookmarkKeys,
+} from '@bypass/shared';
 
 import { bookmarksItem, hasPendingBookmarksItem } from '@/storage/items';
 
@@ -15,4 +19,5 @@ export const setBookmarksInStorage = async (bookmarksObj: IBookmarksObj) => {
     bookmarksItem.setValue(bookmarksObj),
     hasPendingBookmarksItem.setValue(true),
   ]);
+  await invalidateBookmarkKeys();
 };

--- a/apps/extension/src/entrypoints/popup/panels/HomePopup/components/LastVisitedButton.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/HomePopup/components/LastVisitedButton.tsx
@@ -1,4 +1,4 @@
-import { sha256Hash } from '@bypass/shared';
+import { swrKeys } from '@bypass/shared';
 import {
   Button,
   Spinner,
@@ -11,40 +11,44 @@ import {
   Appointment01Icon,
 } from '@hugeicons/core-free-icons';
 import { HugeiconsIcon } from '@hugeicons/react';
-import { useState } from 'react';
+import { toast } from 'sonner';
+import useSWRMutation from 'swr/mutation';
 
 import { trpcApi } from '@/apis/trpcApi';
-import { lastVisitedItem } from '@/storage/items';
 import useFirebaseStore from '@/store/firebase/useFirebaseStore';
 import useCurrentTab from '@popup/hooks/useCurrentTab';
 import useLastVisited from '@popup/hooks/useLastVisited';
+import {
+  getHostnameHash,
+  setLastVisitedInStorage,
+} from '@popup/utils/lastVisited';
 
 function LastVisitedButton() {
   const isSignedIn = useFirebaseStore((state) => state.isSignedIn);
   const currentTab = useCurrentTab();
-  const [isFetching, setIsFetching] = useState(false);
 
   const url = currentTab?.url;
-  const { data: lastVisited = '', mutate: mutateLastVisited } = useLastVisited(
+  const { data: lastVisited = '' } = useLastVisited(
     isSignedIn ? url : undefined
   );
 
-  const handleUpdateLastVisited = async () => {
+  const { trigger: updateLastVisited, isMutating } = useSWRMutation(
+    swrKeys.lastVisited(url),
+    async ([, pageUrl]) => {
+      const hash = await getHostnameHash(pageUrl);
+      const result = await trpcApi.firebaseData.upsertLastVisited.mutate({
+        hash,
+      });
+      await setLastVisitedInStorage(result.hash, result.timestamp);
+    },
+    { onError: () => toast.error('Could not update last visited') }
+  );
+
+  const handleUpdateLastVisited = () => {
     if (!url) {
       return;
     }
-    setIsFetching(true);
-    const { hostname } = new URL(url);
-    const hash = await sha256Hash(hostname);
-    const result = await trpcApi.firebaseData.upsertLastVisited.mutate({
-      hash,
-    });
-    // Patch local storage with just this entry
-    const lastVisitedObj = await lastVisitedItem.getValue();
-    lastVisitedObj[result.hash] = result.timestamp;
-    await lastVisitedItem.setValue(lastVisitedObj);
-    await mutateLastVisited();
-    setIsFetching(false);
+    updateLastVisited();
   };
 
   return (
@@ -53,11 +57,11 @@ function LastVisitedButton() {
         <Button
           className="w-full font-medium"
           variant={lastVisited ? 'default' : 'outline'}
-          disabled={!isSignedIn || isFetching}
+          disabled={!isSignedIn || isMutating}
           data-testid="last-visited-button"
           onClick={handleUpdateLastVisited}
         >
-          {isFetching && <Spinner className="mr-2 size-4" />}
+          {isMutating && <Spinner className="mr-2 size-4" />}
           Visited
           <HugeiconsIcon
             icon={lastVisited ? Appointment01Icon : CalendarAdd01Icon}

--- a/apps/extension/src/entrypoints/popup/panels/HomePopup/components/QuickBookmarkButton.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/HomePopup/components/QuickBookmarkButton.tsx
@@ -20,15 +20,19 @@ import { HugeiconsIcon } from '@hugeicons/react';
 import { useLocation } from 'wouter';
 
 import useFirebaseStore from '@/store/firebase/useFirebaseStore';
+import useCurrentTab from '@popup/hooks/useCurrentTab';
 import useQuickBookmark from '@popup/hooks/useQuickBookmark';
-import { getCurrentTab } from '@popup/utils/tabs';
 
 function QuickBookmarkButton() {
   const [, navigate] = useLocation();
   const isSignedIn = useFirebaseStore((state) => state.isSignedIn);
   const { getFolderFromHash } = useBookmark();
-  const { data: bookmark, isLoading: isFetching } =
-    useQuickBookmark(isSignedIn);
+  const currentTab = useCurrentTab();
+  const currentUrl = currentTab?.url ?? '';
+  const { data: bookmark, isLoading: isFetching } = useQuickBookmark(
+    isSignedIn,
+    currentUrl
+  );
 
   const handleClick = async () => {
     const urlParams: Partial<BMPanelQueryParams> = {};
@@ -39,9 +43,8 @@ function QuickBookmarkButton() {
       urlParams.bmUrl = url;
       urlParams.folderId = parent.id;
     } else {
-      const { url } = await getCurrentTab();
       urlParams.operation = EBookmarkOperation.ADD;
-      urlParams.bmUrl = url;
+      urlParams.bmUrl = currentUrl;
       urlParams.folderId = ROOT_FOLDER_ID;
     }
     navigate(getBookmarksPanelUrl(urlParams));

--- a/apps/extension/src/entrypoints/popup/panels/HomePopup/hooks/useExtensionOutdated.ts
+++ b/apps/extension/src/entrypoints/popup/panels/HomePopup/hooks/useExtensionOutdated.ts
@@ -4,43 +4,38 @@ import { trpcApi } from '@/apis/trpcApi';
 import useFirebaseStore from '@/store/firebase/useFirebaseStore';
 import useOutdatedExtensionStore from '@/store/outdatedExtension';
 
-const checkForUpdates = async () => {
-  const { chrome: chromeData } = await trpcApi.extension.latest.query();
-  const { version: currentVersion } = browser.runtime.getManifest();
-  return chromeData.version === currentVersion;
-};
+const ONE_HOUR_MS = 1000 * 60 * 60;
 
-const shouldCheckForUpdates = () => {
-  const { isSignedIn } = useFirebaseStore.getState();
-  if (!isSignedIn) {
-    return false;
-  }
+const isCheckDue = () => {
   const { lastChecked } = useOutdatedExtensionStore.getState();
-  if (!lastChecked) {
-    return true;
-  }
-  const diff = Date.now() - lastChecked;
-  return diff > 1000 * 60 * 60; // 1 hour
+  return Date.now() - (lastChecked ?? 0) > ONE_HOUR_MS;
 };
 
 const red = '#FF6B6B';
 
+const markOutdated = () => {
+  browser.action.setBadgeText({ text: '!' });
+  browser.action.setBadgeBackgroundColor({ color: red });
+  browser.action.setTitle({
+    title: 'You are using older version of Bypass Links',
+  });
+};
+
 const useExtensionOutdated = () => {
+  // A [] dep would miss it: sign-in is set by the auth effect, after mount
+  const isSignedIn = useFirebaseStore((state) => state.isSignedIn);
+
   useEffect(() => {
-    if (!shouldCheckForUpdates()) {
+    if (!isSignedIn || !isCheckDue()) {
       return;
     }
-    checkForUpdates().then((isUsingLatest) => {
-      if (!isUsingLatest) {
-        browser.action.setBadgeText({ text: '!' });
-        browser.action.setBadgeBackgroundColor({ color: red });
-        browser.action.setTitle({
-          title: 'You are using older version of Bypass Links',
-        });
+    trpcApi.extension.latest.query().then(({ chrome: chromeData }) => {
+      if (chromeData.version !== browser.runtime.getManifest().version) {
+        markOutdated();
       }
       useOutdatedExtensionStore.getState().setLastChecked(Date.now());
     });
-  }, []);
+  }, [isSignedIn]);
 };
 
 export default useExtensionOutdated;

--- a/apps/extension/src/entrypoints/popup/panels/HomePopup/utils/sync.ts
+++ b/apps/extension/src/entrypoints/popup/panels/HomePopup/utils/sync.ts
@@ -1,4 +1,8 @@
-import { ECacheBucketKeys, deleteAllCache } from '@bypass/shared';
+import {
+  ECacheBucketKeys,
+  deleteAllCache,
+  invalidateAllKeys,
+} from '@bypass/shared';
 
 import useProgressStore from '@/store/progress';
 import {
@@ -40,6 +44,7 @@ const syncFirebaseToStorage = async () => {
     syncLastVisitedToStorage(),
     syncPersonsToStorage(),
   ]);
+  await invalidateAllKeys();
 };
 
 const syncStorageToFirebase = async () => {
@@ -56,6 +61,7 @@ const resetStorage = async () => {
     resetPersons(),
     refreshPersonImageUrlsCache(),
   ]);
+  await invalidateAllKeys();
 };
 
 export const processPostLogin = async () => {

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/AddOrEditPersonDialog.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/AddOrEditPersonDialog.tsx
@@ -77,7 +77,6 @@ function AddOrEditPersonDialog({
   const uid = useSelector(form.store, (state) => state.values.uid);
   // Revalidation off so an optimistic upload isn't refetched back to the pre-save value
   const { data: imageUrl = '', mutate: mutateImage } = usePersonImage(uid, {
-    revalidateOnFocus: false,
     revalidateIfStale: false,
     onSuccess: (image) => setIsAvatarImageLoading(Boolean(image)),
   });

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/PersonsPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/PersonsPanel.tsx
@@ -10,61 +10,46 @@ import {
   type IPersons,
   Persons,
   sortAlphabetically,
-  useBookmark,
+  useDefaultFolderUrls,
   usePerson,
+  usePersons,
 } from '@bypass/shared';
 import { Spinner } from '@bypass/ui';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { toast } from 'sonner';
-import useSWR from 'swr';
 import { useLocation } from 'wouter';
 
 import { trpcApi } from '@/apis/trpcApi';
 import { MAX_PANEL_SIZE } from '@/constants';
 import Panel from '@popup/components/Panel';
 
+import { getPersonPos, setPersonsInStorage } from '../utils';
 import {
-  getAllDecodedPersons,
-  getPersonPos,
-  setPersonsInStorage,
-} from '../utils';
-import {
-  invalidatePersonCaches,
   removePersonImageUrl,
   updatePersonCacheAndImageUrls,
 } from '../utils/sync';
 import PersonHeader from './PersonHeader';
 import PersonVirtualCell from './PersonVirtualCell';
 
-const handleSave = async (persons: IPerson[]) => {
+const handleSave = async (persons: IPerson[], uid: string) => {
   const encryptedPersons = persons.reduce<IPersons>((obj, person) => {
     obj[person.uid] = getEncryptedPerson(person);
     return obj;
   }, {});
-  await setPersonsInStorage(encryptedPersons);
+  await setPersonsInStorage(encryptedPersons, uid);
 };
 
 function PersonsPanel() {
   const [, navigate] = useLocation();
   const { getPersonTaggedUrls } = usePerson();
-  const { getDefaultOrRootFolderUrls } = useBookmark();
-  const [persons, setPersons] = useState<IPerson[]>([]);
-  const [isFetching, setIsFetching] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
   const [searchText, setSearchText] = useState('');
   const [orderByRecency, setOrderByRecency] = useState(true);
 
-  useEffect(() => {
-    getAllDecodedPersons().then((decodedPersons) => {
-      setPersons(sortAlphabetically(decodedPersons));
-      setIsFetching(false);
-    });
-  }, []);
+  const { data: persons = [], isLoading } = usePersons();
+  const { data: urls = [] } = useDefaultFolderUrls();
 
-  // Stable key so typing does not re-read bookmarks
-  const { data: urls = [] } = useSWR(
-    'default-folder-urls',
-    getDefaultOrRootFolderUrls
-  );
+  const isFetching = isLoading || isSaving;
 
   const orderedPersons = orderByRecency
     ? sortByRecency(persons, urls)
@@ -74,47 +59,51 @@ function PersonsPanel() {
     searchText
   );
 
+  const runSave = async (errorMessage: string, save: () => Promise<void>) => {
+    setIsSaving(true);
+    try {
+      await save();
+    } catch {
+      toast.error(errorMessage);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
   const handleAddOrEditPerson = async (person: IPerson) => {
-    setIsFetching(true);
     const pos = getPersonPos(persons, person);
     const isNewPerson = pos === -1;
-    const newPersons = [...persons];
-    if (isNewPerson) {
-      // Add person
-      newPersons.push(person);
-    } else {
-      // Update person
-      newPersons[pos] = person;
-    }
-    // Update person cache
-    await updatePersonCacheAndImageUrls(person);
-    // Update in the list
-    const sortedPersons = sortAlphabetically(newPersons);
-    setPersons(sortedPersons);
-    await handleSave(sortedPersons);
-    setIsFetching(false);
-    toast.success(
-      `${person.name} ${isNewPerson ? 'added' : 'updated'} successfully`
-    );
+    const newPersons = isNewPerson
+      ? [...persons, person]
+      : persons.with(pos, person);
+
+    await runSave(`Could not save ${person.name}`, async () => {
+      await updatePersonCacheAndImageUrls(person);
+      await handleSave(sortAlphabetically(newPersons), person.uid);
+      toast.success(
+        `${person.name} ${isNewPerson ? 'added' : 'updated'} successfully`
+      );
+    });
   };
 
   const handlePersonDelete = async (person: IPerson) => {
     const pos = getPersonPos(persons, person);
+    // Without this, toSpliced(-1, 1) would drop the last person instead
+    if (pos === -1) {
+      return;
+    }
     const taggedUrls = await getPersonTaggedUrls(person.uid);
     if (taggedUrls.length > 0) {
       toast.error('Cannot delete a person with tagged bookmarks');
       return;
     }
-    setIsFetching(true);
-    const newPersons = [...persons];
-    newPersons.splice(pos, 1);
-    setPersons(newPersons);
-    await trpcApi.storage.removeFile.mutate(getPersonImageName(person.uid));
-    await removePersonImageUrl(person.uid);
-    await handleSave(newPersons);
-    await invalidatePersonCaches();
-    setIsFetching(false);
-    toast.success('Person deleted successfully');
+
+    await runSave(`Could not delete ${person.name}`, async () => {
+      await trpcApi.storage.removeFile.mutate(getPersonImageName(person.uid));
+      await removePersonImageUrl(person.uid);
+      await handleSave(persons.toSpliced(pos, 1), person.uid);
+      toast.success('Person deleted successfully');
+    });
   };
 
   const toggleOrderByRecency = () => setOrderByRecency((prev) => !prev);

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/utils/index.ts
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/utils/index.ts
@@ -1,12 +1,18 @@
-import { decodePersons, type IPerson, type IPersons } from '@bypass/shared';
+import {
+  decodePersons,
+  type IPerson,
+  type IPersons,
+  invalidatePersonKeys,
+} from '@bypass/shared';
 
 import { personsItem, hasPendingPersonsItem } from '@/storage/items';
 
-export const setPersonsInStorage = async (persons: IPersons) => {
+export const setPersonsInStorage = async (persons: IPersons, uid?: string) => {
   await Promise.all([
     personsItem.setValue(persons),
     hasPendingPersonsItem.setValue(true),
   ]);
+  await invalidatePersonKeys(uid);
 };
 
 export const getAllDecodedPersons = async () => {

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/utils/sync.ts
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/utils/sync.ts
@@ -1,6 +1,5 @@
 import {
   addToCache,
-  ALL_PERSONS_WITH_IMAGES_KEY,
   buildPersonImageUrls,
   cachePersonImages,
   ECacheBucketKeys,
@@ -8,7 +7,6 @@ import {
   getPersonImageName,
   type IPerson,
 } from '@bypass/shared';
-import { mutate } from 'swr';
 
 import { trpcApi } from '@/apis/trpcApi';
 import {
@@ -35,14 +33,6 @@ export const resetPersons = async () => {
 
 const resolveDownloadUrl = async (fileName: string) =>
   trpcApi.storage.getDownloadUrl.query(fileName);
-
-/** Global mutate, not useSWRConfig: this module is not a hook. */
-export const invalidatePersonCaches = async () => {
-  await Promise.all([
-    mutate(ALL_PERSONS_WITH_IMAGES_KEY),
-    mutate((key) => Array.isArray(key) && key[0] === 'person-image'),
-  ]);
-};
 
 export const refreshPersonImageUrlsCache = async () => {
   await personImageUrlsItem.removeValue();
@@ -85,5 +75,4 @@ export const updatePersonCacheAndImageUrls = async (person: IPerson) => {
   evictBlobUrl(previousImageUrl);
   evictBlobUrl(imageUrl);
   await addToCache(ECacheBucketKeys.person, imageUrl);
-  await invalidatePersonCaches();
 };

--- a/apps/extension/src/entrypoints/popup/panels/ShortcutsPanel/components/RedirectionRule.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/ShortcutsPanel/components/RedirectionRule.tsx
@@ -18,9 +18,9 @@ import {
   LinkSquare02Icon,
 } from '@hugeicons/core-free-icons';
 import { HugeiconsIcon } from '@hugeicons/react';
-import { use, useEffect, useState } from 'react';
+import { use, useState } from 'react';
 
-import { getlastVisitedText } from '@popup/utils/lastVisited';
+import useLastVisited from '@popup/hooks/useLastVisited';
 
 import { DEFAULT_RULE_ALIAS } from '../constants';
 import { ReorderButton } from './ReorderButton';
@@ -47,15 +47,7 @@ function RedirectionRule({
   const [ruleAlias, setRuleAlias] = useState(alias);
   const [ruleWebsite, setRuleWebsite] = useState(website);
   const [isDefaultRule, setIsDefaultRule] = useState(isDefault);
-  const [lastVisited, setLastVisited] = useState<string>();
-
-  useEffect(() => {
-    const initLastVisited = async () => {
-      const lastVisitedText = await getlastVisitedText(website);
-      setLastVisited(lastVisitedText);
-    };
-    initLastVisited();
-  }, [website]);
+  const { data: lastVisited } = useLastVisited(website);
 
   const handleRemoveClick = () => {
     handleRemoveRule(pos);

--- a/apps/extension/src/entrypoints/popup/panels/ShortcutsPanel/components/ShortcutsPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/ShortcutsPanel/components/ShortcutsPanel.tsx
@@ -1,9 +1,16 @@
-import { Header, type IRedirection, type IRedirections } from '@bypass/shared';
+import {
+  Header,
+  type IRedirection,
+  type IRedirections,
+  swrKeys,
+} from '@bypass/shared';
 import { Button, Spinner } from '@bypass/ui';
 import { Link01Icon, Download03Icon } from '@hugeicons/core-free-icons';
 import { HugeiconsIcon } from '@hugeicons/react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { toast } from 'sonner';
+import useSWR from 'swr';
+import useSWRMutation from 'swr/mutation';
 
 import { trpcApi } from '@/apis/trpcApi';
 import { redirectionsItem } from '@/storage/items';
@@ -14,78 +21,77 @@ import { DEFAULT_RULE_ALIAS } from '../constants';
 import { getValidRules, isMatchingRule } from '../utils';
 import RedirectionRule from './RedirectionRule';
 
+const SAVE_ERROR = 'Could not save shortcuts';
+
+const fetchRedirections = async () => {
+  const stored = await redirectionsItem.getValue();
+  return stored.map(
+    ({ alias, website, isDefault }) =>
+      ({
+        alias: atob(alias),
+        website: atob(website),
+        isDefault,
+      }) satisfies IRedirection
+  );
+};
+
 function ShortcutsPanel() {
-  const [redirections, setRedirections] = useState<IRedirections>([]);
   const [searchText, setSearchText] = useState('');
-  const [isFetching, setIsFetching] = useState(true);
-  const [isSaveActive, setIsSaveActive] = useState(false);
+  // null means "no local edits yet", distinct from "edited to an empty list"
+  const [stagedRedirections, setStagedRedirections] =
+    useState<IRedirections | null>(null);
 
-  useEffect(() => {
-    redirectionsItem.getValue().then((_redirections) => {
-      const modifiedRedirections = _redirections.map(
-        ({ alias, website, isDefault }) =>
-          ({
-            alias: atob(alias),
-            website: atob(website),
-            isDefault,
-          }) satisfies IRedirection
-      );
-      setRedirections(modifiedRedirections);
-      setIsFetching(false);
-    });
-  }, []);
+  const { data: storedRedirections, isLoading } = useSWR(
+    swrKeys.redirections,
+    fetchRedirections
+  );
+  const redirections = stagedRedirections ?? storedRedirections ?? [];
 
-  const saveRedirectionTemp = (newRedirections: IRedirections) => {
-    setRedirections(newRedirections);
-    setIsSaveActive(true);
-  };
-
-  const handleSave = async () => {
-    setIsFetching(true);
-    const validRules = redirections.filter(getValidRules);
-    const isSaveSuccess =
-      await trpcApi.firebaseData.redirectionsPost.mutate(validRules);
-    if (isSaveSuccess) {
-      syncRedirectionsToStorage();
-      setRedirections(validRules);
+  const { trigger: saveRedirections, isMutating } = useSWRMutation(
+    swrKeys.redirections,
+    async (_key, { arg: rules }: { arg: IRedirections }) => {
+      const validRules = rules.filter(getValidRules);
+      const isSaveSuccess =
+        await trpcApi.firebaseData.redirectionsPost.mutate(validRules);
+      // Thrown, not returned early, so a false response and a rejection look the same
+      if (!isSaveSuccess) {
+        throw new Error(SAVE_ERROR);
+      }
+      await syncRedirectionsToStorage();
+      setStagedRedirections(null);
       toast.success('Saved successfully');
-    }
-    setIsSaveActive(false);
-    setIsFetching(false);
-  };
+    },
+    { onError: () => toast.error(SAVE_ERROR) }
+  );
 
-  const handleAddRule = () => {
-    const newRedirections = [
-      {
-        alias: DEFAULT_RULE_ALIAS,
-        website: '',
-        isDefault: false,
-      },
-      ...redirections,
-    ];
-    saveRedirectionTemp(newRedirections);
-  };
+  const isFetching = isLoading || isMutating;
+  const isSaveActive = stagedRedirections !== null;
 
-  const handleRemoveRule = (pos: number) => {
-    const newRedirections = [...redirections];
-    newRedirections.splice(pos, 1);
-    saveRedirectionTemp(newRedirections);
-  };
+  const stageEdit = (edit: (rules: IRedirections) => IRedirections) =>
+    setStagedRedirections(edit(redirections));
 
-  const handleSaveRule = (redirection: IRedirection, pos: number) => {
-    const newRedirections = [...redirections];
-    newRedirections[pos] = redirection;
-    saveRedirectionTemp(newRedirections);
-  };
+  const handleSave = () => saveRedirections(redirections);
+
+  const handleAddRule = () =>
+    stageEdit((rules) => [
+      { alias: DEFAULT_RULE_ALIAS, website: '', isDefault: false },
+      ...rules,
+    ]);
+
+  const handleRemoveRule = (pos: number) =>
+    stageEdit((rules) => rules.toSpliced(pos, 1));
+
+  const handleSaveRule = (redirection: IRedirection, pos: number) =>
+    stageEdit((rules) => rules.with(pos, redirection));
 
   const handleRuleMove = (pos: number, offset: number) => {
     const target = pos + offset;
     if (target < 0 || target >= redirections.length) {
       return;
     }
-    const newRedirs = [...redirections];
-    [newRedirs[pos], newRedirs[target]] = [newRedirs[target], newRedirs[pos]];
-    saveRedirectionTemp(newRedirs);
+    stageEdit((rules) =>
+      rules.with(pos, rules[target]).with(target, rules[pos])
+    );
   };
 
   return (
@@ -106,7 +112,7 @@ function ShortcutsPanel() {
         </Button>
       </Header>
       <div className="relative flex flex-1 flex-col gap-2 overflow-auto px-1 pt-2 pb-1">
-        {redirections?.map((redirection, index) => {
+        {redirections.map((redirection, index) => {
           const isMatch = isMatchingRule(redirection, searchText);
           return (
             <div

--- a/apps/extension/src/entrypoints/popup/utils/lastVisited.ts
+++ b/apps/extension/src/entrypoints/popup/utils/lastVisited.ts
@@ -1,18 +1,32 @@
-import { sha256Hash } from '@bypass/shared';
+import { sha256Hash, swrKeyMatchers } from '@bypass/shared';
+import { mutate } from 'swr';
 
 import { lastVisitedItem } from '@/storage/items';
 
-export const getlastVisitedText = async (url: string) => {
-  const lastVisitedData = await lastVisitedItem.getValue();
+export const getHostnameHash = async (url: string) => {
   if (!URL.canParse(url)) {
     return '';
   }
-  const { hostname } = new URL(url);
-  const hash = await sha256Hash(hostname);
-  const lastVisitedDate = lastVisitedData[hash];
+  return sha256Hash(new URL(url).hostname);
+};
+
+export const getlastVisitedText = async (url: string) => {
+  const lastVisitedData = await lastVisitedItem.getValue();
+  const hash = await getHostnameHash(url);
+  const lastVisitedDate = hash && lastVisitedData[hash];
   if (!lastVisitedDate) {
     return '';
   }
   const date = new Date(lastVisitedDate);
   return `${date.toDateString()}, ${date.toLocaleTimeString()}`;
+};
+
+export const setLastVisitedInStorage = async (
+  hash: string,
+  timestamp: number
+) => {
+  const lastVisitedObj = await lastVisitedItem.getValue();
+  lastVisitedObj[hash] = timestamp;
+  await lastVisitedItem.setValue(lastVisitedObj);
+  await mutate(swrKeyMatchers.lastVisited);
 };

--- a/apps/web/src/app/bookmark-panel/hooks/usePreloadBookmarks.ts
+++ b/apps/web/src/app/bookmark-panel/hooks/usePreloadBookmarks.ts
@@ -7,6 +7,7 @@ import {
   getBookmarkFaviconUrls,
   getYandexFaviconUrl,
   isCachePresent,
+  invalidateBookmarkKeys,
 } from '@bypass/shared';
 import { useCallback, useState } from 'react';
 
@@ -56,6 +57,7 @@ const usePreloadBookmarks = () => {
     try {
       await syncBookmarksToStorage();
       await cacheBookmarkFavicons();
+      await invalidateBookmarkKeys();
     } finally {
       setIsLoading(false);
     }
@@ -65,6 +67,7 @@ const usePreloadBookmarks = () => {
     setIsLoading(true);
     removeFromLocalStorage(STORAGE_KEYS.bookmarks);
     await deleteCache(ECacheBucketKeys.favicon);
+    await invalidateBookmarkKeys();
     setIsLoading(false);
   };
 

--- a/apps/web/src/app/bookmark-panel/page.tsx
+++ b/apps/web/src/app/bookmark-panel/page.tsx
@@ -10,24 +10,28 @@ import {
   Header,
   type IBookmarksObj,
   STORAGE_KEYS,
+  swrKeys,
 } from '@bypass/shared';
 import { ScrollArea } from '@bypass/ui';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useSearchParams } from 'next/navigation';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
+import useSWR from 'swr';
 
 import { getFromLocalStorage } from '@app/utils/storage';
 
 import VirtualRow from './components/VirtualRow';
 
+const fetchBookmarks = () =>
+  getFromLocalStorage<IBookmarksObj>(STORAGE_KEYS.bookmarks);
+
 export default function BookmarksPage() {
   const searchParams = useSearchParams();
   const scrollAreaRef = useRef<HTMLDivElement>(null);
   const folderId = searchParams?.get('folderId') ?? ROOT_FOLDER_ID;
-  const [bookmarksData, setBookmarksData] = useState<IBookmarksObj | null>(
-    null
-  );
   const [searchText, setSearchText] = useState('');
+
+  const { data: bookmarksData } = useSWR(swrKeys.bookmarks, fetchBookmarks);
 
   const folders = bookmarksData?.folders ?? {};
   // `?? []`: this runs in the render body, so a stale folderId would crash the tree
@@ -50,13 +54,6 @@ export default function BookmarksPage() {
     getScrollElement: () => scrollAreaRef.current,
     getItemKey: (idx) => filteredContextBookmarks[idx].id,
   });
-
-  // Kept in an effect for hydration safety — localStorage is client-only
-  useEffect(() => {
-    setBookmarksData(
-      getFromLocalStorage<IBookmarksObj>(STORAGE_KEYS.bookmarks)
-    );
-  }, []);
 
   return (
     <div className="max-w-panel mx-auto flex h-screen flex-col px-0">

--- a/apps/web/src/app/persons-panel/hooks/usePreloadPerson.ts
+++ b/apps/web/src/app/persons-panel/hooks/usePreloadPerson.ts
@@ -5,6 +5,7 @@ import {
   STORAGE_KEYS,
   deleteCache,
   isCachePresent,
+  invalidatePersonKeys,
   usePerson,
 } from '@bypass/shared';
 import { useState } from 'react';
@@ -55,6 +56,7 @@ const usePreloadPerson = () => {
     try {
       await syncPersonsToStorage();
       await cachePersonAndImages();
+      await invalidatePersonKeys();
     } finally {
       setIsLoading(false);
     }
@@ -65,6 +67,7 @@ const usePreloadPerson = () => {
     removeFromLocalStorage(STORAGE_KEYS.persons);
     removeFromLocalStorage(STORAGE_KEYS.personImageUrls);
     await deleteCache(ECacheBucketKeys.person);
+    await invalidatePersonKeys();
     setIsLoading(false);
   };
 

--- a/apps/web/src/app/persons-panel/page.tsx
+++ b/apps/web/src/app/persons-panel/page.tsx
@@ -1,48 +1,24 @@
 'use client';
 
 import {
-  decodePersons,
   getFilteredPersons,
   Header,
-  type IPerson,
-  type IPersons,
   Persons,
-  sortAlphabetically,
   sortByRecency,
-  STORAGE_KEYS,
-  useBookmark,
+  useDefaultFolderUrls,
+  usePersons,
 } from '@bypass/shared';
 import { Switch } from '@bypass/ui';
-import { useEffect, useState } from 'react';
-import useSWR from 'swr';
-
-import { getFromLocalStorage } from '@app/utils/storage';
+import { useState } from 'react';
 
 import PersonVirtualCell from './components/PersonVirtualCell';
 
 function PersonsPage() {
-  const [persons, setPersons] = useState<IPerson[]>([]);
   const [searchText, setSearchText] = useState('');
   const [orderByRecency, setOrderByRecency] = useState(true);
-  const { getDefaultOrRootFolderUrls } = useBookmark();
 
-  useEffect(() => {
-    const storedPersons = getFromLocalStorage<IPersons>(STORAGE_KEYS.persons);
-    if (!storedPersons) {
-      return;
-    }
-    const alphabeticallySorted = sortAlphabetically(
-      decodePersons(storedPersons)
-    );
-    // oxlint-disable-next-line react/react-compiler
-    setPersons(alphabeticallySorted);
-  }, []);
-
-  // Stable key so typing does not re-read bookmarks
-  const { data: urls = [] } = useSWR(
-    'default-folder-urls',
-    getDefaultOrRootFolderUrls
-  );
+  const { data: persons = [] } = usePersons();
+  const { data: urls = [] } = useDefaultFolderUrls();
 
   const orderedPersons = orderByRecency
     ? sortByRecency(persons, urls)

--- a/apps/web/src/app/provider/AppProviders.tsx
+++ b/apps/web/src/app/provider/AppProviders.tsx
@@ -1,9 +1,11 @@
 'use client';
 
+import { swrConfig } from '@bypass/shared';
 import { TooltipProvider } from '@bypass/ui';
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import { StrictMode, Suspense } from 'react';
+import { SWRConfig } from 'swr';
 
 import { AuthProvider } from './AuthProvider';
 import DynamicProvider from './DynamicProvider';
@@ -12,15 +14,17 @@ function AppProviders({ children }: { children: React.ReactNode }) {
   return (
     <Suspense>
       <StrictMode>
-        <TooltipProvider>
-          <DynamicProvider>
-            <AuthProvider>
-              {children}
-              <Analytics />
-              <SpeedInsights />
-            </AuthProvider>
-          </DynamicProvider>
-        </TooltipProvider>
+        <SWRConfig value={swrConfig}>
+          <TooltipProvider>
+            <DynamicProvider>
+              <AuthProvider>
+                {children}
+                <Analytics />
+                <SpeedInsights />
+              </AuthProvider>
+            </DynamicProvider>
+          </TooltipProvider>
+        </SWRConfig>
       </StrictMode>
     </Suspense>
   );

--- a/packages/shared/src/components/Bookmarks/hooks/useDefaultFolderUrls.ts
+++ b/packages/shared/src/components/Bookmarks/hooks/useDefaultFolderUrls.ts
@@ -1,0 +1,11 @@
+import useSWR from 'swr';
+
+import { swrKeys } from '../../../swr/keys';
+import useBookmark from './useBookmark';
+
+const useDefaultFolderUrls = () => {
+  const { getDefaultOrRootFolderUrls } = useBookmark();
+  return useSWR(swrKeys.defaultFolderUrls, getDefaultOrRootFolderUrls);
+};
+
+export default useDefaultFolderUrls;

--- a/packages/shared/src/components/Persons/hooks/useAllPersonsWithImages.ts
+++ b/packages/shared/src/components/Persons/hooks/useAllPersonsWithImages.ts
@@ -1,13 +1,12 @@
 import useSWR from 'swr';
 
+import { swrKeys } from '../../../swr/keys';
 import usePerson from './usePerson';
-
-export const ALL_PERSONS_WITH_IMAGES_KEY = 'persons-with-images';
 
 const useAllPersonsWithImages = () => {
   const { getAllDecodedPersons, getPersonsWithImageUrl } = usePerson();
 
-  return useSWR(ALL_PERSONS_WITH_IMAGES_KEY, async () =>
+  return useSWR(swrKeys.personsWithImages, async () =>
     getPersonsWithImageUrl(await getAllDecodedPersons())
   );
 };

--- a/packages/shared/src/components/Persons/hooks/usePersonImage.ts
+++ b/packages/shared/src/components/Persons/hooks/usePersonImage.ts
@@ -1,11 +1,12 @@
 import useSWR, { type SWRConfiguration } from 'swr';
 
+import { swrKeys } from '../../../swr/keys';
 import usePerson from './usePerson';
 
 const usePersonImage = (uid = '', config?: SWRConfiguration<string>) => {
   const { resolvePersonImageFromUid } = usePerson();
   return useSWR(
-    uid ? ['person-image', uid] : null,
+    swrKeys.personImage(uid),
     () => resolvePersonImageFromUid(uid),
     config
   );

--- a/packages/shared/src/components/Persons/hooks/usePersons.ts
+++ b/packages/shared/src/components/Persons/hooks/usePersons.ts
@@ -1,0 +1,15 @@
+import useSWR from 'swr';
+
+import { swrKeys } from '../../../swr/keys';
+import { sortAlphabetically } from '../utils';
+import usePerson from './usePerson';
+
+const usePersons = () => {
+  const { getAllDecodedPersons } = usePerson();
+
+  return useSWR(swrKeys.persons, async () =>
+    sortAlphabetically(await getAllDecodedPersons())
+  );
+};
+
+export default usePersons;

--- a/packages/shared/src/components/Persons/hooks/useTaggedBookmarks.ts
+++ b/packages/shared/src/components/Persons/hooks/useTaggedBookmarks.ts
@@ -3,6 +3,7 @@ import useSWR from 'swr';
 
 import { STORAGE_KEYS } from '../../../constants/storage';
 import DynamicContext from '../../../provider/DynamicContext';
+import { swrKeys } from '../../../swr/keys';
 import { ROOT_FOLDER_ID } from '../../Bookmarks/constants';
 import { type IBookmarksObj } from '../../Bookmarks/interfaces';
 import {
@@ -16,40 +17,35 @@ import { getOrderedBookmarksList } from '../utils/bookmark';
 const useTaggedBookmarks = (personUid = '') => {
   const { storage } = use(DynamicContext);
 
-  return useSWR(
-    personUid ? ['tagged-bookmarks', personUid] : null,
-    async () => {
-      // One read for the whole list; the per-hash helpers re-read it twice per bookmark
-      const bookmarks = await storage.get<IBookmarksObj>(
-        STORAGE_KEYS.bookmarks
-      );
-      if (!bookmarks?.urlList) {
-        return [];
-      }
-      const { urlList, folderList, folders } = bookmarks;
-
-      const fetchedBookmarks = Object.entries(urlList)
-        .filter(([, bookmark]) => bookmark.taggedPersons.includes(personUid))
-        .map(([, bookmark]) => {
-          const parent = getDecryptedFolder(folderList[bookmark.parentHash]);
-          return Object.assign(getDecryptedBookmark(bookmark), {
-            parentName: parent.name,
-            parentId: parent.id,
-          }) satisfies IBookmarkWithFolder;
-        });
-      if (!fetchedBookmarks.length) {
-        return [];
-      }
-
-      const parentHash =
-        getDefaultFolder(Object.values(folderList))?.id ?? ROOT_FOLDER_ID;
-      const defaultUrls = Object.values(folders[parentHash])
-        .filter((bookmark) => !bookmark.isDir)
-        .map((urlData) => urlList[urlData.hash]);
-
-      return getOrderedBookmarksList(fetchedBookmarks, defaultUrls);
+  return useSWR(swrKeys.taggedBookmarks(personUid), async () => {
+    // One read for the whole list; the per-hash helpers re-read it twice per bookmark
+    const bookmarks = await storage.get<IBookmarksObj>(STORAGE_KEYS.bookmarks);
+    if (!bookmarks?.urlList) {
+      return [];
     }
-  );
+    const { urlList, folderList, folders } = bookmarks;
+
+    const fetchedBookmarks = Object.entries(urlList)
+      .filter(([, bookmark]) => bookmark.taggedPersons.includes(personUid))
+      .map(([, bookmark]) => {
+        const parent = getDecryptedFolder(folderList[bookmark.parentHash]);
+        return Object.assign(getDecryptedBookmark(bookmark), {
+          parentName: parent.name,
+          parentId: parent.id,
+        }) satisfies IBookmarkWithFolder;
+      });
+    if (!fetchedBookmarks.length) {
+      return [];
+    }
+
+    const parentHash =
+      getDefaultFolder(Object.values(folderList))?.id ?? ROOT_FOLDER_ID;
+    const defaultUrls = Object.values(folders[parentHash])
+      .filter((bookmark) => !bookmark.isDir)
+      .map((urlData) => urlList[urlData.hash]);
+
+    return getOrderedBookmarksList(fetchedBookmarks, defaultUrls);
+  });
 };
 
 export default useTaggedBookmarks;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,6 +5,7 @@ export { default as Folder } from './components/Bookmarks/components/Folder';
 export * from './components/Bookmarks/components/Folder';
 export * from './components/Bookmarks/constants';
 export { default as useBookmark } from './components/Bookmarks/hooks/useBookmark';
+export { default as useDefaultFolderUrls } from './components/Bookmarks/hooks/useDefaultFolderUrls';
 export type * from './components/Bookmarks/interfaces';
 export type * from './components/Bookmarks/interfaces/url';
 export * from './components/Bookmarks/mapper';
@@ -19,11 +20,9 @@ export type * from './components/Persons/interfaces/persons';
 export * from './components/Persons/utils';
 export * from './components/Persons/utils/bookmark';
 export * from './components/Persons/utils/urls';
-export {
-  ALL_PERSONS_WITH_IMAGES_KEY,
-  default as useAllPersonsWithImages,
-} from './components/Persons/hooks/useAllPersonsWithImages';
+export { default as useAllPersonsWithImages } from './components/Persons/hooks/useAllPersonsWithImages';
 export { default as usePerson } from './components/Persons/hooks/usePerson';
+export { default as usePersons } from './components/Persons/hooks/usePersons';
 export { default as usePersonImage } from './components/Persons/hooks/usePersonImage';
 
 // Global components
@@ -54,3 +53,8 @@ export * from './utils/url';
 
 // Hooks
 export { default as useIsMobile } from './hooks/useIsMobile';
+
+// SWR
+export * from './swr/config';
+export * from './swr/invalidate';
+export * from './swr/keys';

--- a/packages/shared/src/swr/config.ts
+++ b/packages/shared/src/swr/config.ts
@@ -1,0 +1,13 @@
+import { type SWRConfiguration } from 'swr';
+
+/**
+ * No cache `provider`: a custom one would be separate from SWR's module-level
+ * default and silently break the `mutate` calls made outside React.
+ * No global `onError`: only the extension mounts a Toaster.
+ */
+export const swrConfig: SWRConfiguration = {
+  // Storage only changes through our own mutations, so refetching is churn
+  revalidateOnFocus: false,
+  revalidateOnReconnect: false,
+  errorRetryCount: 2,
+};

--- a/packages/shared/src/swr/invalidate.ts
+++ b/packages/shared/src/swr/invalidate.ts
@@ -19,7 +19,7 @@ export const invalidatePersonKeys = async (uid?: string) => {
 export const invalidateBookmarkKeys = async () => {
   await Promise.all([
     mutate(swrKeys.bookmarks),
-    mutate(swrKeys.quickBookmark),
+    mutate(swrKeyMatchers.quickBookmark),
     mutate(swrKeys.defaultFolderUrls),
     mutate(swrKeyMatchers.taggedBookmarks),
   ]);

--- a/packages/shared/src/swr/invalidate.ts
+++ b/packages/shared/src/swr/invalidate.ts
@@ -1,0 +1,31 @@
+import { mutate } from 'swr';
+
+import { swrKeyMatchers, swrKeys } from './keys';
+
+/**
+ * Global `mutate`: these run outside React. Call after the write lands, or the
+ * revalidation refetches pre-write data.
+ *
+ * `uid` narrows to one avatar; without it every mounted one re-reads the map.
+ */
+export const invalidatePersonKeys = async (uid?: string) => {
+  await Promise.all([
+    mutate(swrKeys.persons),
+    mutate(swrKeys.personsWithImages),
+    mutate(uid ? swrKeys.personImage(uid) : swrKeyMatchers.personImage),
+  ]);
+};
+
+export const invalidateBookmarkKeys = async () => {
+  await Promise.all([
+    mutate(swrKeys.bookmarks),
+    mutate(swrKeys.quickBookmark),
+    mutate(swrKeys.defaultFolderUrls),
+    mutate(swrKeyMatchers.taggedBookmarks),
+  ]);
+};
+
+/** For login/logout, which swap every storage item at once. */
+export const invalidateAllKeys = async () => {
+  await mutate(() => true);
+};

--- a/packages/shared/src/swr/keys.ts
+++ b/packages/shared/src/swr/keys.ts
@@ -2,6 +2,7 @@
 const PERSON_IMAGE = 'person-image';
 const TAGGED_BOOKMARKS = 'tagged-bookmarks';
 const LAST_VISITED = 'last-visited';
+const QUICK_BOOKMARK = 'quick-bookmark';
 
 /**
  * Single keys are plain strings, not thunks: SWR's global `mutate` treats a
@@ -12,12 +13,12 @@ export const swrKeys = {
   persons: 'persons',
   bookmarks: 'bookmarks',
   defaultFolderUrls: 'default-folder-urls',
-  quickBookmark: 'quick-bookmark',
   redirections: 'redirections',
   currentTab: 'current-tab',
   personImage: (uid?: string) => (uid ? [PERSON_IMAGE, uid] : null),
   taggedBookmarks: (uid?: string) => (uid ? [TAGGED_BOOKMARKS, uid] : null),
   lastVisited: (url?: string) => (url ? [LAST_VISITED, url] : null),
+  quickBookmark: (url?: string) => (url ? [QUICK_BOOKMARK, url] : null),
 } as const;
 
 const matchKeyPrefix = (prefix: string) => (key: unknown) =>
@@ -27,4 +28,5 @@ export const swrKeyMatchers = {
   personImage: matchKeyPrefix(PERSON_IMAGE),
   taggedBookmarks: matchKeyPrefix(TAGGED_BOOKMARKS),
   lastVisited: matchKeyPrefix(LAST_VISITED),
+  quickBookmark: matchKeyPrefix(QUICK_BOOKMARK),
 } as const;

--- a/packages/shared/src/swr/keys.ts
+++ b/packages/shared/src/swr/keys.ts
@@ -1,0 +1,30 @@
+// Consts, so the key factories and the matchers below cannot drift apart
+const PERSON_IMAGE = 'person-image';
+const TAGGED_BOOKMARKS = 'tagged-bookmarks';
+const LAST_VISITED = 'last-visited';
+
+/**
+ * Single keys are plain strings, not thunks: SWR's global `mutate` treats a
+ * function as a key *filter*, so a dropped `()` would wipe the whole cache.
+ */
+export const swrKeys = {
+  personsWithImages: 'persons-with-images',
+  persons: 'persons',
+  bookmarks: 'bookmarks',
+  defaultFolderUrls: 'default-folder-urls',
+  quickBookmark: 'quick-bookmark',
+  redirections: 'redirections',
+  currentTab: 'current-tab',
+  personImage: (uid?: string) => (uid ? [PERSON_IMAGE, uid] : null),
+  taggedBookmarks: (uid?: string) => (uid ? [TAGGED_BOOKMARKS, uid] : null),
+  lastVisited: (url?: string) => (url ? [LAST_VISITED, url] : null),
+} as const;
+
+const matchKeyPrefix = (prefix: string) => (key: unknown) =>
+  Array.isArray(key) && key[0] === prefix;
+
+export const swrKeyMatchers = {
+  personImage: matchKeyPrefix(PERSON_IMAGE),
+  taggedBookmarks: matchKeyPrefix(TAGGED_BOOKMARKS),
+  lastVisited: matchKeyPrefix(LAST_VISITED),
+} as const;


### PR DESCRIPTION
#### Check if the Pull Request fulfils these requirements

- [ ] Does the extension require a version change?

<!-- greptile_comment -->

 

<details><summary><h3>Greptile Summary</h3></summary>

The PR centralizes client-side storage reads around shared SWR keys, configuration, and invalidation helpers.
- Migrates extension and web views from local effects and state to SWR-backed hooks.
- Adds coordinated invalidation after bookmark, person, redirection, last-visited, login, and logout writes.
- Updates extension version metadata and mutation error handling.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because a persistent popup page can retain an obsolete active tab and apply user actions to the wrong URL.

The previously reported active-tab issue remains: `useCurrentTab` uses a fixed SWR key, focus revalidation is disabled, and no tab-change listener or explicit invalidation refreshes that entry while the popup is open as a browser tab.

**Files Needing Attention:** apps/extension/src/entrypoints/popup/hooks/useCurrentTab.ts; packages/shared/src/swr/config.ts; packages/shared/src/swr/keys.ts
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: key quick-bookmark cache by url"](https://github.com/amitsingh-007/bypass-links/commit/44349f64778e6e56fce7bf19cf3d12d710a97382) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51422169)</sub>

**Context used:**

- Knowledge Base — [Extension Popup UI](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/extension-popup.md)
- Knowledge Base — [Shared package (`packages/shared`)](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/shared-package.md)

<!-- /greptile_comment -->