### PR TITLE
fix: bookmark validation refine short-circuits on the first root entry

### DIFF
--- a/packages/shared/src/components/Bookmarks/schema/index.ts
+++ b/packages/shared/src/components/Bookmarks/schema/index.ts
@@ -58,7 +58,7 @@ export const BookmarksAndPersonsValidationSchema = z
         for (const [bmId, bmData] of Object.entries(allData)) {
           // Ignore root folder
           if (!bmData.parentHash) {
-            return true;
+            continue;
           }
           const parentFolder = bookmarks.folders[bmData.parentHash];
           // Check if the parent folder exists


### PR DESCRIPTION
The parent-reference refine in `BookmarksAndPersonsValidationSchema` returns `true` from **inside** its loop when it hits an entry with no `parentHash`, marking the whole tree valid instead of skipping that one entry.

Whether an orphaned or unreferenced bookmark is caught therefore depends on where the root folder happens to land in object iteration order — validation is effectively nondeterministic across datasets.

`return true` → `continue`.

### ⚠️ Rollout risk

This makes validation **strictly stricter**. The only caller is the `bookmarkAndPersonSave` tRPC input, reached via `syncBookmarksAndPersonsFirebaseWithStorage`, so latent bad data that previously slipped through will now fail the sync with a validation error rather than saving.

Worth a look at production data before merging.

### Testing gap

The plan called for a unit test here. This repo has no unit test runner — only Playwright E2E — and adding one (vitest + config + CI wiring) is a bigger infrastructure decision than this fix warrants, so I have not done it unilaterally. Flagging rather than silently skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

 

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes bookmark/person snapshot validation so encountering an entry without a parent no longer terminates the entire parent-membership check.
- Replaces the successful early return with loop continuation.
- Allows subsequent bookmark and folder entries to be checked against their parent folder listings.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code failure identified.

The change preserves the exemption for parentless entries while allowing later entries to undergo the existing parent-folder and membership checks, and current application paths assign non-empty parent identifiers to created bookmarks and folders.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: stop bookmark refine short-circuiti..."](https://github.com/amitsingh-007/bypass-links/commit/2de986baf8b3c9d00e4a0b9b2179232001395d80) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51437734)</sub>

**Context used:**

- Knowledge Base — [Shared package (`packages/shared`)](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/shared-package.md)

<!-- /greptile_comment -->