### PR TITLE
refactor: put shared-layer code at the right altitude

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bypass/extension",
-  "version": "25.5.0",
+  "version": "25.6.0",
   "private": true,
   "description": "Bypass links from various sites to required links, with added functionality of Bookmarks Manager, Tagging Panel.",
   "type": "module",

--- a/apps/extension/src/constants/favicon.ts
+++ b/apps/extension/src/constants/favicon.ts
@@ -1,0 +1,8 @@
+import { getGoogleFaviconUrl } from '@bypass/shared';
+
+/**
+ * One provider per app. The favicon cache is keyed by the generated url, so
+ * changing the provider in some call sites but not others turns every cached
+ * favicon into a permanent miss.
+ */
+export const getFaviconUrl = getGoogleFaviconUrl;

--- a/apps/extension/src/constants/favicon.ts
+++ b/apps/extension/src/constants/favicon.ts
@@ -1,8 +1,3 @@
 import { getGoogleFaviconUrl } from '@bypass/shared';
 
-/**
- * One provider per app. The favicon cache is keyed by the generated url, so
- * changing the provider in some call sites but not others turns every cached
- * favicon into a permanent miss.
- */
 export const getFaviconUrl = getGoogleFaviconUrl;

--- a/apps/extension/src/entrypoints/popup/hooks/useCurrentTab.ts
+++ b/apps/extension/src/entrypoints/popup/hooks/useCurrentTab.ts
@@ -1,10 +1,10 @@
-import { swrKeys } from '@bypass/shared';
 import useSWR from 'swr';
 
+import { extSwrKeys } from '@/swr/keys';
 import { getCurrentTab } from '@popup/utils/tabs';
 
 const useCurrentTab = () => {
-  const { data } = useSWR(swrKeys.currentTab, getCurrentTab);
+  const { data } = useSWR(extSwrKeys.currentTab, getCurrentTab);
   return data;
 };
 

--- a/apps/extension/src/entrypoints/popup/hooks/useLastVisited.ts
+++ b/apps/extension/src/entrypoints/popup/hooks/useLastVisited.ts
@@ -1,16 +1,16 @@
-import { swrKeys } from '@bypass/shared';
 import useSWR from 'swr';
 
+import { extSwrKeys } from '@/swr/keys';
 import {
   getLastVisitedTextMap,
   getlastVisitedText,
 } from '@popup/utils/lastVisited';
 
 const useLastVisited = (url = '') =>
-  useSWR(swrKeys.lastVisited(url), () => getlastVisitedText(url));
+  useSWR(extSwrKeys.lastVisited(url), () => getlastVisitedText(url));
 
 export const useLastVisitedMap = (urls: string[]) => {
-  const { data } = useSWR(swrKeys.lastVisitedMap(urls), () =>
+  const { data } = useSWR(extSwrKeys.lastVisitedMap(urls), () =>
     getLastVisitedTextMap(urls)
   );
   return data ?? {};

--- a/apps/extension/src/entrypoints/popup/hooks/useQuickBookmark.ts
+++ b/apps/extension/src/entrypoints/popup/hooks/useQuickBookmark.ts
@@ -1,11 +1,12 @@
-import { getDecryptedBookmark, swrKeys } from '@bypass/shared';
+import { getDecryptedBookmark } from '@bypass/shared';
 import useSWR from 'swr';
 
 import { bookmarksItem } from '@/storage/items';
+import { extSwrKeys } from '@/swr/keys';
 import { findBookmarkByUrl } from '@popup/panels/BookmarksPanel/utils/bookmark';
 
 const useQuickBookmark = (enabled: boolean, url = '') =>
-  useSWR(enabled ? swrKeys.quickBookmark(url) : null, async () => {
+  useSWR(enabled ? extSwrKeys.quickBookmark(url) : null, async () => {
     const bookmarks = await bookmarksItem.getValue();
     if (!bookmarks) {
       return undefined;

--- a/apps/extension/src/entrypoints/popup/index.tsx
+++ b/apps/extension/src/entrypoints/popup/index.tsx
@@ -1,9 +1,10 @@
 import '@bypass/ui/styles/globals.css';
-import { swrConfig } from '@bypass/shared';
 import { TooltipProvider } from '@bypass/ui';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { SWRConfig } from 'swr';
+
+import { extSwrConfig } from '@/swr/config';
 
 import './fonts.css';
 import './layout.css';
@@ -14,7 +15,7 @@ import DynamicProvider from './provider/DynamicProvider';
 function App() {
   return (
     <StrictMode>
-      <SWRConfig value={swrConfig}>
+      <SWRConfig value={extSwrConfig}>
         <TooltipProvider>
           <DynamicProvider>
             <PopupRoutes />

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/store/useBookmarkStore.ts
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/store/useBookmarkStore.ts
@@ -8,12 +8,12 @@ import {
   bookmarksMapper,
   filterRecord,
   getEncryptedBookmark,
-  getGoogleFaviconUrl,
   getEncryptedFolder,
 } from '@bypass/shared';
 import { toast } from 'sonner';
 import { create } from 'zustand';
 
+import { getFaviconUrl } from '@/constants/favicon';
 import { bookmarksItem } from '@/storage/items';
 
 import { isFolderContainsDir, setBookmarksInStorage } from '../utils';
@@ -196,10 +196,7 @@ const useBookmarkStore = create<State>()((set, get) => ({
     }
 
     // Cache favicon for new URL
-    addToCache(
-      ECacheBucketKeys.favicon,
-      getGoogleFaviconUrl(updatedBookmark.url)
-    );
+    addToCache(ECacheBucketKeys.favicon, getFaviconUrl(updatedBookmark.url));
     set({ isSaveButtonActive: true });
     return true;
   },

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/utils/bookmark.ts
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/utils/bookmark.ts
@@ -3,13 +3,13 @@ import {
   addAllToCache,
   encodeBookmarkField,
   getBookmarkFaviconUrls,
-  getGoogleFaviconUrl,
   type ContextBookmarks,
   type IBookmarksObj,
   type ITransformedBookmark,
 } from '@bypass/shared';
 
 import { trpcApi } from '@/apis/trpcApi';
+import { getFaviconUrl } from '@/constants/favicon';
 import {
   bookmarksItem,
   personsItem,
@@ -62,10 +62,7 @@ export const cacheBookmarkFavicons = async () => {
   if (!bookmarks) {
     return;
   }
-  const faviconUrls = getBookmarkFaviconUrls(
-    bookmarks.urlList,
-    getGoogleFaviconUrl
-  );
+  const faviconUrls = getBookmarkFaviconUrls(bookmarks.urlList, getFaviconUrl);
   await addAllToCache(ECacheBucketKeys.favicon, faviconUrls);
   console.log('Bookmark favicons cached');
   const { incrementProgress } = useProgressStore.getState();

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/utils/index.ts
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/utils/index.ts
@@ -1,10 +1,7 @@
-import {
-  type IBookmarksObj,
-  type ISelectedBookmarks,
-  invalidateBookmarkKeys,
-} from '@bypass/shared';
+import { type IBookmarksObj, type ISelectedBookmarks } from '@bypass/shared';
 
 import { bookmarksItem, hasPendingBookmarksItem } from '@/storage/items';
+import { invalidateExtBookmarkKeys } from '@/swr/keys';
 
 export const isFolderContainsDir = (
   folders: IBookmarksObj['folders'],
@@ -19,5 +16,5 @@ export const setBookmarksInStorage = async (bookmarksObj: IBookmarksObj) => {
     bookmarksItem.setValue(bookmarksObj),
     hasPendingBookmarksItem.setValue(true),
   ]);
-  await invalidateBookmarkKeys();
+  await invalidateExtBookmarkKeys();
 };

--- a/apps/extension/src/entrypoints/popup/panels/HomePopup/components/LastVisitedButton.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/HomePopup/components/LastVisitedButton.tsx
@@ -1,4 +1,3 @@
-import { swrKeys } from '@bypass/shared';
 import {
   Button,
   Spinner,
@@ -16,6 +15,7 @@ import useSWRMutation from 'swr/mutation';
 
 import { trpcApi } from '@/apis/trpcApi';
 import useFirebaseStore from '@/store/firebase/useFirebaseStore';
+import { extSwrKeys } from '@/swr/keys';
 import useCurrentTab from '@popup/hooks/useCurrentTab';
 import useLastVisited from '@popup/hooks/useLastVisited';
 import {
@@ -33,7 +33,7 @@ function LastVisitedButton() {
   );
 
   const { trigger: updateLastVisited, isMutating } = useSWRMutation(
-    swrKeys.lastVisited(url),
+    extSwrKeys.lastVisited(url),
     async ([, pageUrl]) => {
       const hash = await getHostnameHash(pageUrl);
       const result = await trpcApi.firebaseData.upsertLastVisited.mutate({

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/ImagePicker.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/ImagePicker.tsx
@@ -1,4 +1,4 @@
-import { Header, getPersonImageName } from '@bypass/shared';
+import { Header, getPersonImageName, PERSON_IMAGE_SIZE } from '@bypass/shared';
 import {
   Button,
   Dialog,
@@ -121,9 +121,8 @@ function ImagePicker({ uid, isOpen, onDialogClose, handleImageSave }: Props) {
                 ref={imageCropperRef}
                 image={debouncedInputUrl}
                 crossOrigin="anonymous"
-                // When changing this, change in upload API as well
-                width={250}
-                height={250}
+                width={PERSON_IMAGE_SIZE}
+                height={PERSON_IMAGE_SIZE}
                 border={[270, 70]}
                 borderRadius={4}
                 scale={zoom}

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/PersonsPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/PersonsPanel.tsx
@@ -2,15 +2,13 @@ import {
   EBookmarkOperation,
   getBookmarksPanelUrl,
   getEncryptedPerson,
-  getFilteredPersons,
-  sortByRecency,
   getPersonImageName,
   HEADER_HEIGHT,
   type IPerson,
   type IPersons,
   Persons,
   sortAlphabetically,
-  useDefaultFolderUrls,
+  useOrderedPersons,
   usePerson,
   usePersons,
 } from '@bypass/shared';
@@ -47,18 +45,13 @@ function PersonsPanel() {
   const [searchText, setSearchText] = useState('');
   const [orderByRecency, setOrderByRecency] = useState(true);
 
-  const { data: persons = [], isLoading } = usePersons();
-  const { data: urls = [] } = useDefaultFolderUrls();
-
-  const isFetching = isLoading || isSaving;
-
-  const orderedPersons = orderByRecency
-    ? sortByRecency(persons, urls)
-    : persons;
-  const filteredAndOrderedPersons = getFilteredPersons(
-    orderedPersons,
+  const { data: persons = [] } = usePersons();
+  const { data: filteredAndOrderedPersons, isLoading } = useOrderedPersons(
+    orderByRecency,
     searchText
   );
+
+  const isFetching = isLoading || isSaving;
 
   const runSave = async (errorMessage: string, save: () => Promise<void>) => {
     setIsSaving(true);

--- a/apps/extension/src/entrypoints/popup/provider/DynamicProvider.tsx
+++ b/apps/extension/src/entrypoints/popup/provider/DynamicProvider.tsx
@@ -1,7 +1,8 @@
-import { DynamicContext, getGoogleFaviconUrl } from '@bypass/shared';
+import { DynamicContext } from '@bypass/shared';
 import { type PropsWithChildren, useMemo } from 'react';
 import { useLocation } from 'wouter';
 
+import { getFaviconUrl } from '@/constants/favicon';
 import useHistoryStore from '@store/history';
 
 import { getFromChromeStorage, setToChromeStorage } from './utils';
@@ -30,7 +31,7 @@ function DynamicProvider({ children }: PropsWithChildren) {
           browser.tabs.create({ url, active: false });
         },
       },
-      favicon: { getUrl: getGoogleFaviconUrl },
+      favicon: { getUrl: getFaviconUrl },
     }),
     [navigate, startHistoryMonitor]
   );

--- a/apps/extension/src/entrypoints/popup/utils/lastVisited.ts
+++ b/apps/extension/src/entrypoints/popup/utils/lastVisited.ts
@@ -1,7 +1,8 @@
-import { sha256Hash, swrKeyMatchers } from '@bypass/shared';
+import { sha256Hash } from '@bypass/shared';
 import { mutate } from 'swr';
 
 import { lastVisitedItem } from '@/storage/items';
+import { extSwrKeyMatchers } from '@/swr/keys';
 
 export const getHostnameHash = async (url: string) => {
   if (!URL.canParse(url)) {
@@ -42,5 +43,5 @@ export const setLastVisitedInStorage = async (
   const lastVisitedObj = await lastVisitedItem.getValue();
   lastVisitedObj[hash] = timestamp;
   await lastVisitedItem.setValue(lastVisitedObj);
-  await mutate(swrKeyMatchers.lastVisited);
+  await mutate(extSwrKeyMatchers.lastVisited);
 };

--- a/apps/extension/src/swr/config.ts
+++ b/apps/extension/src/swr/config.ts
@@ -1,0 +1,30 @@
+import { swrConfig } from '@bypass/shared';
+import { toast } from 'sonner';
+import { type SWRConfiguration } from 'swr';
+
+const FALLBACK_MESSAGE = 'Something went wrong';
+
+/**
+ * Adapter, not `toast.error` itself: SWR calls onError(error, key, config),
+ * and toast.error reads its second argument as options, so the SWR key would
+ * be interpreted as toast config.
+ *
+ * Server messages are not surfaced verbatim; a fetch failure should not put
+ * backend wording in front of a user.
+ */
+const notifyError = (error: unknown) => {
+  console.error(error);
+  toast.error(FALLBACK_MESSAGE);
+};
+
+/**
+ * The extension is the only app that mounts a Toaster, which is why the
+ * shared config leaves onError out. This is the intended override point:
+ * without it a query added without its own onError fails silently.
+ *
+ * Covers useSWR only. useSWRMutation takes its own onError.
+ */
+export const extSwrConfig: SWRConfiguration = {
+  ...swrConfig,
+  onError: notifyError,
+};

--- a/apps/extension/src/swr/config.ts
+++ b/apps/extension/src/swr/config.ts
@@ -2,28 +2,14 @@ import { swrConfig } from '@bypass/shared';
 import { toast } from 'sonner';
 import { type SWRConfiguration } from 'swr';
 
-const FALLBACK_MESSAGE = 'Something went wrong';
-
-/**
- * Adapter, not `toast.error` itself: SWR calls onError(error, key, config),
- * and toast.error reads its second argument as options, so the SWR key would
- * be interpreted as toast config.
- *
- * Server messages are not surfaced verbatim; a fetch failure should not put
- * backend wording in front of a user.
- */
+// Adapter, not toast.error itself: SWR passes (error, key, config), and
+// toast.error would read the key as options
 const notifyError = (error: unknown) => {
   console.error(error);
-  toast.error(FALLBACK_MESSAGE);
+  toast.error('Something went wrong');
 };
 
-/**
- * The extension is the only app that mounts a Toaster, which is why the
- * shared config leaves onError out. This is the intended override point:
- * without it a query added without its own onError fails silently.
- *
- * Covers useSWR only. useSWRMutation takes its own onError.
- */
+/** Covers useSWR only; useSWRMutation takes its own onError. */
 export const extSwrConfig: SWRConfiguration = {
   ...swrConfig,
   onError: notifyError,

--- a/apps/extension/src/swr/keys.ts
+++ b/apps/extension/src/swr/keys.ts
@@ -12,8 +12,6 @@ const QUICK_BOOKMARK = 'quick-bookmark';
 export const extSwrKeys = {
   currentTab: 'current-tab',
   lastVisited: (url?: string) => (url ? [LAST_VISITED, url] : null),
-  // Shares the LAST_VISITED prefix so one matcher invalidates both shapes.
-  // Sorted: reordering rules is the same request, not a new one.
   lastVisitedMap: (urls: string[]) => [LAST_VISITED, 'map', joinIds(urls)],
   quickBookmark: (url?: string) => (url ? [QUICK_BOOKMARK, url] : null),
 } as const;
@@ -23,10 +21,7 @@ export const extSwrKeyMatchers = {
   quickBookmark: matchKeyPrefix(QUICK_BOOKMARK),
 } as const;
 
-/**
- * A wrapper rather than an optional argument on the shared invalidator: a new
- * extension write path cannot forget to pass something it never sees.
- */
+/** A wrapper, so a new extension write path cannot forget to pass matchers. */
 export const invalidateExtBookmarkKeys = async () => {
   await Promise.all([
     invalidateBookmarkKeys(),

--- a/apps/extension/src/swr/keys.ts
+++ b/apps/extension/src/swr/keys.ts
@@ -1,4 +1,8 @@
-import { invalidateBookmarkKeys, matchKeyPrefix } from '@bypass/shared';
+import {
+  invalidateBookmarkKeys,
+  joinIds,
+  matchKeyPrefix,
+} from '@bypass/shared';
 import { mutate } from 'swr';
 
 const LAST_VISITED = 'last-visited';
@@ -8,8 +12,9 @@ const QUICK_BOOKMARK = 'quick-bookmark';
 export const extSwrKeys = {
   currentTab: 'current-tab',
   lastVisited: (url?: string) => (url ? [LAST_VISITED, url] : null),
-  // Shares the LAST_VISITED prefix so one matcher invalidates both shapes
-  lastVisitedMap: (urls: string[]) => [LAST_VISITED, 'map', urls.join('|')],
+  // Shares the LAST_VISITED prefix so one matcher invalidates both shapes.
+  // Sorted: reordering rules is the same request, not a new one.
+  lastVisitedMap: (urls: string[]) => [LAST_VISITED, 'map', joinIds(urls)],
   quickBookmark: (url?: string) => (url ? [QUICK_BOOKMARK, url] : null),
 } as const;
 

--- a/apps/extension/src/swr/keys.ts
+++ b/apps/extension/src/swr/keys.ts
@@ -1,0 +1,30 @@
+import { invalidateBookmarkKeys, matchKeyPrefix } from '@bypass/shared';
+import { mutate } from 'swr';
+
+const LAST_VISITED = 'last-visited';
+const QUICK_BOOKMARK = 'quick-bookmark';
+
+/** Popup-only concepts, so they stay out of the shared key surface. */
+export const extSwrKeys = {
+  currentTab: 'current-tab',
+  lastVisited: (url?: string) => (url ? [LAST_VISITED, url] : null),
+  // Shares the LAST_VISITED prefix so one matcher invalidates both shapes
+  lastVisitedMap: (urls: string[]) => [LAST_VISITED, 'map', urls.join('|')],
+  quickBookmark: (url?: string) => (url ? [QUICK_BOOKMARK, url] : null),
+} as const;
+
+export const extSwrKeyMatchers = {
+  lastVisited: matchKeyPrefix(LAST_VISITED),
+  quickBookmark: matchKeyPrefix(QUICK_BOOKMARK),
+} as const;
+
+/**
+ * A wrapper rather than an optional argument on the shared invalidator: a new
+ * extension write path cannot forget to pass something it never sees.
+ */
+export const invalidateExtBookmarkKeys = async () => {
+  await Promise.all([
+    invalidateBookmarkKeys(),
+    mutate(extSwrKeyMatchers.quickBookmark),
+  ]);
+};

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { getFirebaseAuthHelperUrl } from '@bypass/configs/firebase.config';
 import { type NextConfig } from 'next';
 
 if (!process.env.VERCEL) {
@@ -37,7 +38,10 @@ const nextConfig: NextConfig = {
   // blocked by Safari ITP. Must be a rewrite (transparent), not a 302.
   // https://firebase.google.com/docs/auth/web/redirect-best-practices
   async rewrites() {
-    const authHelper = 'https://bypass-links.firebaseapp.com';
+    // Same discriminator the runtime config uses, so dev doesn't proxy to prod
+    const authHelper = getFirebaseAuthHelperUrl(
+      process.env.NODE_ENV === 'production'
+    );
     return [
       {
         source: '/__/auth/:path*',

--- a/apps/web/src/app/api/upload-file/utils.ts
+++ b/apps/web/src/app/api/upload-file/utils.ts
@@ -1,14 +1,12 @@
+import { PERSON_IMAGE_SIZE } from '@bypass/shared';
 import { fileTypeFromBuffer } from 'file-type';
 import sharp from 'sharp';
 
 const getCompressedImage = async (buffer: Buffer, fileSize: number) => {
-  return (
-    sharp(buffer)
-      // When changing this width, change on client app as well
-      .resize({ width: 250, withoutEnlargement: true })
-      .jpeg({ quality: fileSize < 50 * 1024 ? 100 : 90 })
-      .toBuffer()
-  );
+  return sharp(buffer)
+    .resize({ width: PERSON_IMAGE_SIZE, withoutEnlargement: true })
+    .jpeg({ quality: fileSize < 50 * 1024 ? 100 : 90 })
+    .toBuffer();
 };
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB

--- a/apps/web/src/app/bookmark-panel/hooks/usePreloadBookmarks.ts
+++ b/apps/web/src/app/bookmark-panel/hooks/usePreloadBookmarks.ts
@@ -5,12 +5,12 @@ import {
   STORAGE_KEYS,
   deleteCache,
   getBookmarkFaviconUrls,
-  getYandexFaviconUrl,
   isCachePresent,
   invalidateBookmarkKeys,
 } from '@bypass/shared';
 import { useCallback, useState } from 'react';
 
+import { getFaviconUrl } from '@app/constants/favicon';
 import { useUser } from '@app/provider/AuthProvider';
 import { api } from '@app/utils/api';
 import {
@@ -37,10 +37,7 @@ const cacheBookmarkFavicons = async () => {
   if (!bookmarks) {
     return;
   }
-  const faviconUrls = getBookmarkFaviconUrls(
-    bookmarks.urlList,
-    getYandexFaviconUrl
-  );
+  const faviconUrls = getBookmarkFaviconUrls(bookmarks.urlList, getFaviconUrl);
   await addAllToCache(ECacheBucketKeys.favicon, faviconUrls);
 };
 

--- a/apps/web/src/app/bookmark-panel/page.tsx
+++ b/apps/web/src/app/bookmark-panel/page.tsx
@@ -8,22 +8,14 @@ import {
   getFilteredContextBookmarks,
   getFolderName,
   Header,
-  type IBookmarksObj,
-  STORAGE_KEYS,
-  swrKeys,
+  useBookmarks,
 } from '@bypass/shared';
 import { ScrollArea } from '@bypass/ui';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useSearchParams } from 'next/navigation';
 import { useRef, useState } from 'react';
-import useSWR from 'swr';
-
-import { getFromLocalStorage } from '@app/utils/storage';
 
 import VirtualRow from './components/VirtualRow';
-
-const fetchBookmarks = () =>
-  getFromLocalStorage<IBookmarksObj>(STORAGE_KEYS.bookmarks);
 
 export default function BookmarksPage() {
   const searchParams = useSearchParams();
@@ -31,7 +23,7 @@ export default function BookmarksPage() {
   const folderId = searchParams?.get('folderId') ?? ROOT_FOLDER_ID;
   const [searchText, setSearchText] = useState('');
 
-  const { data: bookmarksData } = useSWR(swrKeys.bookmarks, fetchBookmarks);
+  const { data: bookmarksData } = useBookmarks();
 
   const folders = bookmarksData?.folders ?? {};
   // `?? []`: this runs in the render body, so a stale folderId would crash the tree

--- a/apps/web/src/app/components/AppHeader.tsx
+++ b/apps/web/src/app/components/AppHeader.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { GITHUB_REPO_URL } from '@bypass/shared';
 import { GithubIcon } from '@hugeicons/core-free-icons';
 import { HugeiconsIcon } from '@hugeicons/react';
 import Image from 'next/image';
@@ -46,7 +47,7 @@ function AppHeader() {
           </div>
         </button>
         <a
-          href="https://github.com/bypass-links/bypass-links"
+          href={GITHUB_REPO_URL}
           target="_blank"
           rel="noopener noreferrer"
           className="flex size-8 items-center justify-center rounded-lg border border-border bg-background text-muted-foreground transition-all hover:border-primary/30 hover:text-foreground"

--- a/apps/web/src/app/components/Footer.tsx
+++ b/apps/web/src/app/components/Footer.tsx
@@ -1,3 +1,4 @@
+import { GITHUB_REPO_URL } from '@bypass/shared';
 import {
   Calendar03Icon,
   GithubIcon,
@@ -63,7 +64,7 @@ async function Footer({
         </div>
         <a
           target="_blank"
-          href="https://github.com/amitsingh-007/bypass-links"
+          href={GITHUB_REPO_URL}
           title="Bypass Links - Github"
           className="flex size-10 shrink-0 items-center justify-center rounded-full bg-muted transition-colors hover:bg-muted/80"
           aria-label="Github Repository Link"

--- a/apps/web/src/app/components/PageHeader.tsx
+++ b/apps/web/src/app/components/PageHeader.tsx
@@ -1,31 +1,7 @@
 import { ChromeIcon } from '@hugeicons/core-free-icons';
-import { HugeiconsIcon, type IconSvgElement } from '@hugeicons/react';
+import { HugeiconsIcon } from '@hugeicons/react';
 
-interface IExtData {
-  version: string;
-  date: string;
-  downloadLink: string;
-}
-
-interface Props {
-  icon: IconSvgElement;
-  text: string;
-  downloadLink: string;
-}
-
-function DownloadButton({ icon, text, downloadLink }: Props) {
-  return (
-    <a
-      href={downloadLink}
-      className="inline-flex h-11 shrink-0 items-center justify-center gap-2 rounded-lg border border-transparent bg-primary bg-clip-padding px-5 text-base font-semibold text-primary-foreground transition-all outline-none hover:bg-primary/80 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 [&_svg]:pointer-events-none [&_svg]:shrink-0"
-    >
-      <HugeiconsIcon icon={icon} size={20} />
-      {text}
-    </a>
-  );
-}
-
-function PageHeader({ chrome }: { chrome: IExtData }) {
+function PageHeader({ chrome }: { chrome: { downloadLink: string } }) {
   return (
     <section className="flex flex-col items-center justify-center py-24 text-center">
       <h1 className="max-w-3xl text-5xl/tight font-bold md:text-6xl">
@@ -36,11 +12,13 @@ function PageHeader({ chrome }: { chrome: IExtData }) {
         with person tagging. All in one extension.
       </p>
       <div className="mt-10">
-        <DownloadButton
-          icon={ChromeIcon}
-          text="Download for Chrome"
-          downloadLink={chrome.downloadLink}
-        />
+        <a
+          href={chrome.downloadLink}
+          className="inline-flex h-11 shrink-0 items-center justify-center gap-2 rounded-lg border border-transparent bg-primary bg-clip-padding px-5 text-base font-semibold text-primary-foreground transition-all outline-none hover:bg-primary/80 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 [&_svg]:pointer-events-none [&_svg]:shrink-0"
+        >
+          <HugeiconsIcon icon={ChromeIcon} size={20} />
+          Download for Chrome
+        </a>
       </div>
     </section>
   );

--- a/apps/web/src/app/constants/favicon.ts
+++ b/apps/web/src/app/constants/favicon.ts
@@ -1,8 +1,3 @@
 import { getYandexFaviconUrl } from '@bypass/shared';
 
-/**
- * One provider per app. The favicon cache is keyed by the generated url, so
- * changing the provider in some call sites but not others turns every cached
- * favicon into a permanent miss.
- */
 export const getFaviconUrl = getYandexFaviconUrl;

--- a/apps/web/src/app/constants/favicon.ts
+++ b/apps/web/src/app/constants/favicon.ts
@@ -1,0 +1,8 @@
+import { getYandexFaviconUrl } from '@bypass/shared';
+
+/**
+ * One provider per app. The favicon cache is keyed by the generated url, so
+ * changing the provider in some call sites but not others turns every cached
+ * favicon into a permanent miss.
+ */
+export const getFaviconUrl = getYandexFaviconUrl;

--- a/apps/web/src/app/persons-panel/page.tsx
+++ b/apps/web/src/app/persons-panel/page.tsx
@@ -1,13 +1,6 @@
 'use client';
 
-import {
-  getFilteredPersons,
-  Header,
-  Persons,
-  sortByRecency,
-  useDefaultFolderUrls,
-  usePersons,
-} from '@bypass/shared';
+import { Header, Persons, useOrderedPersons } from '@bypass/shared';
 import { Switch } from '@bypass/ui';
 import { useSearchParams } from 'next/navigation';
 import { useState } from 'react';
@@ -19,14 +12,8 @@ function PersonsPage() {
   const [searchText, setSearchText] = useState('');
   const [orderByRecency, setOrderByRecency] = useState(true);
 
-  const { data: persons = [] } = usePersons();
-  const { data: urls = [] } = useDefaultFolderUrls();
-
-  const orderedPersons = orderByRecency
-    ? sortByRecency(persons, urls)
-    : persons;
-  const filteredAndOrderedPersons = getFilteredPersons(
-    orderedPersons,
+  const { data: filteredAndOrderedPersons } = useOrderedPersons(
+    orderByRecency,
     searchText
   );
 

--- a/apps/web/src/app/provider/DynamicProvider.tsx
+++ b/apps/web/src/app/provider/DynamicProvider.tsx
@@ -1,7 +1,8 @@
-import { DynamicContext, getYandexFaviconUrl } from '@bypass/shared';
+import { DynamicContext } from '@bypass/shared';
 import { useRouter } from 'next/navigation';
 import { type PropsWithChildren, useMemo } from 'react';
 
+import { getFaviconUrl } from '../constants/favicon';
 import { openNewTab } from '../utils';
 import { getFromLocalStorage, setToLocalStorage } from '../utils/storage';
 
@@ -20,7 +21,7 @@ function DynamicProvider({ children }: PropsWithChildren) {
         set: async (key: string, value: any) => setToLocalStorage(key, value),
       },
       tabs: { open: openNewTab },
-      favicon: { getUrl: getYandexFaviconUrl },
+      favicon: { getUrl: getFaviconUrl },
     }),
     [router]
   );

--- a/packages/configs/firebase.config.ts
+++ b/packages/configs/firebase.config.ts
@@ -1,3 +1,10 @@
+/**
+ * Derived from projectId so the rewrite target cannot name a different
+ * Firebase project than the one the app initialises against.
+ */
+export const getFirebaseAuthHelperUrl = (isProd: boolean) =>
+  `https://${getFirebasePublicConfig(isProd).projectId}.firebaseapp.com`;
+
 export const getFirebasePublicConfig = (isProd: boolean) => {
   if (isProd) {
     return {

--- a/packages/configs/firebase.config.ts
+++ b/packages/configs/firebase.config.ts
@@ -1,7 +1,3 @@
-/**
- * Derived from projectId so the rewrite target cannot name a different
- * Firebase project than the one the app initialises against.
- */
 export const getFirebaseAuthHelperUrl = (isProd: boolean) =>
   `https://${getFirebasePublicConfig(isProd).projectId}.firebaseapp.com`;
 

--- a/packages/shared/src/components/Bookmarks/hooks/useBookmarks.ts
+++ b/packages/shared/src/components/Bookmarks/hooks/useBookmarks.ts
@@ -6,11 +6,6 @@ import DynamicContext from '../../../provider/DynamicContext';
 import { swrKeys } from '../../../swr/keys';
 import { type IBookmarksObj } from '../interfaces';
 
-/**
- * Reads through DynamicContext.storage rather than a per-app fetcher, so
- * swapping a platform's backing store stays a provider-level change instead
- * of leaving pages that know the storage key and value type behind.
- */
 const useBookmarks = () => {
   const { storage } = use(DynamicContext);
   return useSWR(swrKeys.bookmarks, async () =>

--- a/packages/shared/src/components/Bookmarks/hooks/useBookmarks.ts
+++ b/packages/shared/src/components/Bookmarks/hooks/useBookmarks.ts
@@ -1,0 +1,21 @@
+import { use } from 'react';
+import useSWR from 'swr';
+
+import { STORAGE_KEYS } from '../../../constants/storage';
+import DynamicContext from '../../../provider/DynamicContext';
+import { swrKeys } from '../../../swr/keys';
+import { type IBookmarksObj } from '../interfaces';
+
+/**
+ * Reads through DynamicContext.storage rather than a per-app fetcher, so
+ * swapping a platform's backing store stays a provider-level change instead
+ * of leaving pages that know the storage key and value type behind.
+ */
+const useBookmarks = () => {
+  const { storage } = use(DynamicContext);
+  return useSWR(swrKeys.bookmarks, async () =>
+    storage.get<IBookmarksObj>(STORAGE_KEYS.bookmarks)
+  );
+};
+
+export default useBookmarks;

--- a/packages/shared/src/components/Persons/hooks/useOrderedPersons.ts
+++ b/packages/shared/src/components/Persons/hooks/useOrderedPersons.ts
@@ -1,0 +1,24 @@
+import useDefaultFolderUrls from '../../Bookmarks/hooks/useDefaultFolderUrls';
+import { getFilteredPersons, sortByRecency } from '../utils';
+import usePersons from './usePersons';
+
+/**
+ * The order -> filter pipeline both persons panels share.
+ *
+ * Returns IPerson[]; avatars come from usePersonImageMap so image urls stay
+ * out of the array the extension panel persists.
+ *
+ * The tag dropdown deliberately keeps its own hook: it needs images, and it
+ * sorts alphabetically rather than leaving the list untouched when recency
+ * is off. Unifying that would change visible ordering, so it is left alone.
+ */
+const useOrderedPersons = (orderByRecency: boolean, searchText = '') => {
+  const { data: persons = [], ...rest } = usePersons();
+  const { data: urls = [] } = useDefaultFolderUrls();
+
+  const ordered = orderByRecency ? sortByRecency(persons, urls) : persons;
+
+  return { ...rest, data: getFilteredPersons(ordered, searchText) };
+};
+
+export default useOrderedPersons;

--- a/packages/shared/src/components/Persons/hooks/useOrderedPersons.ts
+++ b/packages/shared/src/components/Persons/hooks/useOrderedPersons.ts
@@ -3,14 +3,8 @@ import { getFilteredPersons, sortByRecency } from '../utils';
 import usePersons from './usePersons';
 
 /**
- * The order -> filter pipeline both persons panels share.
- *
  * Returns IPerson[]; avatars come from usePersonImageMap so image urls stay
  * out of the array the extension panel persists.
- *
- * The tag dropdown deliberately keeps its own hook: it needs images, and it
- * sorts alphabetically rather than leaving the list untouched when recency
- * is off. Unifying that would change visible ordering, so it is left alone.
  */
 const useOrderedPersons = (orderByRecency: boolean, searchText = '') => {
   const { data: persons = [], ...rest } = usePersons();

--- a/packages/shared/src/components/Persons/utils/index.ts
+++ b/packages/shared/src/components/Persons/utils/index.ts
@@ -8,11 +8,7 @@ import {
   type PersonImageUrls,
 } from '../interfaces/persons';
 
-/**
- * Built field by field rather than spread: these sit on the persistence
- * boundary, and a spread would carry view-model extras (an imageUrl, say)
- * into local storage and the Firebase payload.
- */
+/** Field by field, so view-model extras cannot reach storage or Firebase. */
 export const getDecryptedPerson = ({ uid, name }: IPerson): IPerson => ({
   uid,
   name: atob(name),

--- a/packages/shared/src/components/Persons/utils/index.ts
+++ b/packages/shared/src/components/Persons/utils/index.ts
@@ -8,19 +8,20 @@ import {
   type PersonImageUrls,
 } from '../interfaces/persons';
 
-export const getDecryptedPerson = (person: IPerson): IPerson => {
-  return {
-    ...person,
-    name: atob(person.name),
-  };
-};
+/**
+ * Built field by field rather than spread: these sit on the persistence
+ * boundary, and a spread would carry view-model extras (an imageUrl, say)
+ * into local storage and the Firebase payload.
+ */
+export const getDecryptedPerson = ({ uid, name }: IPerson): IPerson => ({
+  uid,
+  name: atob(name),
+});
 
-export const getEncryptedPerson = (person: IPerson): IPerson => {
-  return {
-    ...person,
-    name: btoa(person.name),
-  };
-};
+export const getEncryptedPerson = ({ uid, name }: IPerson): IPerson => ({
+  uid,
+  name: btoa(name),
+});
 
 export const decodePersons = (persons: IPersons): IPerson[] =>
   Object.values(persons)

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -1,1 +1,18 @@
 export const HEADER_HEIGHT = 56;
+
+/**
+ * The cropper and the upload API must agree, or every uploaded avatar gets
+ * silently rescaled. They previously tracked each other by paired comments.
+ */
+export const PERSON_IMAGE_SIZE = 250;
+
+/**
+ * Canonical repository identity. Lives here rather than in @bypass/trpc so
+ * client components can import it without pulling in a server package.
+ */
+export const REPO = {
+  OWNER: 'amitsingh-007',
+  NAME: 'bypass-links',
+};
+
+export const GITHUB_REPO_URL = `https://github.com/${REPO.OWNER}/${REPO.NAME}`;

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -1,15 +1,7 @@
 export const HEADER_HEIGHT = 56;
 
-/**
- * The cropper and the upload API must agree, or every uploaded avatar gets
- * silently rescaled. They previously tracked each other by paired comments.
- */
 export const PERSON_IMAGE_SIZE = 250;
 
-/**
- * Canonical repository identity. Lives here rather than in @bypass/trpc so
- * client components can import it without pulling in a server package.
- */
 export const REPO = {
   OWNER: 'amitsingh-007',
   NAME: 'bypass-links',

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,6 +5,7 @@ export { default as Folder } from './components/Bookmarks/components/Folder';
 export * from './components/Bookmarks/components/Folder';
 export * from './components/Bookmarks/constants';
 export { default as useBookmark } from './components/Bookmarks/hooks/useBookmark';
+export { default as useBookmarks } from './components/Bookmarks/hooks/useBookmarks';
 export { default as useDefaultFolderUrls } from './components/Bookmarks/hooks/useDefaultFolderUrls';
 export type * from './components/Bookmarks/interfaces';
 export type * from './components/Bookmarks/interfaces/url';
@@ -23,6 +24,7 @@ export * from './components/Persons/utils/urls';
 export { default as useAllPersonsWithImages } from './components/Persons/hooks/useAllPersonsWithImages';
 export { default as usePerson } from './components/Persons/hooks/usePerson';
 export { default as usePersons } from './components/Persons/hooks/usePersons';
+export { default as useOrderedPersons } from './components/Persons/hooks/useOrderedPersons';
 export { default as usePersonImage } from './components/Persons/hooks/usePersonImage';
 export { default as usePersonImageMap } from './components/Persons/hooks/usePersonImageMap';
 

--- a/packages/shared/src/swr/config.ts
+++ b/packages/shared/src/swr/config.ts
@@ -1,11 +1,8 @@
 import { type SWRConfiguration } from 'swr';
 
 /**
- * No cache `provider`: a custom one would be separate from SWR's module-level
- * default and silently break the `mutate` calls made outside React.
- * No global `onError`: only the extension mounts a Toaster, so it layers one
- * on in its own SWRConfig rather than this transport-neutral base carrying a
- * dependency the web app cannot satisfy.
+ * No cache `provider`: it would break the `mutate` calls made outside React.
+ * No global `onError`: only the extension mounts a Toaster, so it adds one.
  */
 export const swrConfig: SWRConfiguration = {
   // Storage only changes through our own mutations, so refetching is churn

--- a/packages/shared/src/swr/config.ts
+++ b/packages/shared/src/swr/config.ts
@@ -3,7 +3,9 @@ import { type SWRConfiguration } from 'swr';
 /**
  * No cache `provider`: a custom one would be separate from SWR's module-level
  * default and silently break the `mutate` calls made outside React.
- * No global `onError`: only the extension mounts a Toaster.
+ * No global `onError`: only the extension mounts a Toaster, so it layers one
+ * on in its own SWRConfig rather than this transport-neutral base carrying a
+ * dependency the web app cannot satisfy.
  */
 export const swrConfig: SWRConfiguration = {
   // Storage only changes through our own mutations, so refetching is churn

--- a/packages/shared/src/swr/invalidate.ts
+++ b/packages/shared/src/swr/invalidate.ts
@@ -11,10 +11,10 @@ export const invalidatePersonKeys = async () => {
   ]);
 };
 
+/** Web-neutral. The extension wraps this to add its own keys. */
 export const invalidateBookmarkKeys = async () => {
   await Promise.all([
     mutate(swrKeys.bookmarks),
-    mutate(swrKeyMatchers.quickBookmark),
     mutate(swrKeys.defaultFolderUrls),
     mutate(swrKeyMatchers.taggedBookmarks),
   ]);

--- a/packages/shared/src/swr/keys.ts
+++ b/packages/shared/src/swr/keys.ts
@@ -1,8 +1,6 @@
 // Consts, so the key factories and the matchers below cannot drift apart
 const PERSON_IMAGE = 'person-image';
 const TAGGED_BOOKMARKS = 'tagged-bookmarks';
-const LAST_VISITED = 'last-visited';
-const QUICK_BOOKMARK = 'quick-bookmark';
 
 export const joinIds = (ids: string[]) =>
   [...new Set(ids)].toSorted().join('|');
@@ -14,21 +12,15 @@ export const swrKeys = {
   bookmarks: 'bookmarks',
   defaultFolderUrls: 'default-folder-urls',
   redirections: 'redirections',
-  currentTab: 'current-tab',
   personImage: (uid?: string) => (uid ? [PERSON_IMAGE, uid] : null),
   personImageMap: (uids: string[]) => [PERSON_IMAGE, 'map', joinIds(uids)],
   taggedBookmarks: (uid?: string) => (uid ? [TAGGED_BOOKMARKS, uid] : null),
-  lastVisited: (url?: string) => (url ? [LAST_VISITED, url] : null),
-  lastVisitedMap: (urls: string[]) => [LAST_VISITED, 'map', joinIds(urls)],
-  quickBookmark: (url?: string) => (url ? [QUICK_BOOKMARK, url] : null),
 } as const;
 
-const matchKeyPrefix = (prefix: string) => (key: unknown) =>
+export const matchKeyPrefix = (prefix: string) => (key: unknown) =>
   Array.isArray(key) && key[0] === prefix;
 
 export const swrKeyMatchers = {
   personImage: matchKeyPrefix(PERSON_IMAGE),
   taggedBookmarks: matchKeyPrefix(TAGGED_BOOKMARKS),
-  lastVisited: matchKeyPrefix(LAST_VISITED),
-  quickBookmark: matchKeyPrefix(QUICK_BOOKMARK),
 } as const;

--- a/packages/trpc/src/constants/github.ts
+++ b/packages/trpc/src/constants/github.ts
@@ -1,2 +1,0 @@
-// Re-exported so the release service and the UI cannot name different repos
-export { REPO } from '@bypass/shared';

--- a/packages/trpc/src/constants/github.ts
+++ b/packages/trpc/src/constants/github.ts
@@ -1,4 +1,2 @@
-export const REPO = {
-  OWNER: 'amitsingh-007',
-  NAME: 'bypass-links',
-};
+// Re-exported so the release service and the UI cannot name different repos
+export { REPO } from '@bypass/shared';

--- a/packages/trpc/src/services/githubService.ts
+++ b/packages/trpc/src/services/githubService.ts
@@ -1,7 +1,7 @@
+import { REPO } from '@bypass/shared';
 import { Octokit } from '@octokit/rest';
 
 import { env } from '../constants/env';
-import { REPO } from '../constants/github';
 
 const octokit = new Octokit({
   auth: env.GITHUB_TOKEN,


### PR DESCRIPTION
Moves logic to the layer that owns it, and removes special cases that only ever served one app.

## SWR keys and invalidation

- `currentTab`, `lastVisited` and `quickBookmark` move to the extension. They had **zero** web consumers, so the shared invalidator was mutating keys that could never match in one app and vice versa.
- The extension composes its own keys via `invalidateExtBookmarkKeys` rather than the shared invalidator taking an optional matcher list — a new extension write path cannot forget to pass something it never sees.
- The extension layers a global SWR `onError` on top of the shared config. That config omits one because only the extension mounts a Toaster, which makes an app-level override the *intended* escape hatch. It is an adapter, not `toast.error` itself, whose second parameter is toast options and would otherwise receive the SWR key. Covers `useSWR` only — `useSWRMutation` takes its own.

## Persons

- `useOrderedPersons` replaces the character-identical order/filter pipeline in both panels.
- It returns `IPerson[]`. The tag dropdown keeps its own hook: it needs images and sorts alphabetically when recency is off. That is a deliberate UX difference, not drift, and unifying it would change visible ordering — flagging rather than deciding.
- `getEncryptedPerson`/`getDecryptedPerson` build their result field by field. They sit on the persistence boundary and a spread would carry view-model extras into storage and the Firebase payload.

## Bookmarks

- `useBookmarks` reads through `DynamicContext.storage`, replacing a page-level localStorage fetcher that used the shared SWR key while bypassing the abstraction that owns it.
- Shared null guards are **kept**: the web provider is raw localStorage returning `null` on a fresh profile, so fixing only the extension adapter would not make absence impossible.

## Constants

- ⚠️ **One favicon provider per app.** The cache is keyed by the generated URL, so changing the provider at some of the five call sites and not others turned every cached favicon into a permanent miss.
- ⚠️ **`GITHUB_REPO_URL`** — two links on the same page pointed at *different orgs* (`bypass-links/bypass-links` vs `amitsingh-007/bypass-links`). Canonicalized to `amitsingh-007`, which is what the release service fetches from. Repository identity lives in `@bypass/shared` so client components do not import it from a server package.
- ⚠️ **Firebase auth-helper rewrite** derives from `projectId` using the same discriminator as the runtime config, instead of hardcoding the prod project while dev initialises against `bypass-links-dev`. This changes which project dev proxies `/__/auth/*` to — worth confirming that is the intent.
- `PERSON_IMAGE_SIZE` replaces a raw `250` that the cropper and upload API kept in step with paired comments.
- `PageHeader` takes the field it reads instead of re-declaring the release payload shape.

## Not included

The redirection base64 codec consolidation is **deferred**. The plan required building it on a UTF-8-safe field-generic pair, but a back-compatible decode would corrupt existing values containing percent-encoding, and migrating persisted data is a decision that needs your call. Consolidating raw `btoa` instead would just centralize the defect. Happy to do either once you pick.

The `EFirebaseDBRef` / `STORAGE_KEYS` dedup is also skipped: a TS string enum cannot be cleanly derived from an imported object, and the representation change ripples wider than the five duplicated literals are worth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

 

<details><summary><h3>Greptile Summary</h3></summary>

This refactor moves app-specific SWR keys, invalidation, favicon selection, and error handling into their owning applications while consolidating shared bookmark/person hooks and constants.
- Adds extension-specific SWR configuration and bookmark invalidation.
- Centralizes shared person ordering and context-backed bookmark reads.
- Aligns favicon providers, repository metadata, image sizing, and Firebase auth-helper configuration.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (5): Last reviewed commit: ["docs: trim comments to the constraints t..."](https://github.com/amitsingh-007/bypass-links/commit/857b68d062fbf149fc3003e5a5b5da7847fac7d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51437742)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Extension Popup UI](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/extension-popup.md)
- Knowledge Base — [Web App (apps/web)](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/web-app.md)
- Knowledge Base — [Shared package (`packages/shared`)](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/shared-package.md)
- Knowledge Base — [packages/trpc: shared tRPC API layer](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/trpc-package.md)
</details>

<!-- /greptile_comment -->