### PR TITLE
refactor: dedupe repeated components and test helpers

### DIFF
--- a/apps/extension/src/entrypoints/popup/components/LoadingOverlay.tsx
+++ b/apps/extension/src/entrypoints/popup/components/LoadingOverlay.tsx
@@ -1,0 +1,18 @@
+import { Spinner } from '@bypass/ui';
+
+interface Props {
+  testId?: string;
+}
+
+function LoadingOverlay({ testId = 'loading-overlay' }: Props) {
+  return (
+    <div
+      data-testid={testId}
+      className="absolute inset-0 z-50 flex items-center justify-center bg-black/50"
+    >
+      <Spinner className="size-8" />
+    </div>
+  );
+}
+
+export default LoadingOverlay;

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/ImagePicker.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/ImagePicker.tsx
@@ -6,7 +6,6 @@ import {
   DialogHeader,
   DialogTitle,
   Input,
-  Slider,
   Spinner,
 } from '@bypass/ui';
 import { useDebouncedValue } from '@mantine/hooks';
@@ -19,7 +18,10 @@ import {
 import AvatarEditor, { type AvatarEditorRef } from 'react-avatar-editor';
 import wretch from 'wretch';
 
+import LoadingOverlay from '@popup/components/LoadingOverlay';
+
 import { uploadFileToFirebase } from '../utils/uploadImage';
+import LabeledSlider from './LabeledSlider';
 
 interface Props {
   uid: string;
@@ -98,14 +100,7 @@ function ImagePicker({ uid, isOpen, onDialogClose, handleImageSave }: Props) {
         showCloseButton={false}
       >
         <div className="size-full bg-background">
-          {isUploadingImage && (
-            <div
-              className="absolute inset-0 z-50 flex items-center justify-center bg-black/50"
-              data-testid="uploading-overlay"
-            >
-              <Spinner className="size-8" />
-            </div>
-          )}
+          {isUploadingImage && <LoadingOverlay testId="uploading-overlay" />}
           <DialogHeader className="px-0">
             <DialogTitle className="sr-only">Upload Image</DialogTitle>
           </DialogHeader>
@@ -151,35 +146,23 @@ function ImagePicker({ uid, isOpen, onDialogClose, handleImageSave }: Props) {
               </Button>
             </div>
             <div className="mt-6 flex flex-wrap items-center justify-center gap-6">
-              <div className="w-[40%]">
-                <span className="mb-2 block text-sm">Zoom</span>
-                <Slider
-                  value={[zoom]}
-                  min={1}
-                  max={3}
-                  step={0.001}
-                  disabled={disableControls}
-                  thumbAlignment="center"
-                  onValueChange={(value) => {
-                    const val = typeof value === 'number' ? value : value[0];
-                    setZoom(val ?? 1);
-                  }}
-                />
-              </div>
-              <div className="w-[40%]">
-                <span className="mb-2 block text-sm">Rotate</span>
-                <Slider
-                  value={[rotation]}
-                  min={0}
-                  max={360}
-                  disabled={disableControls}
-                  thumbAlignment="center"
-                  onValueChange={(value) => {
-                    const val = typeof value === 'number' ? value : value[0];
-                    setRotation(val ?? 0);
-                  }}
-                />
-              </div>
+              <LabeledSlider
+                label="Zoom"
+                value={zoom}
+                min={1}
+                max={3}
+                step={0.001}
+                disabled={disableControls}
+                onValueChange={setZoom}
+              />
+              <LabeledSlider
+                label="Rotate"
+                value={rotation}
+                min={0}
+                max={360}
+                disabled={disableControls}
+                onValueChange={setRotation}
+              />
             </div>
           </div>
         </div>

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/LabeledSlider.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/LabeledSlider.tsx
@@ -30,8 +30,7 @@ function LabeledSlider({
         disabled={disabled}
         thumbAlignment="center"
         onValueChange={(next) => {
-          // Base UI hands back a number for single-thumb sliders and an array
-          // for ranges
+          // Base UI: number for single-thumb sliders, array for ranges
           onValueChange((typeof next === 'number' ? next : next[0]) ?? min);
         }}
       />

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/LabeledSlider.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/LabeledSlider.tsx
@@ -1,0 +1,42 @@
+import { Slider } from '@bypass/ui';
+
+interface Props {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  disabled?: boolean;
+  onValueChange: (value: number) => void;
+}
+
+function LabeledSlider({
+  label,
+  value,
+  min,
+  max,
+  step,
+  disabled,
+  onValueChange,
+}: Props) {
+  return (
+    <div className="w-[40%]">
+      <span className="mb-2 block text-sm">{label}</span>
+      <Slider
+        value={[value]}
+        min={min}
+        max={max}
+        step={step}
+        disabled={disabled}
+        thumbAlignment="center"
+        onValueChange={(next) => {
+          // Base UI hands back a number for single-thumb sliders and an array
+          // for ranges
+          onValueChange((typeof next === 'number' ? next : next[0]) ?? min);
+        }}
+      />
+    </div>
+  );
+}
+
+export default LabeledSlider;

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/PersonsPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/PersonsPanel.tsx
@@ -12,13 +12,13 @@ import {
   usePerson,
   usePersons,
 } from '@bypass/shared';
-import { Spinner } from '@bypass/ui';
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { useLocation, useSearch } from 'wouter';
 
 import { trpcApi } from '@/apis/trpcApi';
 import { MAX_PANEL_SIZE } from '@/constants';
+import LoadingOverlay from '@popup/components/LoadingOverlay';
 import Panel from '@popup/components/Panel';
 
 import { getPersonPos, setPersonsInStorage } from '../utils';
@@ -116,14 +116,7 @@ function PersonsPanel() {
         className="relative"
         style={{ height: MAX_PANEL_SIZE.HEIGHT - HEADER_HEIGHT }}
       >
-        {isFetching && (
-          <div
-            data-testid="loading-overlay"
-            className="absolute inset-0 z-50 flex items-center justify-center bg-black/50"
-          >
-            <Spinner className="size-8" />
-          </div>
-        )}
+        {isFetching && <LoadingOverlay />}
         {filteredAndOrderedPersons.length > 0 ? (
           <Persons
             scrollButton

--- a/apps/extension/src/entrypoints/popup/panels/ShortcutsPanel/components/ShortcutsPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/ShortcutsPanel/components/ShortcutsPanel.tsx
@@ -15,6 +15,7 @@ import useSWRMutation from 'swr/mutation';
 import { trpcApi } from '@/apis/trpcApi';
 import { redirectionsItem } from '@/storage/items';
 import { syncRedirectionsToStorage } from '@background/redirections';
+import LoadingOverlay from '@popup/components/LoadingOverlay';
 import Panel from '@popup/components/Panel';
 import { useLastVisitedMap } from '@popup/hooks/useLastVisited';
 
@@ -137,14 +138,7 @@ function ShortcutsPanel() {
             </div>
           );
         })}
-        {isFetching && (
-          <div
-            data-testid="loading-overlay"
-            className="absolute inset-0 z-50 flex items-center justify-center bg-black/50"
-          >
-            <Spinner className="size-8" />
-          </div>
-        )}
+        {isFetching && <LoadingOverlay />}
       </div>
     </Panel>
   );

--- a/apps/extension/tests/global-teardown.ts
+++ b/apps/extension/tests/global-teardown.ts
@@ -1,10 +1,8 @@
-import fs from 'node:fs';
-
+import { removeAuthCacheDir } from '@bypass/shared/tests';
 import { test as teardown } from '@playwright/test';
 
 import { AUTH_CACHE_DIR } from './auth-constants';
 
 teardown('clean up cache directory', async () => {
-  // Clean up the cache directory after all tests complete
-  await fs.promises.rm(AUTH_CACHE_DIR, { recursive: true, force: true });
+  await removeAuthCacheDir(AUTH_CACHE_DIR);
 });

--- a/apps/web/src/app/bookmark-panel/layout.tsx
+++ b/apps/web/src/app/bookmark-panel/layout.tsx
@@ -1,16 +1,13 @@
 import { type Metadata } from 'next';
 import { type ReactNode } from 'react';
 
+import { NOINDEX_ROBOTS } from '@app/constants/metadata';
+
 export const metadata: Metadata = {
   title: 'Bookmarks Panel',
-  robots: {
-    follow: false,
-    index: false,
-  },
+  robots: NOINDEX_ROBOTS,
 };
 
-const Layout = async ({ children }: Readonly<{ children: ReactNode }>) => {
-  return children;
-};
+const Layout = ({ children }: Readonly<{ children: ReactNode }>) => children;
 
 export default Layout;

--- a/apps/web/src/app/constants/metadata.ts
+++ b/apps/web/src/app/constants/metadata.ts
@@ -1,9 +1,5 @@
 import { type Metadata } from 'next';
 
-/**
- * The panels are signed-in surfaces. Stated once so a new one cannot quietly
- * ship without it.
- */
 export const NOINDEX_ROBOTS: Metadata['robots'] = {
   follow: false,
   index: false,

--- a/apps/web/src/app/constants/metadata.ts
+++ b/apps/web/src/app/constants/metadata.ts
@@ -1,0 +1,10 @@
+import { type Metadata } from 'next';
+
+/**
+ * The panels are signed-in surfaces. Stated once so a new one cannot quietly
+ * ship without it.
+ */
+export const NOINDEX_ROBOTS: Metadata['robots'] = {
+  follow: false,
+  index: false,
+};

--- a/apps/web/src/app/persons-panel/layout.tsx
+++ b/apps/web/src/app/persons-panel/layout.tsx
@@ -1,16 +1,13 @@
 import { type Metadata } from 'next';
 import { type ReactNode } from 'react';
 
+import { NOINDEX_ROBOTS } from '@app/constants/metadata';
+
 export const metadata: Metadata = {
   title: 'Persons Panel',
-  robots: {
-    follow: false,
-    index: false,
-  },
+  robots: NOINDEX_ROBOTS,
 };
 
-const Layout = async ({ children }: Readonly<{ children: ReactNode }>) => {
-  return children;
-};
+const Layout = ({ children }: Readonly<{ children: ReactNode }>) => children;
 
 export default Layout;

--- a/apps/web/src/app/web-ext/layout.tsx
+++ b/apps/web/src/app/web-ext/layout.tsx
@@ -1,16 +1,13 @@
 import { type Metadata } from 'next';
 import { type ReactNode } from 'react';
 
+import { NOINDEX_ROBOTS } from '@app/constants/metadata';
+
 export const metadata: Metadata = {
   title: 'Web',
-  robots: {
-    follow: false,
-    index: false,
-  },
+  robots: NOINDEX_ROBOTS,
 };
 
-const Layout = async ({ children }: { children: ReactNode }) => {
-  return children;
-};
+const Layout = ({ children }: Readonly<{ children: ReactNode }>) => children;
 
 export default Layout;

--- a/apps/web/tests/global-teardown.ts
+++ b/apps/web/tests/global-teardown.ts
@@ -1,10 +1,8 @@
-import fs from 'node:fs';
-
+import { removeAuthCacheDir } from '@bypass/shared/tests';
 import { test as teardown } from '@playwright/test';
 
 import { AUTH_CACHE_DIR } from './auth-constants';
 
 teardown('clean up cache directory', async () => {
-  // Clean up the cache directory after all tests complete
-  await fs.promises.rm(AUTH_CACHE_DIR, { recursive: true, force: true });
+  await removeAuthCacheDir(AUTH_CACHE_DIR);
 });

--- a/apps/web/tests/page-object-models/persons-panel.ts
+++ b/apps/web/tests/page-object-models/persons-panel.ts
@@ -1,4 +1,6 @@
 import {
+  clearSearchInput,
+  fillSearchInput,
   getHeaderPersonCount,
   parseBadgeCount,
   verifyModalClosed,
@@ -70,17 +72,11 @@ export class PersonsPanel {
   }
 
   async searchWithinBookmarks(query: string) {
-    const modal = this.getModal();
-    const searchInput = modal.getByPlaceholder('Search');
-    await searchInput.fill(query);
-    await expect(searchInput).toHaveValue(query);
+    await fillSearchInput(this.getModal(), query);
   }
 
   async clearSearchWithinBookmarks() {
-    const modal = this.getModal();
-    const searchInput = modal.getByPlaceholder('Search');
-    await searchInput.clear();
-    await expect(searchInput).toHaveValue('');
+    await clearSearchInput(this.getModal());
   }
 
   async closeModal() {

--- a/packages/shared/src/utils/test-helpers.ts
+++ b/packages/shared/src/utils/test-helpers.ts
@@ -98,7 +98,6 @@ export const verifyModalVisible = async (page: Page, modalTestId?: string) => {
   }
 };
 
-/** Locator as well as Page, so callers can scope to a dialog. */
 type SearchScope = Pick<Page, 'getByPlaceholder'>;
 
 /**
@@ -210,10 +209,7 @@ export const openNewPageFromAction = async (
   return newPage;
 };
 
-/**
- * The teardown entrypoints stay in each app because Playwright discovers
- * projects inside their own testDir; only the body is shared.
- */
+/** Entrypoints stay per-app; Playwright discovers projects in their testDir. */
 export const removeAuthCacheDir = async (cacheDir: string) => {
   await fs.promises.rm(cacheDir, { recursive: true, force: true });
 };

--- a/packages/shared/src/utils/test-helpers.ts
+++ b/packages/shared/src/utils/test-helpers.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+
 import {
   expect,
   type BrowserContext,
@@ -96,15 +98,18 @@ export const verifyModalVisible = async (page: Page, modalTestId?: string) => {
   }
 };
 
+/** Locator as well as Page, so callers can scope to a dialog. */
+type SearchScope = Pick<Page, 'getByPlaceholder'>;
+
 /**
  * Fill a search input.
  */
 export const fillSearchInput = async (
-  page: Page,
+  scope: SearchScope,
   query: string,
   placeholder = 'Search'
 ) => {
-  const searchInput = page.getByPlaceholder(placeholder);
+  const searchInput = scope.getByPlaceholder(placeholder);
   await searchInput.fill(query);
   await expect(searchInput).toHaveValue(query);
 };
@@ -112,8 +117,11 @@ export const fillSearchInput = async (
 /**
  * Clear a search input.
  */
-export const clearSearchInput = async (page: Page, placeholder = 'Search') => {
-  const searchInput = page.getByPlaceholder(placeholder);
+export const clearSearchInput = async (
+  scope: SearchScope,
+  placeholder = 'Search'
+) => {
+  const searchInput = scope.getByPlaceholder(placeholder);
   await searchInput.clear();
   await expect(searchInput).toHaveValue('');
 };
@@ -200,4 +208,12 @@ export const openNewPageFromAction = async (
     .not.toBe('about:blank');
 
   return newPage;
+};
+
+/**
+ * The teardown entrypoints stay in each app because Playwright discovers
+ * projects inside their own testDir; only the body is shared.
+ */
+export const removeAuthCacheDir = async (cacheDir: string) => {
+  await fs.promises.rm(cacheDir, { recursive: true, force: true });
 };


### PR DESCRIPTION
Extractions taken only where they shrink the call site once every variant is accounted for.

## Taken

- **`LoadingOverlay`** — the same absolutely-positioned spinner block in three places; the third differed only by its test id.
- **`LabeledSlider`** — the byte-identical zoom and rotate blocks in `ImagePicker`, plus the value-normalisation line each repeated. The fallback is the slider own `min`, which matches what both call sites hardcoded (`1` and `0`).
- **`NOINDEX_ROBOTS`** — states the panels noindex policy once instead of in each of the three layouts, where a fourth page could silently omit it. The layouts also drop a pointless `async`.
- **Playwright teardown** — the body moves to shared test utils. The entrypoints stay per-app because projects are discovered inside their own `testDir`, so only the duplicated body is shared, not the file.
- **Shared search helpers** take a scope rather than a `Page`, so the web persons POM can call them against the modal instead of keeping its own copies under different names (`searchWithinBookmarks`/`clearSearchWithinBookmarks`).

## Deliberately not extracted

Per the net-reduction guardrail — each of these would take more configuration than it removes:

- **The two bookmark virtual lists** differ in `overscan` (10 vs 5) and share *no* row props (`{bookmark, folders}` vs `{bookmark, pos, isSelected, isCut}`).
- **`sortByPriorityMap`** — the two sorts share a comparator but build their maps differently, and last-write-wins keying is load-bearing for recency order.
- **`filterBySearch`** and **`LabeledSwitch`** — three and five call sites respectively, each with real field or layout differences that would become boolean flags.

Note `LabeledSwitch` being skipped leaves a real inconsistency in place: the two cross-app "Recency" switches share `data-testid="recency-switch"` but render differently (web hides the label below `sm`). Worth fixing as a styling change rather than an abstraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

 

<details><summary><h3>Greptile Summary</h3></summary>

The PR consolidates repeated UI and test utilities while preserving the existing call-site variants.
- Extracts shared loading-overlay and labeled-slider components.
- Centralizes noindex metadata and Playwright authentication-cache cleanup.
- Generalizes search helpers to operate within either a page or locator scope.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (4): Last reviewed commit: ["docs: trim comments to the constraints t..."](https://github.com/amitsingh-007/bypass-links/commit/54bedce95eaa9da8826b6e17a13cb4a2e41e92de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51437745)</sub>

<!-- /greptile_comment -->