### PR TITLE
refactor: simplify local control flow

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -34,22 +34,21 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GOOGLE_GENERATIVE_AI_API_KEY:
-            ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-          
+
           # for Amazon Bedrock (https://docs.pullfrog.com/bedrock)
           # AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
           # AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           # AWS_REGION: us-east-1
           # BEDROCK_MODEL_ID: <bedrock-model-id>
-          
+
           # for Google Vertex AI (https://docs.pullfrog.com/vertex)
           # VERTEX_SERVICE_ACCOUNT_JSON: >-
           #   ${{ secrets.VERTEX_SERVICE_ACCOUNT_JSON }}

--- a/.vercelignore
+++ b/.vercelignore
@@ -7,5 +7,4 @@
 **/.env.local
 
 # Need this for eslint
-
 !.gitignore

--- a/apps/extension/src/entrypoints/background/utils/index.ts
+++ b/apps/extension/src/entrypoints/background/utils/index.ts
@@ -1,5 +1,4 @@
 import { type EExtensionState } from '@/constants';
-import { extStateItem } from '@/storage/items';
 import { getIsExtensionActive } from '@/utils/common';
 
 const restrictedProtocols = new Set([
@@ -32,19 +31,17 @@ export const setExtensionIcon = async ({
   hasPendingBookmarks,
   hasPendingPersons,
 }: {
-  extState?: EExtensionState;
-  hasPendingBookmarks?: boolean;
-  hasPendingPersons?: boolean;
+  extState: EExtensionState;
+  hasPendingBookmarks: boolean;
+  hasPendingPersons: boolean;
 }) => {
-  let icon: string;
-  if (hasPendingBookmarks === true || hasPendingPersons === true) {
-    icon = 'assets/bypass_link_pending_32.png';
-  } else {
-    const newExtState = extState ?? (await extStateItem.getValue());
-    icon = getIsExtensionActive(newExtState)
-      ? 'assets/bypass_link_on_32.png'
-      : 'assets/bypass_link_off_32.png';
-  }
+  const isActive = getIsExtensionActive(extState);
+  const icon =
+    hasPendingBookmarks || hasPendingPersons
+      ? 'assets/bypass_link_pending_32.png'
+      : isActive
+        ? 'assets/bypass_link_on_32.png'
+        : 'assets/bypass_link_off_32.png';
   await browser.action.setIcon({ path: icon });
 };
 
@@ -54,9 +51,4 @@ export const isValidUrl = (_url?: string): boolean => {
   return (
     !restrictedHosts.has(url.hostname) && !restrictedProtocols.has(url.protocol)
   );
-};
-
-export const isValidTabUrl = async (tabId: number) => {
-  const tab = await browser.tabs.get(tabId);
-  return isValidUrl(tab.url);
 };

--- a/apps/extension/src/entrypoints/background/utils/index.ts
+++ b/apps/extension/src/entrypoints/background/utils/index.ts
@@ -35,14 +35,15 @@ export const setExtensionIcon = async ({
   hasPendingBookmarks: boolean;
   hasPendingPersons: boolean;
 }) => {
-  const isActive = getIsExtensionActive(extState);
-  const icon =
-    hasPendingBookmarks || hasPendingPersons
-      ? 'assets/bypass_link_pending_32.png'
-      : isActive
-        ? 'assets/bypass_link_on_32.png'
-        : 'assets/bypass_link_off_32.png';
-  await browser.action.setIcon({ path: icon });
+  const getIcon = () => {
+    if (hasPendingBookmarks || hasPendingPersons) {
+      return 'assets/bypass_link_pending_32.png';
+    }
+    return getIsExtensionActive(extState)
+      ? 'assets/bypass_link_on_32.png'
+      : 'assets/bypass_link_off_32.png';
+  };
+  await browser.action.setIcon({ path: getIcon() });
 };
 
 export const isValidUrl = (_url?: string): boolean => {

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarkAddEditDialog.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarkAddEditDialog.tsx
@@ -136,12 +136,14 @@ function BookmarkAddEditDialog({ curFolderId, handleScroll }: Props) {
     async (currentOperation: EBookmarkOperation, currentBmUrl: string) => {
       if (currentOperation === EBookmarkOperation.ADD) {
         const { title = '' } = await getCurrentTab();
-        form.setFieldValue('id', crypto.randomUUID());
-        form.setFieldValue('pos', contextBookmarks.length);
-        form.setFieldValue('url', currentBmUrl);
-        form.setFieldValue('title', title);
-        form.setFieldValue('folderId', defaultFolderId ?? ROOT_FOLDER_ID);
-        form.setFieldValue('taggedPersons', []);
+        form.reset({
+          id: crypto.randomUUID(),
+          pos: contextBookmarks.length,
+          url: currentBmUrl,
+          title,
+          folderId: defaultFolderId ?? ROOT_FOLDER_ID,
+          taggedPersons: [],
+        });
         dialogHandlers.open();
         return;
       }
@@ -156,12 +158,14 @@ function BookmarkAddEditDialog({ curFolderId, handleScroll }: Props) {
             `Expected a bookmark at index ${pos}, found a folder`
           );
         }
-        form.setFieldValue('id', bookmark.id);
-        form.setFieldValue('pos', pos);
-        form.setFieldValue('url', bookmark.url);
-        form.setFieldValue('title', bookmark.title);
-        form.setFieldValue('folderId', curFolderId);
-        form.setFieldValue('taggedPersons', bookmark.taggedPersons);
+        form.reset({
+          id: bookmark.id,
+          pos,
+          url: bookmark.url,
+          title: bookmark.title,
+          folderId: curFolderId,
+          taggedPersons: bookmark.taggedPersons,
+        });
         dialogHandlers.open();
       }
     },

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarkContextMenu.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarkContextMenu.tsx
@@ -18,7 +18,6 @@ import { countTruthy } from '../utils';
 import { findBookmarkById } from '../utils/bookmark';
 
 type Props = PropsWithChildren<{
-  children: React.ReactNode;
   handleOpenSelectedBookmarks: VoidFunction;
 }>;
 
@@ -73,10 +72,6 @@ function BookmarkContextMenu({ children, handleOpenSelectedBookmarks }: Props) {
     return bookmark;
   };
 
-  const handleDeleteOptionClick = (id: string) => {
-    handleUrlRemove(id);
-  };
-
   const handleBookmarkEdit = (id: string) => {
     const bookmark = getBookmark(id);
     setBookmarkOperation(EBookmarkOperation.EDIT, bookmark.url);
@@ -124,7 +119,7 @@ function BookmarkContextMenu({ children, handleOpenSelectedBookmarks }: Props) {
           icon: BookEditIcon,
         },
         {
-          onClick: handleDeleteOptionClick,
+          onClick: handleUrlRemove,
           text: 'Delete',
           id: 'delete',
           icon: BookmarkRemove01Icon,

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksPanel.tsx
@@ -56,7 +56,8 @@ function BookmarksPanel({ folderId, operation, bmUrl }: BMPanelQueryParams) {
     getItemKey: (idx) => filteredContextBookmarks[idx].id,
   });
 
-  // Memoized: it is a dep of an effect below, which would re-run every render
+  // Memoized: it is a dep of an effect below. React Compiler does not satisfy
+  // the exhaustive-deps lint rule here, which still wants a stable identity.
   const handleScroll = useCallback(
     (itemNumber: number) => virtualizer.scrollToIndex(itemNumber),
     [virtualizer]

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksPanel.tsx
@@ -56,8 +56,7 @@ function BookmarksPanel({ folderId, operation, bmUrl }: BMPanelQueryParams) {
     getItemKey: (idx) => filteredContextBookmarks[idx].id,
   });
 
-  // Memoized: it is a dep of an effect below. React Compiler does not satisfy
-  // the exhaustive-deps lint rule here, which still wants a stable identity.
+  // Memoized: exhaustive-deps wants a stable identity for the effect below
   const handleScroll = useCallback(
     (itemNumber: number) => virtualizer.scrollToIndex(itemNumber),
     [virtualizer]

--- a/apps/extension/src/entrypoints/popup/panels/HomePopup/components/Authenticate.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/HomePopup/components/Authenticate.tsx
@@ -25,7 +25,8 @@ function Authenticate() {
     stopLoading();
   };
 
-  // Memoized: it is a dep of the effect below, which would re-run every render
+  // Memoized: it is a dep of an effect below. React Compiler does not satisfy
+  // the exhaustive-deps lint rule here, which still wants a stable identity.
   const handleSignOut = useCallback(async () => {
     startLoading();
     const isSignedOutSuccess = await signOut();

--- a/apps/extension/src/entrypoints/popup/panels/HomePopup/components/Authenticate.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/HomePopup/components/Authenticate.tsx
@@ -25,8 +25,7 @@ function Authenticate() {
     stopLoading();
   };
 
-  // Memoized: it is a dep of an effect below. React Compiler does not satisfy
-  // the exhaustive-deps lint rule here, which still wants a stable identity.
+  // Memoized: exhaustive-deps wants a stable identity for the effect below
   const handleSignOut = useCallback(async () => {
     startLoading();
     const isSignedOutSuccess = await signOut();

--- a/apps/extension/src/entrypoints/popup/panels/HomePopup/components/OpenDefaultsButton.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/HomePopup/components/OpenDefaultsButton.tsx
@@ -15,11 +15,8 @@ function OpenDefaultsButton() {
   const handleOpenDefaults = async () => {
     setIsFetching(true);
     const redirections = await redirectionsItem.getValue();
-    const defaults = redirections.filter(
-      ({ isDefault }: { isDefault: boolean }) => isDefault
-    );
-    defaults
-      .filter((data) => data?.alias && data.website)
+    redirections
+      .filter(({ isDefault, alias, website }) => isDefault && alias && website)
       .forEach(({ website }) => {
         tabs.open(atob(website));
       });

--- a/apps/extension/src/entrypoints/popup/panels/HomePopup/components/OpenForumLinks/useFeedbackButton.ts
+++ b/apps/extension/src/entrypoints/popup/panels/HomePopup/components/OpenForumLinks/useFeedbackButton.ts
@@ -12,8 +12,6 @@ const SUCCESS_TIMEOUT_MS = 3000;
 const useFeedbackButton = (handler: () => Promise<void>) => {
   const [buttonState, setButtonState] = useState(EButtonState.INITIAL);
 
-  // The cleanup covers both cancelling on a re-click, which moves state to
-  // LOADING, and unmounting, so no ref or manual clearTimeout is needed
   useEffect(() => {
     if (buttonState !== EButtonState.SUCCESS) {
       return noOp;

--- a/apps/extension/src/entrypoints/popup/panels/HomePopup/components/OpenForumLinks/useFeedbackButton.ts
+++ b/apps/extension/src/entrypoints/popup/panels/HomePopup/components/OpenForumLinks/useFeedbackButton.ts
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from 'react';
+import { noOp } from '@bypass/shared';
+import { useEffect, useState } from 'react';
 
 export enum EButtonState {
   INITIAL,
@@ -10,25 +11,21 @@ const SUCCESS_TIMEOUT_MS = 3000;
 
 const useFeedbackButton = (handler: () => Promise<void>) => {
   const [buttonState, setButtonState] = useState(EButtonState.INITIAL);
-  const timeoutRef = useRef<NodeJS.Timeout>(undefined);
 
+  // The cleanup covers both cancelling on a re-click, which moves state to
+  // LOADING, and unmounting, so no ref or manual clearTimeout is needed
   useEffect(() => {
-    if (buttonState === EButtonState.SUCCESS) {
-      timeoutRef.current = setTimeout(
-        () => setButtonState(EButtonState.INITIAL),
-        SUCCESS_TIMEOUT_MS
-      );
+    if (buttonState !== EButtonState.SUCCESS) {
+      return noOp;
     }
+    const timeout = setTimeout(
+      () => setButtonState(EButtonState.INITIAL),
+      SUCCESS_TIMEOUT_MS
+    );
+    return () => clearTimeout(timeout);
   }, [buttonState]);
 
-  useEffect(() => {
-    return () => {
-      clearTimeout(timeoutRef.current);
-    };
-  }, []);
-
   const onClick = async () => {
-    clearTimeout(timeoutRef.current);
     setButtonState(EButtonState.LOADING);
 
     await handler();

--- a/apps/extension/src/entrypoints/popup/panels/HomePopup/utils/sync.ts
+++ b/apps/extension/src/entrypoints/popup/panels/HomePopup/utils/sync.ts
@@ -22,7 +22,7 @@ import {
 } from '../../BookmarksPanel/utils/bookmark';
 import {
   cachePersonImagesInStorage,
-  refreshPersonImageUrlsCache,
+  clearPersonImageUrls,
   resetPersons,
   syncPersonsToStorage,
 } from '../../PersonsPanel/utils/sync';
@@ -59,7 +59,7 @@ const resetStorage = async () => {
     resetBookmarks(),
     resetLastVisited(),
     resetPersons(),
-    refreshPersonImageUrlsCache(),
+    clearPersonImageUrls(),
   ]);
   await invalidateAllKeys();
 };

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/AddOrEditPersonDialog.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/AddOrEditPersonDialog.tsx
@@ -19,7 +19,7 @@ import { HugeiconsIcon } from '@hugeicons/react';
 import { useDisclosure } from '@mantine/hooks';
 import { useForm } from '@tanstack/react-form';
 import { useSelector } from '@tanstack/react-store';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { z } from 'zod/mini';
 
 import { trpcApi } from '@/apis/trpcApi';
@@ -46,6 +46,9 @@ function AddOrEditPersonDialog({
   onClose,
   handleSaveClick,
 }: Props) {
+  // Lazy state, not a call in defaultValues: the id has to survive re-renders
+  // of the open dialog. Both call sites mount this only while open, so there
+  // is no "reopened for a different person" case to reset for.
   const [initialUid] = useState(() => crypto.randomUUID());
   const [isAvatarImageLoading, setIsAvatarImageLoading] = useState(false);
   const [showImagePicker, imagePickerHandlers] = useDisclosure(false);
@@ -80,17 +83,6 @@ function AddOrEditPersonDialog({
     revalidateIfStale: false,
     onSuccess: (image) => setIsAvatarImageLoading(Boolean(image)),
   });
-
-  // Reset the form when the dialog opens for a different person
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-    const defaultValues = person
-      ? { uid: person.uid, name: person.name }
-      : { uid: crypto.randomUUID(), name: '' };
-    form.reset(defaultValues);
-  }, [form, isOpen, person]);
 
   const handleImageCropSave = async (fileName: string) => {
     setIsAvatarImageLoading(true);

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/AddOrEditPersonDialog.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/components/AddOrEditPersonDialog.tsx
@@ -46,9 +46,7 @@ function AddOrEditPersonDialog({
   onClose,
   handleSaveClick,
 }: Props) {
-  // Lazy state, not a call in defaultValues: the id has to survive re-renders
-  // of the open dialog. Both call sites mount this only while open, so there
-  // is no "reopened for a different person" case to reset for.
+  // Lazy state: the id has to survive re-renders of the open dialog
   const [initialUid] = useState(() => crypto.randomUUID());
   const [isAvatarImageLoading, setIsAvatarImageLoading] = useState(false);
   const [showImagePicker, imagePickerHandlers] = useDisclosure(false);

--- a/apps/extension/src/entrypoints/popup/panels/PersonsPanel/utils/sync.ts
+++ b/apps/extension/src/entrypoints/popup/panels/PersonsPanel/utils/sync.ts
@@ -34,7 +34,7 @@ export const resetPersons = async () => {
 const resolveDownloadUrl = async (fileName: string) =>
   trpcApi.storage.getDownloadUrl.query(fileName);
 
-export const refreshPersonImageUrlsCache = async () => {
+export const clearPersonImageUrls = async () => {
   await personImageUrlsItem.removeValue();
 };
 

--- a/apps/web/src/app/bookmark-panel/hooks/usePreloadBookmarks.ts
+++ b/apps/web/src/app/bookmark-panel/hooks/usePreloadBookmarks.ts
@@ -8,7 +8,7 @@ import {
   isCachePresent,
   invalidateBookmarkKeys,
 } from '@bypass/shared';
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 
 import { getFaviconUrl } from '@app/constants/favicon';
 import { useUser } from '@app/provider/AuthProvider';
@@ -45,8 +45,7 @@ const usePreloadBookmarks = () => {
   const { user } = useUser();
   const [isLoading, setIsLoading] = useState(false);
 
-  // Memoized: reaches a dep array via useWebPreload -> web-ext/page.tsx
-  const preloadData = useCallback(async () => {
+  const preloadData = async () => {
     if (!user) {
       return;
     }
@@ -58,7 +57,7 @@ const usePreloadBookmarks = () => {
     } finally {
       setIsLoading(false);
     }
-  }, [user]);
+  };
 
   const clearData = async () => {
     setIsLoading(true);

--- a/apps/web/src/app/components/AppHeader.tsx
+++ b/apps/web/src/app/components/AppHeader.tsx
@@ -5,19 +5,21 @@ import { GithubIcon } from '@hugeicons/core-free-icons';
 import { HugeiconsIcon } from '@hugeicons/react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useRef } from 'react';
 
 import { WEB_ROUTES } from '@app/constants/routes';
 
 function AppHeader() {
   const router = useRouter();
-  const [clickCount, setClickCount] = useState(0);
+  // A ref, not state: the count drives nothing that renders
+  const clickCount = useRef(0);
 
-  useEffect(() => {
-    if (clickCount === 5) {
+  const handleLogoClick = () => {
+    clickCount.current += 1;
+    if (clickCount.current === 5) {
       router.push(WEB_ROUTES.BYPASS_LINKS_WEB);
     }
-  }, [clickCount, router]);
+  };
 
   return (
     <header className="sticky top-0 z-50 border-b-2 border-primary/20 bg-linear-to-r from-primary/5 via-background to-primary/5">
@@ -25,7 +27,7 @@ function AppHeader() {
         <button
           type="button"
           className="group flex items-center gap-3"
-          onClick={() => setClickCount(clickCount + 1)}
+          onClick={handleLogoClick}
         >
           <div className="rounded-lg bg-primary/10 p-1.5 transition-colors group-hover:bg-primary/20">
             <Image

--- a/apps/web/src/app/components/AppHeader.tsx
+++ b/apps/web/src/app/components/AppHeader.tsx
@@ -11,7 +11,6 @@ import { WEB_ROUTES } from '@app/constants/routes';
 
 function AppHeader() {
   const router = useRouter();
-  // A ref, not state: the count drives nothing that renders
   const clickCount = useRef(0);
 
   const handleLogoClick = () => {

--- a/apps/web/src/app/web-ext/hooks/useWebPreload.ts
+++ b/apps/web/src/app/web-ext/hooks/useWebPreload.ts
@@ -1,9 +1,12 @@
+import { useRef } from 'react';
+
 import usePreloadBookmarks from '@app/bookmark-panel/hooks/usePreloadBookmarks';
 import usePreloadPerson from '@app/persons-panel/hooks/usePreloadPerson';
 import { useUser } from '@app/provider/AuthProvider';
 
 const useWebPreload = () => {
   const { isLoginIntialized } = useUser();
+  const inFlight = useRef<Promise<void> | null>(null);
   const {
     isLoading: isLoadingBookmarks,
     preloadData: preloadBookmarksData,
@@ -15,8 +18,23 @@ const useWebPreload = () => {
     clearData: clearPersonData,
   } = usePreloadPerson();
 
+  /**
+   * Idempotent while running, rather than memoized. This identity reaches an
+   * effect dep array in web-ext/page.tsx, but nothing in the chain below is
+   * memoized either, so a useCallback here would be defeated regardless.
+   * Guarding on the in-flight promise makes a repeat call cheap however often
+   * the effect re-runs.
+   */
   const preloadData = async () => {
-    await Promise.all([preloadBookmarksData(), preloadPersonData()]);
+    inFlight.current ??= Promise.all([
+      preloadBookmarksData(),
+      preloadPersonData(),
+    ])
+      .then(() => undefined)
+      .finally(() => {
+        inFlight.current = null;
+      });
+    return inFlight.current;
   };
 
   const clearData = async () => {

--- a/apps/web/src/app/web-ext/hooks/useWebPreload.ts
+++ b/apps/web/src/app/web-ext/hooks/useWebPreload.ts
@@ -1,12 +1,9 @@
-import { useRef } from 'react';
-
 import usePreloadBookmarks from '@app/bookmark-panel/hooks/usePreloadBookmarks';
 import usePreloadPerson from '@app/persons-panel/hooks/usePreloadPerson';
 import { useUser } from '@app/provider/AuthProvider';
 
 const useWebPreload = () => {
   const { isLoginIntialized } = useUser();
-  const inFlight = useRef<Promise<void> | null>(null);
   const {
     isLoading: isLoadingBookmarks,
     preloadData: preloadBookmarksData,
@@ -18,23 +15,8 @@ const useWebPreload = () => {
     clearData: clearPersonData,
   } = usePreloadPerson();
 
-  /**
-   * Idempotent while running, rather than memoized. This identity reaches an
-   * effect dep array in web-ext/page.tsx, but nothing in the chain below is
-   * memoized either, so a useCallback here would be defeated regardless.
-   * Guarding on the in-flight promise makes a repeat call cheap however often
-   * the effect re-runs.
-   */
   const preloadData = async () => {
-    inFlight.current ??= Promise.all([
-      preloadBookmarksData(),
-      preloadPersonData(),
-    ])
-      .then(() => undefined)
-      .finally(() => {
-        inFlight.current = null;
-      });
-    return inFlight.current;
+    await Promise.all([preloadBookmarksData(), preloadPersonData()]);
   };
 
   const clearData = async () => {

--- a/packages/shared/src/components/Bookmarks/hooks/useBookmark.ts
+++ b/packages/shared/src/components/Bookmarks/hooks/useBookmark.ts
@@ -1,4 +1,4 @@
-import { use, useCallback } from 'react';
+import { use } from 'react';
 
 import { STORAGE_KEYS } from '../../../constants/storage';
 import DynamicContext from '../../../provider/DynamicContext';
@@ -8,23 +8,19 @@ import { getDecryptedFolder, getDefaultFolder } from '../utils';
 
 const useBookmark = () => {
   const { storage } = use(DynamicContext);
-  const getBookmarks = useCallback(
-    async () => storage.get<IBookmarksObj>(STORAGE_KEYS.bookmarks),
-    [storage]
-  );
 
-  const getFolderFromHash = useCallback(
-    async (hash: string) => {
-      const bookmarks = await getBookmarks();
-      if (!bookmarks) {
-        throw new Error('No bookmarks found for getFolderFromHash');
-      }
-      return getDecryptedFolder(bookmarks.folderList[hash]);
-    },
-    [getBookmarks]
-  );
+  const getBookmarks = async () =>
+    storage.get<IBookmarksObj>(STORAGE_KEYS.bookmarks);
 
-  const getDefaultOrRootFolderUrls = useCallback(async () => {
+  const getFolderFromHash = async (hash: string) => {
+    const bookmarks = await getBookmarks();
+    if (!bookmarks) {
+      throw new Error('No bookmarks found for getFolderFromHash');
+    }
+    return getDecryptedFolder(bookmarks.folderList[hash]);
+  };
+
+  const getDefaultOrRootFolderUrls = async () => {
     const bookmarks = await getBookmarks();
     if (!bookmarks) {
       throw new Error('No bookmarks found for getDefaultOrRootFolderUrls');
@@ -33,10 +29,10 @@ const useBookmark = () => {
     const defaultFolder = getDefaultFolder(folderList);
     const parentHash = defaultFolder?.id ?? ROOT_FOLDER_ID;
 
-    return Object.values(bookmarks.folders[parentHash])
+    return Object.values(bookmarks.folders[parentHash] ?? [])
       .filter((bookmark) => !bookmark.isDir)
       .map((urlData) => bookmarks.urlList[urlData.hash]);
-  }, [getBookmarks]);
+  };
 
   return {
     getFolderFromHash,

--- a/packages/shared/src/components/Persons/components/Persons.tsx
+++ b/packages/shared/src/components/Persons/components/Persons.tsx
@@ -1,7 +1,7 @@
 import { ScrollArea } from '@bypass/ui';
 import { useElementSize } from '@mantine/hooks';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { type ReactNode, useCallback, useState } from 'react';
+import { type ReactNode, useState } from 'react';
 
 import useIsMobile from '../../../hooks/useIsMobile';
 import { deserializeQueryStringToObject } from '../../../utils/url';
@@ -111,9 +111,6 @@ function Persons(props: Props) {
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(
     null
   );
-  const handleViewportRef = useCallback((node: HTMLDivElement | null) => {
-    setScrollElement(node);
-  }, []);
   const { openBookmarksList } = deserializeQueryStringToObject(
     props.queryString
   );
@@ -125,7 +122,7 @@ function Persons(props: Props) {
   return (
     <ScrollArea
       ref={containerRef}
-      viewportRef={handleViewportRef}
+      viewportRef={setScrollElement}
       className="size-full"
     >
       {bodyWidth > 0 && (

--- a/packages/shared/src/components/Persons/hooks/usePerson.ts
+++ b/packages/shared/src/components/Persons/hooks/usePerson.ts
@@ -1,4 +1,4 @@
-import { use, useCallback } from 'react';
+import { use } from 'react';
 
 import { ECacheBucketKeys } from '../../../constants/cache';
 import { STORAGE_KEYS } from '../../../constants/storage';
@@ -19,99 +19,88 @@ import { decodePersons } from '../utils';
 
 const usePerson = () => {
   const { storage } = use(DynamicContext);
-  const getBookmarks = useCallback(
-    async () => storage.get<IBookmarksObj>(STORAGE_KEYS.bookmarks),
-    [storage]
-  );
-  const getPersons = useCallback(
-    async () => storage.get<IPersons>(STORAGE_KEYS.persons),
-    [storage]
-  );
-  const getPersonImageUrls = useCallback(
-    async () => storage.get<PersonImageUrls>(STORAGE_KEYS.personImageUrls),
-    [storage]
-  );
 
-  const getAllDecodedPersons = useCallback(async () => {
+  const getBookmarks = async () =>
+    storage.get<IBookmarksObj>(STORAGE_KEYS.bookmarks);
+
+  const getPersons = async () => storage.get<IPersons>(STORAGE_KEYS.persons);
+
+  const getPersonImageUrls = async () =>
+    storage.get<PersonImageUrls>(STORAGE_KEYS.personImageUrls);
+
+  const getAllDecodedPersons = async () => {
     const persons = await getPersons();
-    if (!persons) return [];
+    if (!persons) {
+      return [];
+    }
     return decodePersons(persons);
-  }, [getPersons]);
+  };
 
-  const resolvePersonImageFromUid = useCallback(
-    async (uid: string) => {
-      const personImages = await getPersonImageUrls();
-      if (!personImages) {
-        return '';
-      }
-      const imageUrl = personImages[uid];
-      return getBlobUrlFromCache(ECacheBucketKeys.person, imageUrl);
-    },
-    [getPersonImageUrls]
-  );
+  const resolvePersonImageFromUid = async (uid: string) => {
+    const personImages = await getPersonImageUrls();
+    if (!personImages) {
+      return '';
+    }
+    return getBlobUrlFromCache(ECacheBucketKeys.person, personImages[uid]);
+  };
 
   // One storage read and one bucket open for a whole grid
-  const getPersonImageMap = useCallback(
-    async (uids: string[]): Promise<Record<string, string>> => {
-      const personImages = await getPersonImageUrls();
-      if (!personImages) {
-        return {};
-      }
-      const cache = await getCacheObj(ECacheBucketKeys.person);
-      const entries = await Promise.all(
-        uids.map(
-          async (uid) =>
-            [
-              uid,
-              await getBlobUrlFromOpenCache(cache, personImages[uid]),
-            ] as const
-        )
-      );
-      return Object.fromEntries(entries);
-    },
-    [getPersonImageUrls]
-  );
+  const getPersonImageMap = async (
+    uids: string[]
+  ): Promise<Record<string, string>> => {
+    const personImages = await getPersonImageUrls();
+    if (!personImages) {
+      return {};
+    }
+    const cache = await getCacheObj(ECacheBucketKeys.person);
+    const entries = await Promise.all(
+      uids.map(
+        async (uid) =>
+          [
+            uid,
+            await getBlobUrlFromOpenCache(cache, personImages[uid]),
+          ] as const
+      )
+    );
+    return Object.fromEntries(entries);
+  };
 
-  const getPersonsWithImageUrl = useCallback(
-    async (persons: IPerson[]): Promise<IPersonWithImage[]> => {
-      if (!persons?.length) {
-        return [];
-      }
-      const personImages = await getPersonImageUrls();
-      if (!personImages) {
-        return persons.map((person) => ({ ...person, imageUrl: '' }));
-      }
-      // Open the bucket once for the whole list
-      const cache = await getCacheObj(ECacheBucketKeys.person);
-      return Promise.all(
-        persons.map(async (person) => ({
-          ...person,
-          imageUrl: await getBlobUrlFromOpenCache(
-            cache,
-            personImages[person.uid]
-          ),
-        }))
-      );
-    },
-    [getPersonImageUrls]
-  );
+  const getPersonsWithImageUrl = async (
+    persons: IPerson[]
+  ): Promise<IPersonWithImage[]> => {
+    if (!persons?.length) {
+      return [];
+    }
+    const personImages = await getPersonImageUrls();
+    if (!personImages) {
+      return persons.map((person) => ({ ...person, imageUrl: '' }));
+    }
+    // Open the bucket once for the whole list
+    const cache = await getCacheObj(ECacheBucketKeys.person);
+    return Promise.all(
+      persons.map(async (person) => ({
+        ...person,
+        imageUrl: await getBlobUrlFromOpenCache(
+          cache,
+          personImages[person.uid]
+        ),
+      }))
+    );
+  };
 
-  const getPersonTaggedUrls = useCallback(
-    async (personId: string) => {
-      const bookmarks = await getBookmarks();
-      if (!bookmarks?.urlList) {
-        return [];
+  const getPersonTaggedUrls = async (personId: string) => {
+    const bookmarks = await getBookmarks();
+    if (!bookmarks?.urlList) {
+      return [];
+    }
+    const taggedUrls = [];
+    for (const [bmId, bookmark] of Object.entries(bookmarks.urlList)) {
+      if (bookmark.taggedPersons.includes(personId)) {
+        taggedUrls.push(bmId);
       }
-      const taggedUrls = [];
-      for (const [bmId, bookmark] of Object.entries(bookmarks.urlList)) {
-        if (bookmark.taggedPersons.includes(personId)) {
-          taggedUrls.push(bmId);
-        }
-      }
-      return taggedUrls;
-    },
-    [getBookmarks]
-  );
+    }
+    return taggedUrls;
+  };
 
   return {
     getAllDecodedPersons,

--- a/packages/shared/src/components/Persons/hooks/useTaggedBookmarks.ts
+++ b/packages/shared/src/components/Persons/hooks/useTaggedBookmarks.ts
@@ -25,9 +25,9 @@ const useTaggedBookmarks = (personUid = '') => {
     }
     const { urlList, folderList, folders } = bookmarks;
 
-    const fetchedBookmarks = Object.entries(urlList)
-      .filter(([, bookmark]) => bookmark.taggedPersons.includes(personUid))
-      .map(([, bookmark]) => {
+    const fetchedBookmarks = Object.values(urlList)
+      .filter((bookmark) => bookmark.taggedPersons.includes(personUid))
+      .map((bookmark) => {
         const parent = getDecryptedFolder(folderList[bookmark.parentHash]);
         return Object.assign(getDecryptedBookmark(bookmark), {
           parentName: parent.name,


### PR DESCRIPTION
Mechanical cleanups. No behaviour changes intended.

- **`AddOrEditPersonDialog`** drops the reset effect — both call sites mount the dialog only while open, so the "reopened for a different person" case it guarded cannot happen. The lazy uid state **stays**: the id has to survive re-renders of the open dialog, and calling `crypto.randomUUID()` inline in `defaultValues` would lean on undocumented `useForm` behaviour.
- **`BookmarkAddEditDialog`** uses two `form.reset` calls instead of twelve `setFieldValue` calls, matching the sibling dialog.
- **`setExtensionIcon`** takes its three params as required. Its only caller always passes all three, from items with non-undefined fallbacks, so the storage read in the else branch was unreachable. Dead export `isValidTabUrl` removed (zero callers).
- **`useFeedbackButton`** uses one effect with a cleanup instead of a ref, a second unmount effect, and a manual `clearTimeout`. The cleanup already fires when state leaves SUCCESS and on unmount.
- **`AppHeader`** counts logo clicks in a ref, since the count drives nothing that renders, replacing state plus a navigation effect.
- Smaller: `OpenDefaultsButton` filters once instead of twice; `useTaggedBookmarks` uses `Object.values`; `BookmarkContextMenu` drops the duplicate `children` in `PropsWithChildren` and an identity wrapper around `handleUrlRemove`; `refreshPersonImageUrlsCache` becomes `clearPersonImageUrls`, which is what it does.
- `getDefaultOrRootFolderUrls` guards its folders lookup, which throws today on a missing parent hash.

## React Compiler cleanup — partial, and this is worth knowing

The `useCallback` wrappers in `usePerson` (7), `useBookmark` (3), `Persons` and `usePreloadBookmarks` are gone.

The two in `BookmarksPanel` and `Authenticate` are **kept**. Both are effect dependencies, and the `react-hooks/exhaustive-deps` rule this repo runs at `error` still demands a stable identity there regardless of React Compiler — removing them fails lint. The original "Memoized: it is a dep of an effect below" comments were correct; they now say why the compiler does not change that.

Same reason `AuthProvider`s context-value `useMemo` stays: `react/jsx-no-constructed-context-values` requires it.

## Not included

The progress-step refactor (`SIGN_IN_TOTAL_STEPS`) is deferred. The two consecutive `incrementProgress` calls are load-bearing — the sign-in path has exactly 7 increments matching the constant, so collapsing one strands the bar below 100%. It needs the declarative step-list rewrite to be done safely, which is a larger change than this batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

 

<details><summary><h3>Greptile Summary</h3></summary>

This PR performs behavior-preserving control-flow and React hook cleanup across the extension, web app, and shared components.
- Simplifies dialog resets, timeout cleanup, click tracking, filtering, and cache helper naming.
- Removes unnecessary callback wrappers while retaining callbacks required by effect dependencies.
- Adds a safe fallback when the default or root bookmark folder is absent.
- Deduplicates repeated web preload invocations at the orchestration boundary.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported preload issue is addressed by an in-flight promise guard and the page’s one-shot preload state.
</details>

<sub>Reviews (5): Last reviewed commit: ["docs: trim comments to the constraints t..."](https://github.com/amitsingh-007/bypass-links/commit/c949ccb176510fe839a70c5c42ea5f2275bee67b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51437750)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Extension Popup UI](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/extension-popup.md)
- Knowledge Base — [Web App (apps/web)](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/web-app.md)
- Knowledge Base — [Shared package (`packages/shared`)](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/shared-package.md)
</details>

<!-- /greptile_comment -->