### PR TITLE
fix: extension popup width, stale release cache, popup error, and flaky e2e

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,11 +173,26 @@ jobs:
   Create_Release:
     runs-on: ubuntu-latest
     needs: [Deploy]
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setting up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
 
       - name: Download extension
         uses: actions/download-artifact@v8
@@ -202,3 +217,9 @@ jobs:
           generate_release_notes: true
           files: |
             ./apps/extension/.output/chrome-*.zip
+
+      - name: Purge Vercel Cache
+        run: |
+          pnpm vercel cache dangerously-delete \
+            --tag extensions-release-cache \
+            --yes --token=${{ secrets.VERCEL_TOKEN }}

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bypass/extension",
-  "version": "25.6.0",
+  "version": "25.7.0",
   "private": true,
   "description": "Bypass links from various sites to required links, with added functionality of Bookmarks Manager, Tagging Panel.",
   "type": "module",

--- a/apps/extension/src/entrypoints/popup/layout.css
+++ b/apps/extension/src/entrypoints/popup/layout.css
@@ -1,5 +1,6 @@
-/* Centres the panel when popup.html is opened as a tab; a no-op in the content-sized popup. */
-#root {
+/* An auto-width root stretches to the popup's current width, so the popup never
+   shrank back after closing a panel. Centres the tab view too. */
+html {
   width: fit-content;
   margin-inline: auto;
 }

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksPanel.tsx
@@ -63,8 +63,10 @@ function BookmarksPanel({ folderId, operation, bmUrl }: BMPanelQueryParams) {
   );
 
   const handleOpenSelectedBookmarks = () => {
-    contextBookmarks.forEach((bookmark, index) => {
-      if (selectedBookmarks[index] && !bookmark.isDir) {
+    const { contextBookmarks: bookmarks, selectedBookmarks: selected } =
+      useBookmarkStore.getState();
+    bookmarks.forEach((bookmark, index) => {
+      if (selected[index] && !bookmark.isDir) {
         tabs.open(bookmark.url);
       }
     });

--- a/apps/extension/tests/fixtures/background-fixture.ts
+++ b/apps/extension/tests/fixtures/background-fixture.ts
@@ -21,7 +21,10 @@ interface BaseBackgroundEnv {
   ensureInactiveState: () => Promise<void>;
   clearHistoryStartTime: () => Promise<void>;
   setHistoryStartTime: (value: number) => Promise<void>;
+  /** For URLs that may never load: shortcuts awaiting redirect, restricted, invalid. */
   openTab: (url: string) => Promise<Page>;
+  /** For real pages, where returning mid-navigation lets a later reload race the load. */
+  openLoadedTab: (url: string) => Promise<Page>;
 }
 
 const readStorageFromWorker = async <T = unknown>(
@@ -106,6 +109,15 @@ const createBackgroundEnv = async (
       await page
         .goto(url, { waitUntil: 'commit', timeout: TEST_TIMEOUTS.NAVIGATION })
         .catch(() => undefined);
+      return page;
+    },
+    async openLoadedTab(url: string) {
+      const page = await context.newPage();
+      // Failures surface here rather than as a puzzling assertion on about:blank
+      await page.goto(url, {
+        waitUntil: 'domcontentloaded',
+        timeout: TEST_TIMEOUTS.PAGE_OPEN,
+      });
       return page;
     },
   };

--- a/apps/extension/tests/specs/background-navigation.spec.ts
+++ b/apps/extension/tests/specs/background-navigation.spec.ts
@@ -1,4 +1,4 @@
-import { TEST_SHORTCUTS } from '@bypass/shared/tests';
+import { TEST_SHORTCUTS, TEST_SITES } from '@bypass/shared/tests';
 import type { Page } from '@playwright/test';
 
 import { EExtStorageKey } from '@/constants';
@@ -68,6 +68,8 @@ test.describe.serial('Background Service Worker Navigation', () => {
     try {
       await expect.poll(() => page.url()).toContain('https://html5test.com');
 
+      // Reloading mid-navigation detaches the page target
+      await page.waitForLoadState('domcontentloaded');
       await page.reload({ waitUntil: 'domcontentloaded' });
 
       await expect.poll(() => page.url()).toContain('https://html5test.com');
@@ -89,14 +91,14 @@ test.describe.serial('Background Service Worker Navigation', () => {
     }
   });
 
-  test('navigating to WIKIPEDIA applies autocomplete=off to page inputs', async ({
+  test('navigating to TODOMVC applies autocomplete=off to page inputs', async ({
     sharedBackground,
   }) => {
     await sharedBackground.ensureActiveState();
 
-    const page = await sharedBackground.openTab(TEST_SHORTCUTS.WIKIPEDIA);
+    const page = await sharedBackground.openTab(TEST_SHORTCUTS.TODOMVC);
     try {
-      await expect.poll(() => page.url()).toContain('wikipedia.org');
+      await expect.poll(() => page.url()).toContain(TEST_SITES.TODOMVC);
 
       await expect.poll(async () => allInputsAutocompleteOff(page)).toBe(true);
     } finally {
@@ -104,14 +106,17 @@ test.describe.serial('Background Service Worker Navigation', () => {
     }
   });
 
-  test('reloading WIKIPEDIA still applies autocomplete suppression', async ({
+  test('reloading TODOMVC still applies autocomplete suppression', async ({
     sharedBackground,
   }) => {
     await sharedBackground.ensureActiveState();
 
-    const page = await sharedBackground.openTab(TEST_SHORTCUTS.WIKIPEDIA);
+    const page = await sharedBackground.openTab(TEST_SHORTCUTS.TODOMVC);
     try {
-      await expect.poll(() => page.url()).toContain('wikipedia.org');
+      await expect.poll(() => page.url()).toContain(TEST_SITES.TODOMVC);
+
+      // Reloading mid-navigation detaches the page target
+      await page.waitForLoadState('domcontentloaded');
       await page.reload({ waitUntil: 'domcontentloaded' });
 
       await expect.poll(async () => allInputsAutocompleteOff(page)).toBe(true);
@@ -147,9 +152,9 @@ test.describe.serial('Background Service Worker Navigation', () => {
     await sharedBackground.ensureActiveState();
     await sharedBackground.clearHistoryStartTime();
 
-    const page = await sharedBackground.openTab('https://example.com');
+    const page = await sharedBackground.openLoadedTab(TEST_SITES.EXAMPLE_COM);
     try {
-      await expect.poll(() => page.url()).toContain('https://example.com');
+      expect(page.url()).toContain(TEST_SITES.EXAMPLE_COM);
 
       const historyStartTime = await sharedBackground.readStorage<number>(
         EExtStorageKey.HISTORY_START_TIME
@@ -207,14 +212,14 @@ test.describe.serial('Background Service Worker Navigation', () => {
     await sharedBackground.ensureActiveState();
     await sharedBackground.clearHistoryStartTime();
 
-    const page = await sharedBackground.openTab('https://example.com');
+    const page = await sharedBackground.openLoadedTab(TEST_SITES.EXAMPLE_COM);
     try {
       const inputCount = await page.evaluate(() => {
         return document.querySelectorAll('input').length;
       });
       expect(inputCount).toBe(0);
 
-      await expect.poll(() => page.url()).toContain('https://example.com');
+      expect(page.url()).toContain(TEST_SITES.EXAMPLE_COM);
 
       const historyStartTime = await sharedBackground.readStorage<number>(
         EExtStorageKey.HISTORY_START_TIME

--- a/apps/extension/tests/specs/bookmarks.spec.ts
+++ b/apps/extension/tests/specs/bookmarks.spec.ts
@@ -187,36 +187,10 @@ test.describe('Bookmarks Panel', () => {
         await openOption.click();
       };
 
-      let contextMenuPage;
-      const pagesBefore = new Set(context.pages());
-      for (let attempt = 0; attempt < 2; attempt++) {
-        try {
-          contextMenuPage = await openNewPageFromAction(
-            context,
-            openFromContextMenu,
-            {
-              timeout: 10_000,
-            }
-          );
-          break;
-        } catch (error) {
-          if (attempt === 1) {
-            throw error;
-          }
-
-          const leakedPages = context
-            .pages()
-            .filter((page) => !pagesBefore.has(page));
-          await Promise.all(
-            leakedPages.map(async (page) => page.close().catch(() => undefined))
-          );
-        }
-      }
-
-      if (!contextMenuPage) {
-        throw new Error('Expected context menu action to open a new page');
-      }
-
+      const contextMenuPage = await openNewPageFromAction(
+        context,
+        openFromContextMenu
+      );
       await contextMenuPage.close();
     });
 

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -39,7 +39,10 @@ export default defineConfig({
         }),
         tailwindcss(),
       ],
-      build: { target: 'esnext' },
+      build: {
+        target: 'esnext',
+        modulePreload: false,
+      },
       resolve: {
         tsconfigPaths: true,
       },

--- a/apps/web/src/app/page.utils.ts
+++ b/apps/web/src/app/page.utils.ts
@@ -2,10 +2,12 @@ import { getLatestExtension } from '@bypass/trpc/edge';
 import { cacheLife, cacheTag } from 'next/cache';
 import 'server-only';
 
+const ONE_MONTH_IN_SEC = 30 * 24 * 60 * 60;
+
 export const fetchExtensionData = async () => {
   'use cache';
   cacheTag('extensions-release-cache');
-  cacheLife({ revalidate: 60 });
+  cacheLife({ revalidate: ONE_MONTH_IN_SEC, expire: ONE_MONTH_IN_SEC });
 
   return getLatestExtension();
 };

--- a/packages/shared/src/constants/e2e-tests.ts
+++ b/packages/shared/src/constants/e2e-tests.ts
@@ -40,17 +40,21 @@ export const TEST_SHORTCUTS = {
   TWITCH: 'http://t/',
   YOUTUBE: 'http://y/',
   // Rules for background tests
-  WIKIPEDIA: 'http://hah/',
+  TODOMVC: 'http://hah/',
   BROWSERTEST: 'http://bt/',
 } as const;
 
 /**
- * Test websites for history tracking tests
+ * Real websites navigated to by E2E specs.
+ * TODOMVC is where TEST_SHORTCUTS.TODOMVC redirects. It renders its input via
+ * JS, so it covers the MutationObserver branch of the autocomplete suppression
+ * script.
  */
 export const TEST_SITES = {
   EXAMPLE_COM: 'https://example.com',
   EXAMPLE_ORG: 'https://example.org',
   EXAMPLE_NET: 'https://example.net',
+  TODOMVC: 'https://demo.playwright.dev/todomvc',
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

Batch of bug fixes for the extension and web download page:

- **Extension popup width** — shrink the extension popup back down after closing a panel, so it no longer stays stretched. Fixes #4153
- **Stale extension version on download page** — purge the extension release cache on publish instead of serving a stale version/download link until refresh. Fixes #4134
- **Error on opening extension popup** — disable module preload in the extension build, which was causing an error whenever the popup opened. Fixes #4152
- **Flaky e2e test** — stop the background-navigation reload test from flaking. Fixes #4133

## Verification

- `pnpm lint`, `pnpm format:check`, `pnpm typecheck:all`
- Playwright e2e for the affected specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

 

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not yet safe to merge because the release job still executes a mutable third-party action before authenticated release operations.

The current workflow leaves `pnpm/action-setup@v6` unpinned, allowing a repointed tag to execute unreviewed code in a job that later receives GitHub and Vercel credentials.

**Files Needing Attention:** .github/workflows/release.yml
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(extension): stop &#39;open bookmark via ..."](https://github.com/amitsingh-007/bypass-links/commit/534fe970ec81713c4d118177d94bc9b79695e3a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51568801)</sub>

**Context used:**

- Knowledge Base — [Extension Popup UI](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/extension-popup.md)
- Knowledge Base — [Web App (apps/web)](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/web-app.md)

<!-- /greptile_comment -->