### PR TITLE
fix(extension): stop bookmarks panel crashing on back navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Playwright tests use setup/teardown projects for both web and extension flows:
 - Use workspace protocol (`workspace:*`) for internal dependencies
 - Shared types and utilities go in `packages/shared`
 - tRPC procedures are defined in `packages/trpc`
-- Add comments only when needed, and keep them short. Explain the reasoning (the "why"), not what the code does. Only elaborate for edge cases or logic that is tricky or hard to follow.
+- **CRITICAL — Minimize comments. This is non-negotiable.** Do NOT add comments by default. Add a comment ONLY when it is absolutely necessary AND conveys meaningful information that the code itself cannot express. When a comment is truly justified, keep it concise and short — explain the reasoning (the "why"), never what the code does. Elaborate ONLY for edge cases or genuinely tricky, hard-to-follow logic. If in doubt, leave the comment out.
 
 ## shadcn/ui Components
 
@@ -127,5 +127,10 @@ Always after making changes, run the following commands:
 pnpm lint
 pnpm format:check
 pnpm typecheck:all
+```
+
+Optionally, run E2E tests only when the user explicitly asks, or when the changes affect behavior covered by E2E tests:
+
+```bash
 pnpm e2e <relative-filepath>
 ```

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bypass/extension",
-  "version": "25.7.0",
+  "version": "25.8.0",
   "private": true,
   "description": "Bypass links from various sites to required links, with added functionality of Bookmarks Manager, Tagging Panel.",
   "type": "module",

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksPanel.tsx
@@ -80,7 +80,9 @@ function BookmarksPanel({ folderId, operation, bmUrl }: BMPanelQueryParams) {
   }, [isFetching, handleScroll]);
 
   useEffect(() => {
-    loadData(folderId);
+    if (folderId) {
+      loadData(folderId);
+    }
   }, [folderId, loadData]);
 
   useEffect(() => {

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/store/useBookmarkStore.ts
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/store/useBookmarkStore.ts
@@ -65,7 +65,7 @@ const useBookmarkStore = create<State>()((set, get) => ({
     set({ isSaveButtonActive: false, isFetching: true });
     const { folders, urlList, folderList } = await bookmarksItem.getValue();
 
-    const modifiedBookmarks = folders[folderId].map((meta) =>
+    const modifiedBookmarks = (folders[folderId] ?? []).map((meta) =>
       bookmarksMapper(meta, urlList, folderList)
     );
 

--- a/apps/extension/tests/specs/bookmarks.spec.ts
+++ b/apps/extension/tests/specs/bookmarks.spec.ts
@@ -447,11 +447,15 @@ test.describe('Bookmarks Panel', () => {
     const onPageError = (error: Error) => pageErrors.push(error.message);
     bookmarksPage.on('pageerror', onPageError);
 
-    await panel.navigateBack();
-    await expect(bookmarksPage.getByTestId('home-popup-heading')).toBeVisible();
-
-    bookmarksPage.off('pageerror', onPageError);
-    expect(pageErrors).toEqual([]);
+    try {
+      await panel.navigateBack();
+      await expect(
+        bookmarksPage.getByTestId('home-popup-heading')
+      ).toBeVisible();
+      expect(pageErrors).toEqual([]);
+    } finally {
+      bookmarksPage.off('pageerror', onPageError);
+    }
 
     await panel.ensureAtRoot();
   });

--- a/apps/extension/tests/specs/bookmarks.spec.ts
+++ b/apps/extension/tests/specs/bookmarks.spec.ts
@@ -436,4 +436,23 @@ test.describe('Bookmarks Panel', () => {
 
     await expect(bookmarksPage.getByText('Saved temporarily')).toBeVisible();
   });
+
+  test('should not throw when navigating back out of the panel', async ({
+    bookmarksPage,
+  }) => {
+    const panel = new BookmarksPanel(bookmarksPage);
+    await panel.ensureAtRoot();
+
+    const pageErrors: string[] = [];
+    const onPageError = (error: Error) => pageErrors.push(error.message);
+    bookmarksPage.on('pageerror', onPageError);
+
+    await panel.navigateBack();
+    await expect(bookmarksPage.getByTestId('home-popup-heading')).toBeVisible();
+
+    bookmarksPage.off('pageerror', onPageError);
+    expect(pageErrors).toEqual([]);
+
+    await panel.ensureAtRoot();
+  });
 });


### PR DESCRIPTION
#### Check if the Pull Request fulfils these requirements

- [x] Does the extension require a version change?

<!-- greptile_comment -->

 

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR does not yet appear safe to merge because stale or deleted folder IDs can still become editable state and be persisted as phantom folders.

The back-navigation crash is addressed, but the fallback for a missing non-empty folder ID still presents an editable empty folder, and the save path can write that unknown ID into persisted folder state.

**Files Needing Attention:** apps/extension/src/entrypoints/popup/panels/BookmarksPanel/store/useBookmarkStore.ts
</details>

<sub>Reviews (2): Last reviewed commit: ["test(extension): detach pageerror listen..."](https://github.com/amitsingh-007/bypass-links/commit/92967e926046dbb7cecf41199c0810aaf786bd97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51580234)</sub>

**Context used:**

- Knowledge Base — [Extension Popup UI](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/extension-popup.md)

<!-- /greptile_comment -->