### PR TITLE
fix(ci): stop deployment bookkeeping failing the deploy job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,6 +175,10 @@ jobs:
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
           env_url: ${{ steps.vercel-action.outputs.preview-url }}
           env: ${{ steps.deployment.outputs.env }}
+          # Defaults to true on finish, which walks every existing deployment of
+          # the environment and writes a status to each. That hit GitHub's
+          # secondary rate limit and failed the job, skipping Create_Release.
+          override: false
 
   Create_Release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### Check if the Pull Request fulfils these requirements

- [ ] Does the extension require a version change?

<!-- greptile_comment -->

 

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code failure identified.

The new action input narrowly disables environment-wide deployment status overrides, and the workflow continues to pass the current deployment ID and job status to the finish step.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): stop deployment bookkeeping fai..."](https://github.com/amitsingh-007/bypass-links/commit/8d677d4cd2fc2283224863d0f9b07f63b300ef64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53001684)</sub>

<!-- /greptile_comment -->