### PR TITLE
test: cover cross-panel bookmark edit, folder validation and grid wrapping

### DIFF
--- a/apps/extension/tests/specs/bookmark-editing.spec.ts
+++ b/apps/extension/tests/specs/bookmark-editing.spec.ts
@@ -113,4 +113,17 @@ test.describe('Bookmark form validation', () => {
     await expect(dialog.getByText('Invalid URL format')).toBeVisible();
     await expect(dialog).toBeVisible();
   });
+
+  test('refuses to create a folder without a name', async ({
+    bookmarksPage,
+  }) => {
+    const panel = new BookmarksPanel(bookmarksPage);
+    await panel.ensureAtRoot();
+
+    const dialog = await panel.openAddFolderDialog();
+    await dialog.getByTestId('dialog-save-button').click();
+
+    await expect(dialog.getByText('Required')).toBeVisible();
+    await expect(dialog).toBeVisible();
+  });
 });

--- a/apps/extension/tests/specs/persons-interactions.spec.ts
+++ b/apps/extension/tests/specs/persons-interactions.spec.ts
@@ -1,0 +1,24 @@
+import { TEST_PERSONS } from '@bypass/shared/tests';
+
+import { expect, test } from '../fixtures/persons-fixture';
+import { BookmarksPanel } from '../utils/bookmarks-panel';
+import { PersonsPanel } from '../utils/persons-panel';
+
+// This test leaves the popup on the bookmarks panel, which the worker-scoped
+// page would otherwise carry into whatever runs next
+test.afterEach(async ({ personsPage }) => {
+  await new PersonsPanel(personsPage).ensureAtRoot();
+});
+
+test('opens the bookmarks panel to edit a tagged bookmark', async ({
+  personsPage,
+}) => {
+  const panel = new PersonsPanel(personsPage);
+  await panel.openPersonCard(TEST_PERSONS.JOHN_NATHAN);
+
+  const editButtons = await panel.getEditButtons();
+  await editButtons.first().click();
+
+  await expect(new BookmarksPanel(personsPage).getUrlInput()).toBeVisible();
+  await expect(personsPage).toHaveURL(/operation=edit/);
+});

--- a/apps/web/tests/specs/persons.spec.ts
+++ b/apps/web/tests/specs/persons.spec.ts
@@ -220,6 +220,14 @@ test.describe('Persons Panel', () => {
       return new Set(offsets).size;
     };
 
+    // Wrapping is only observable with more persons than the narrow column
+    // count, so say so here rather than failing later on a puzzling row compare
+    const panel = new PersonsPanel(authenticatedPage);
+    expect(
+      await panel.getPersonCount(),
+      'the grid needs more than three persons to wrap on a narrow viewport'
+    ).toBeGreaterThan(3);
+
     // Polled, not read once: the grid only lays out after its width is measured
     await expect.poll(countRenderedRows).toBeGreaterThan(0);
     const wideRows = await countRenderedRows();

--- a/apps/web/tests/specs/persons.spec.ts
+++ b/apps/web/tests/specs/persons.spec.ts
@@ -202,4 +202,28 @@ test.describe('Persons Panel', () => {
     await panel.verifyEditButtonsHidden();
     await panel.closeModal();
   });
+  /**
+   * `test.use({ viewport })` cannot drive this: the auth fixture supplies its
+   * own persistent context, so Playwright's viewport option is ignored and the
+   * page would stay wide. Resizing the page itself is what crosses the
+   * breakpoint, dropping the grid from five columns to three.
+   */
+  test('should wrap the grid onto a second row on a narrow viewport', async ({
+    authenticatedPage,
+  }) => {
+    const countRenderedRows = async () => {
+      const offsets = await authenticatedPage
+        .locator('[data-testid^="person-item-"]')
+        .evaluateAll((cards) =>
+          cards.map((card) => Math.round(card.getBoundingClientRect().y))
+        );
+      return new Set(offsets).size;
+    };
+
+    expect(await countRenderedRows()).toBe(1);
+
+    await authenticatedPage.setViewportSize({ width: 700, height: 900 });
+
+    await expect.poll(countRenderedRows).toBe(2);
+  });
 });

--- a/apps/web/tests/specs/persons.spec.ts
+++ b/apps/web/tests/specs/persons.spec.ts
@@ -220,10 +220,13 @@ test.describe('Persons Panel', () => {
       return new Set(offsets).size;
     };
 
-    expect(await countRenderedRows()).toBe(1);
+    // Polled, not read once: the grid only lays out after its width is measured
+    await expect.poll(countRenderedRows).toBeGreaterThan(0);
+    const wideRows = await countRenderedRows();
 
     await authenticatedPage.setViewportSize({ width: 700, height: 900 });
 
-    await expect.poll(countRenderedRows).toBe(2);
+    // Relative, so the assertion survives the account gaining or losing a person
+    await expect.poll(countRenderedRows).toBeGreaterThan(wideRows);
   });
 });


### PR DESCRIPTION
Stacked on #4165.

## Why

Interactions the suite asserted the *existence* of but never performed.

- `persons.spec.ts` asserted the edit-bookmark buttons render but never clicked one, so the cross-panel jump from a tagged bookmark into the bookmark edit dialog had never run.
- The folder dialog's empty-name branch had never rendered.
- The persons grid's mobile column count had never been reached.

## The viewport test needed a real fix, not a declaration

`test.use({ viewport })` **does not work in this suite**. The web `auth-fixture` supplies its own `chromium.launchPersistentContext`, and Playwright's `viewport` option is only read by its built-in `context` fixture — so the option is silently ignored, the page stays at 1280x720, and `useIsMobile` never flips. A test written that way passes while proving nothing.

It now calls `setViewportSize` on the page and asserts the grid **wraps from one row to two**, which is the observable consequence of the column count changing. Row counting is order-independent, so it does not depend on how the seeded persons happen to sort.

## One test written and deliberately dropped

A scroll-button test would have taken `ScrollButton` from 33% to 100% functions, but it could not assert anything: the seeded set is four persons in a five-column grid inside a fixed 800x600 panel, so `rowCount` is 1, `scrollToIndex` is a clamped no-op, and both assertions held *before* the clicks. That is coverage theatre, so the test and its two `data-testid`s were reverted rather than left as orphaned hooks in `packages/shared`. If this coverage is wanted later, the bookmarks panel is the honest host — it renders the same component over a list that genuinely overflows.

## Verification

10 web tests pass including the new viewport test; 10 extension tests pass across `persons-interactions.spec.ts` and `bookmark-editing.spec.ts`.

Note: `persons.spec.ts` fails locally on its image-upload tests. That is the pre-existing Firebase Storage upload flake — confirmed by running that spec in isolation, without any of this branch's changes.

<!-- greptile_comment -->

 

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (5): Last reviewed commit: ["test(web): state the fixture size the wr..."](https://github.com/amitsingh-007/bypass-links/commit/bf9117fda623bf2d3c31fd7c1991e790892f3969) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53380823)</sub>

<!-- /greptile_comment -->