### PR TITLE
test(extension): cover forum link collection and tab opening

### DIFF
--- a/apps/extension/src/entrypoints/background/utils/receiveRuntimeMessage.ts
+++ b/apps/extension/src/entrypoints/background/utils/receiveRuntimeMessage.ts
@@ -13,9 +13,15 @@ export const receiveRuntimeMessage = (
 ) => {
   switch (message.key) {
     case 'openWebsiteLinks': {
-      getForumPageLinks(message.tabId, message.url).then((forumPageLinks) => {
-        sendMessage({ forumPageLinks });
-      });
+      getForumPageLinks(message.tabId, message.url)
+        .then((forumPageLinks) => {
+          sendMessage({ forumPageLinks });
+        })
+        .catch((error) => {
+          // The popup awaits this reply, so staying silent leaves it hanging
+          console.error('Failed to collect forum links', error);
+          sendMessage({ forumPageLinks: [] });
+        });
       break;
     }
 

--- a/apps/extension/tests/fixtures/background-fixture.ts
+++ b/apps/extension/tests/fixtures/background-fixture.ts
@@ -11,12 +11,14 @@ import { EExtensionState, EExtStorageKey } from '@/constants';
 import {
   createSharedBackgroundSW,
   getExtensionId,
+  getPopupUrl,
   withTempProfileContext,
 } from './base-fixture';
 
 interface BaseBackgroundEnv {
   extensionId: string;
   readStorage: <T = unknown>(key: string) => Promise<T | undefined>;
+  writeStorage: (values: Record<string, unknown>) => Promise<void>;
   ensureActiveState: () => Promise<void>;
   ensureInactiveState: () => Promise<void>;
   clearHistoryStartTime: () => Promise<void>;
@@ -25,6 +27,13 @@ interface BaseBackgroundEnv {
   openTab: (url: string) => Promise<Page>;
   /** For real pages, where returning mid-navigation lets a later reload race the load. */
   openLoadedTab: (url: string) => Promise<Page>;
+  /**
+   * Serves markup from a genuine https origin, which `scripting.executeScript`
+   * requires: it refuses `about:blank` and `data:` targets outright.
+   */
+  openFixturePage: (url: string, html: string) => Promise<Page>;
+  /** An extension page, which is the only place `chrome.runtime` is reachable. */
+  openPopup: () => Promise<Page>;
 }
 
 const readStorageFromWorker = async <T = unknown>(
@@ -59,6 +68,16 @@ const createBackgroundEnv = async (
   context: BrowserContext,
   extensionId: string
 ): Promise<BaseBackgroundEnv> => {
+  const openLoadedTab = async (url: string) => {
+    const page = await context.newPage();
+    // Failures surface here rather than as a puzzling assertion on about:blank
+    await page.goto(url, {
+      waitUntil: 'domcontentloaded',
+      timeout: TEST_TIMEOUTS.PAGE_OPEN,
+    });
+    return page;
+  };
+
   const runWithBackground = async <T>(
     operation: (backgroundSW: Worker) => Promise<T>
   ): Promise<T> => {
@@ -83,6 +102,10 @@ const createBackgroundEnv = async (
       runWithBackground(async (backgroundSW) =>
         readStorageFromWorker<T>(backgroundSW, key)
       ),
+    writeStorage: async (values: Record<string, unknown>) =>
+      runWithBackground(async (backgroundSW) =>
+        writeStorageFromWorker(backgroundSW, values)
+      ),
     ensureActiveState: async () =>
       runWithBackground(async (backgroundSW) =>
         writeStorageFromWorker(backgroundSW, {
@@ -105,15 +128,22 @@ const createBackgroundEnv = async (
       ),
     async openTab(url: string) {
       const page = await context.newPage();
-      // Shortcut URLs like http://bt/ fail DNS but the extension intercepts them via webRequest
+      // Shortcut URLs like http://bt/ fail DNS, but tabs.onUpdated still fires
+      // with the url, which is what the redirect listens on
       await page
         .goto(url, { waitUntil: 'commit', timeout: TEST_TIMEOUTS.NAVIGATION })
         .catch(() => undefined);
       return page;
     },
-    async openLoadedTab(url: string) {
+    openLoadedTab,
+    async openPopup() {
+      return openLoadedTab(getPopupUrl(extensionId));
+    },
+    async openFixturePage(url: string, html: string) {
       const page = await context.newPage();
-      // Failures surface here rather than as a puzzling assertion on about:blank
+      await page.route(url, async (route) => {
+        await route.fulfill({ contentType: 'text/html', body: html });
+      });
       await page.goto(url, {
         waitUntil: 'domcontentloaded',
         timeout: TEST_TIMEOUTS.PAGE_OPEN,
@@ -141,7 +171,7 @@ export const test = base.extend<
     );
   },
 
-  // Safe to share: the spec is describe.serial and each test resets its own state
+  // Shared across specs and workers, so anything written here must be restored
   sharedBackground: [
     async ({}, use, testInfo) => {
       await withTempProfileContext(

--- a/apps/extension/tests/specs/background-messages.spec.ts
+++ b/apps/extension/tests/specs/background-messages.spec.ts
@@ -142,7 +142,7 @@ test('answers with no links when the scrape cannot run', async ({
   await isolatedBackground.writeStorage({ websites: {} });
   const popup = await isolatedBackground.openPopup();
   const url = `https://${FORUM_HOST}/`;
-  await isolatedBackground.openFixturePage(url, UNREAD_ROWS_HTML);
+  const tab = await isolatedBackground.openFixturePage(url, UNREAD_ROWS_HTML);
 
   const { forumPageLinks } = await sendMessage(popup, {
     key: 'openWebsiteLinks',
@@ -151,6 +151,7 @@ test('answers with no links when the scrape cannot run', async ({
   });
 
   expect(forumPageLinks).toEqual([]);
+  await tab.close();
 });
 
 test.describe('Forum button', () => {

--- a/apps/extension/tests/specs/background-messages.spec.ts
+++ b/apps/extension/tests/specs/background-messages.spec.ts
@@ -1,0 +1,250 @@
+import { TEST_SITES, TEST_TIMEOUTS } from '@bypass/shared/tests';
+import { type Page } from '@playwright/test';
+
+import { EExtStorageKey } from '@/constants';
+import {
+  type RuntimeInput,
+  type RuntimeKeys,
+  type RuntimeOutput,
+} from '@/utils/sendRuntimeMessage';
+
+import { expect, test } from '../fixtures/background-fixture';
+
+/**
+ * The scraper runs inside the page, so the fixture needs a real https origin,
+ * but the *branch* is chosen by substring-matching the synced website against
+ * the url in the message rather than the tab, so one host serves every forum.
+ */
+const FORUM_HOST = 'forum.test';
+
+const UNREAD_ROWS_HTML = `
+  <div class="block-row block-row--separated is-unread">
+    <a class="fauxBlockLink-blockLink" href="/thread/unread-1"></a>
+  </div>
+  <div class="block-row block-row--separated block-row--alt is-unread">
+    <a class="fauxBlockLink-blockLink" href="/thread/alt-skipped"></a>
+  </div>
+  <div class="block-row block-row--separated">
+    <a class="fauxBlockLink-blockLink" href="/thread/read-skipped"></a>
+  </div>
+`;
+
+const WATCHED_THREADS_HTML = `
+  <div class="structItemContainer">
+    <div class="structItem-cell--main">
+      <div class="structItem-pageJump"><a href="/p/1"></a><a href="/p/last"></a></div>
+    </div>
+    <div class="structItem-cell--main">
+      <div class="structItem-title"><a data-preview-url href="/preview/2"></a></div>
+    </div>
+  </div>
+`;
+
+const RECENT_POSTS_HTML = `
+  <ul class="recent-posts">
+    <li class="post-thumb"><a href="/stale"></a></li>
+  </ul>
+  <ul class="recent-posts">
+    <li class="post-thumb"><a href="/recent-1"></a></li>
+    <li class="post-thumb"><a href="/recent-2"></a></li>
+  </ul>
+`;
+
+const GALLERY_HTML = `
+  <div class="tthumb_gal_item"><a class="tthumb_grid_unread" href="/gal/unread"></a></div>
+  <div class="tthumb_gal_item"><a class="tthumb_grid_read" href="/gal/read-skipped"></a></div>
+`;
+
+interface ForumCase {
+  name: string;
+  key: 'FORUM_1' | 'FORUM_2' | 'FORUM_3' | 'FORUM_4';
+  path?: string;
+  html: string;
+  expected: string[];
+}
+
+const FORUM_CASES: ForumCase[] = [
+  {
+    name: 'forum one keeps only unread, non-alt rows',
+    key: 'FORUM_1',
+    html: UNREAD_ROWS_HTML,
+    expected: ['/thread/unread-1'],
+  },
+  {
+    name: 'forum two shares the forum one scraper',
+    key: 'FORUM_2',
+    html: UNREAD_ROWS_HTML,
+    expected: ['/thread/unread-1'],
+  },
+  {
+    name: 'watched threads prefers the last page jump, else the preview link',
+    key: 'FORUM_1',
+    path: '/watched/threads',
+    html: WATCHED_THREADS_HTML,
+    expected: ['/p/last', '/preview/2'],
+  },
+  {
+    name: 'forum three reads only the newest recent-posts block',
+    key: 'FORUM_3',
+    html: RECENT_POSTS_HTML,
+    expected: ['/recent-1', '/recent-2'],
+  },
+  {
+    name: 'forum four keeps only unread gallery items',
+    key: 'FORUM_4',
+    html: GALLERY_HTML,
+    expected: ['/gal/unread'],
+  },
+];
+
+const sendMessage = async <K extends RuntimeKeys>(
+  popup: Page,
+  input: Extract<RuntimeInput, { key: K }>
+): Promise<RuntimeOutput[K]> =>
+  popup.evaluate(async (message) => chrome.runtime.sendMessage(message), input);
+
+const findTabId = async (popup: Page, url: string) =>
+  popup.evaluate(async (target) => {
+    const [tab] = await chrome.tabs.query({ url: target });
+    return tab?.id ?? -1;
+  }, url);
+
+test('picks a scraper per forum and returns absolute links', async ({
+  isolatedBackground,
+}) => {
+  const popup = await isolatedBackground.openPopup();
+
+  for (const forumCase of FORUM_CASES) {
+    await test.step(forumCase.name, async () => {
+      const url = `https://${FORUM_HOST}${forumCase.path ?? '/'}`;
+      await isolatedBackground.writeStorage({
+        websites: { [forumCase.key]: FORUM_HOST },
+      });
+      const tab = await isolatedBackground.openFixturePage(url, forumCase.html);
+
+      const { forumPageLinks } = await sendMessage(popup, {
+        key: 'openWebsiteLinks',
+        tabId: await findTabId(popup, url),
+        url,
+      });
+
+      expect(forumPageLinks).toEqual(
+        forumCase.expected.map((path) => `https://${FORUM_HOST}${path}`)
+      );
+      await tab.close();
+    });
+  }
+});
+
+test('answers with no links when the scrape cannot run', async ({
+  isolatedBackground,
+}) => {
+  await isolatedBackground.writeStorage({ websites: {} });
+  const popup = await isolatedBackground.openPopup();
+  const url = `https://${FORUM_HOST}/`;
+  await isolatedBackground.openFixturePage(url, UNREAD_ROWS_HTML);
+
+  const { forumPageLinks } = await sendMessage(popup, {
+    key: 'openWebsiteLinks',
+    tabId: await findTabId(popup, url),
+    url,
+  });
+
+  expect(forumPageLinks).toEqual([]);
+});
+
+test.describe('Forum button', () => {
+  test('reports success once it has opened the collected links', async ({
+    sharedBackground,
+  }) => {
+    const synced = await sharedBackground.readStorage('websites');
+    try {
+      await sharedBackground.writeStorage({
+        websites: { FORUM_1: FORUM_HOST },
+      });
+
+      /**
+       * The popup enables the button from the active tab, so the forum tab has
+       * to take focus before this reload -- opening the popup last would leave
+       * the popup itself in front.
+       */
+      const popup = await sharedBackground.openPopup();
+      await sharedBackground.openFixturePage(
+        `https://${FORUM_HOST}/`,
+        UNREAD_ROWS_HTML
+      );
+      await popup.reload({ waitUntil: 'domcontentloaded' });
+
+      const forumButton = popup.getByRole('button', { name: 'Forum' });
+      await expect(forumButton).toBeEnabled();
+      await forumButton.click();
+
+      await expect(
+        popup.getByRole('button', { name: 'Success' })
+      ).toBeVisible();
+    } finally {
+      await sharedBackground.writeStorage({ websites: synced ?? {} });
+    }
+  });
+});
+
+test.describe('Opening collected links', () => {
+  test('opens one background tab per url', async ({ isolatedBackground }) => {
+    await isolatedBackground.clearHistoryStartTime();
+    const popup = await isolatedBackground.openPopup();
+    const context = popup.context();
+    const before = context.pages().length;
+
+    await sendMessage(popup, {
+      key: 'openLinksInTabs',
+      urls: [TEST_SITES.EXAMPLE_COM, TEST_SITES.EXAMPLE_ORG],
+    });
+
+    // Opens are paced a second apart, so both tabs land well after the reply
+    await expect
+      .poll(() => context.pages().length, {
+        timeout: TEST_TIMEOUTS.PAGE_OPEN,
+      })
+      .toBe(before + 2);
+    await expect
+      .poll(() =>
+        isolatedBackground.readStorage(EExtStorageKey.HISTORY_START_TIME)
+      )
+      .toBeDefined();
+  });
+
+  test('opens nothing and starts no history watch for an empty list', async ({
+    isolatedBackground,
+  }) => {
+    await isolatedBackground.clearHistoryStartTime();
+    const popup = await isolatedBackground.openPopup();
+    const context = popup.context();
+    const before = context.pages().length;
+
+    await sendMessage(popup, { key: 'openLinksInTabs', urls: [] });
+
+    expect(context.pages().length).toBe(before);
+    expect(
+      await isolatedBackground.readStorage(EExtStorageKey.HISTORY_START_TIME)
+    ).toBeUndefined();
+  });
+
+  test('survives a url the browser refuses to open', async ({
+    isolatedBackground,
+  }) => {
+    const popup = await isolatedBackground.openPopup();
+    const context = popup.context();
+    const before = context.pages().length;
+
+    await sendMessage(popup, {
+      key: 'openLinksInTabs',
+      urls: ['javascript:void(0)', TEST_SITES.EXAMPLE_NET],
+    });
+
+    await expect
+      .poll(() => context.pages().length, {
+        timeout: TEST_TIMEOUTS.PAGE_OPEN,
+      })
+      .toBe(before + 1);
+  });
+});


### PR DESCRIPTION
Stacked on #4167.

## Why

**No test had ever sent a runtime message.** `receiveRuntimeMessage` read 28% — which was just its import lines — and the link-bypass feature, the reason the extension exists, sat at **1.3%**. Nothing touched the Forum button either.

## How the forums are faked

`getForumPageLinks(tabId, url)` picks its scraper by substring-matching the synced website against the **url in the message**, not the tab. So one fixture host covers all four forums and **no real forum domain enters the repo**. The scrapers themselves still run for real, injected into fixture markup served from a genuine https origin (`executeScript` refuses `about:blank` and `data:`).

That makes these genuine selector-regression tests, not tautologies. They pin down that:
- the `--alt` row and the read row are dropped, only `.is-unread` survives
- watched threads prefers `.structItem-pageJump > a:last-child` and falls back to `[data-preview-url]`
- forum three reads only the **last** `.recent-posts` block
- forum four keeps only `tthumb_grid_unread`
- hrefs come back **absolute**, which `tabs.create` depends on

What they do not prove is that the selectors match real XenForo — the fixture markup was written from the selectors.

## One production fix, and an honest limitation

`receiveRuntimeMessage` had a `.then()` with **no `.catch()`**. On a rejected scrape it sent no reply at all, so `sendRuntimeMessage` rejected, `openForumlinks` rejected, and `useFeedbackButton` never reached `setButtonState(SUCCESS)` — the button spun in LOADING **forever**, with an unhandled rejection in the popup. It now replies with an empty list.

That is strictly better than hanging, but be clear on what it does: **a failed scrape now shows a green "Success" with no links.** An honest error path needs a fourth `EButtonState`, an error variant in `ButtonWithFeedback`, and an error field in `RuntimeOutput` — a product change that does not belong in a coverage PR. Worth a follow-up.

## Cost control

The five scraper cases share **one** browser via `test.step` rather than one isolated profile each — a measured ~0.6–1.2s per context launch, so this saves four launches and four concurrent Chromes. The `openLinksInTabs` tests stay isolated because they assert on `context.pages().length`, which is only meaningful in a private context.

The Forum button test needs the authenticated profile, so it uses the worker-scoped `sharedBackground` and **restores `websites` in a `finally`** — a trailing reset would leak the fake host into every later test in that worker whenever an assertion failed. The fixture comment claiming that profile was safe because its consumer was `describe.serial` is no longer true and has been corrected.

Also fixes a stale comment claiming `webRequest` interception, which the manifest has never had.

## Verification

22 background tests pass together (`background-messages`, `background-navigation`, `background-lifecycle`), no flake.

<!-- greptile_comment -->

 

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up-review scope.

No blocking failure remains.
</details>

<sub>Reviews (3): Last reviewed commit: ["test(extension): close the fixture tab i..."](https://github.com/amitsingh-007/bypass-links/commit/7f2105e368a4898e8b2ac75569c38b2e17ab0e86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53380832)</sub>

**Context used:**

- Knowledge Base — [Extension background service worker](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/extension-background.md)

<!-- /greptile_comment -->