### PR TITLE
test(extension): cover the person select combobox

### DIFF
--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/PersonSelect.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/PersonSelect.tsx
@@ -44,7 +44,11 @@ function AvatarWithPreview({ person }: AvatarWithPreviewProps) {
   return (
     <HoverCard>
       <HoverCardTrigger delay={0} closeDelay={0}>
-        <Avatar size="sm" className="size-6!">
+        <Avatar
+          size="sm"
+          className="size-6!"
+          data-testid={`person-avatar-${person.label}`}
+        >
           <AvatarImage src={person.image} alt={person.label} />
           <AvatarFallback>
             <HugeiconsIcon icon={UserWarning03Icon} className="size-3" />
@@ -109,6 +113,8 @@ function PersonSelect({ value, onChange }: PersonSelectProps) {
             <Switch
               checked={orderByRecency}
               size="sm"
+              aria-label="Sort by recency"
+              data-testid="recency-switch"
               onCheckedChange={toggleOrderByRecency}
             />
           </div>

--- a/apps/extension/tests/specs/person-select.spec.ts
+++ b/apps/extension/tests/specs/person-select.spec.ts
@@ -1,8 +1,4 @@
-import {
-  TEST_BOOKMARKS,
-  TEST_FOLDERS,
-  TEST_PERSONS,
-} from '@bypass/shared/tests';
+import { TEST_BOOKMARKS, TEST_PERSONS } from '@bypass/shared/tests';
 
 import { expect, test } from '../fixtures/bookmark-fixture';
 import { BookmarksPanel } from '../utils/bookmarks-panel';
@@ -10,9 +6,12 @@ import { fillSearchInput } from '../utils/test-utils';
 
 const PERSON_SEARCH_PLACEHOLDER = 'Search persons...';
 
+/**
+ * Stays on the root listing, where the fixture bookmark lives: `openFolder`
+ * single-clicks, and the folder component navigates only on double-click.
+ */
 const openPersonSelect = async (panel: BookmarksPanel) => {
   await panel.ensureAtRoot();
-  await panel.openFolder(TEST_FOLDERS.MAIN);
   return panel.openPersonSelect(TEST_BOOKMARKS.REACT_DOCS);
 };
 

--- a/apps/extension/tests/specs/person-select.spec.ts
+++ b/apps/extension/tests/specs/person-select.spec.ts
@@ -1,0 +1,95 @@
+import {
+  TEST_BOOKMARKS,
+  TEST_FOLDERS,
+  TEST_PERSONS,
+} from '@bypass/shared/tests';
+
+import { expect, test } from '../fixtures/bookmark-fixture';
+import { BookmarksPanel } from '../utils/bookmarks-panel';
+import { fillSearchInput } from '../utils/test-utils';
+
+const PERSON_SEARCH_PLACEHOLDER = 'Search persons...';
+
+const openPersonSelect = async (panel: BookmarksPanel) => {
+  await panel.ensureAtRoot();
+  await panel.openFolder(TEST_FOLDERS.MAIN);
+  return panel.openPersonSelect(TEST_BOOKMARKS.REACT_DOCS);
+};
+
+// The dialog holds unsaved edits, and the page is worker scoped
+test.afterEach(async ({ bookmarksPage }) => {
+  await new BookmarksPanel(bookmarksPage).ensureAtRoot();
+});
+
+test.describe('Tagging a bookmark with a person', () => {
+  test('narrows the list to the typed name', async ({ bookmarksPage }) => {
+    const panel = new BookmarksPanel(bookmarksPage);
+    const dialog = await openPersonSelect(panel);
+
+    await fillSearchInput(dialog, 'Donald', PERSON_SEARCH_PLACEHOLDER);
+
+    await expect(bookmarksPage.getByRole('option')).toHaveText([
+      TEST_PERSONS.DONALD,
+    ]);
+  });
+
+  test('shows an empty state when no person matches', async ({
+    bookmarksPage,
+  }) => {
+    const panel = new BookmarksPanel(bookmarksPage);
+    const dialog = await openPersonSelect(panel);
+
+    await fillSearchInput(
+      dialog,
+      'nobody-by-this-name',
+      PERSON_SEARCH_PLACEHOLDER
+    );
+
+    await expect(bookmarksPage.getByText('No persons found')).toBeVisible();
+    await expect(bookmarksPage.getByRole('option')).toHaveCount(0);
+  });
+
+  test('sorts alphabetically once recency sorting is turned off', async ({
+    bookmarksPage,
+  }) => {
+    const panel = new BookmarksPanel(bookmarksPage);
+    const dialog = await openPersonSelect(panel);
+    const options = bookmarksPage.getByRole('option');
+    // Selected by test id, not role: the open combobox takes the rest of the
+    // dialog out of the accessibility tree, so getByRole('switch') finds nothing
+    const recencySwitch = dialog.getByTestId('recency-switch');
+
+    await expect(options).not.toHaveCount(0);
+    const byRecency = await options.allTextContents();
+
+    await recencySwitch.click();
+
+    // Asserting the expected order, not merely a changed one: recency order can
+    // coincide with alphabetical depending on what the account has tagged
+    await expect(options).toHaveText(
+      byRecency.toSorted((left, right) => left.localeCompare(right))
+    );
+  });
+
+  test('previews a person behind their avatar', async ({ bookmarksPage }) => {
+    const panel = new BookmarksPanel(bookmarksPage);
+    await openPersonSelect(panel);
+
+    // Options are portaled out of the dialog
+    await bookmarksPage
+      .getByTestId(`person-avatar-${TEST_PERSONS.DONALD}`)
+      .hover();
+
+    const preview = bookmarksPage.locator(
+      '[data-testid^="person-avatar-preview-"]'
+    );
+    await expect(preview).toBeVisible();
+
+    // The tooltip lives inside the portaled hover card, wired to a provider
+    // outside it, which is the composition worth guarding
+    await preview.locator('[data-slot="avatar"]').hover();
+    await expect(
+      bookmarksPage.locator('[data-slot="tooltip-content"]')
+    ).toContainText(TEST_PERSONS.DONALD);
+  });
+});

--- a/apps/extension/tests/specs/person-select.spec.ts
+++ b/apps/extension/tests/specs/person-select.spec.ts
@@ -63,8 +63,9 @@ test.describe('Tagging a bookmark with a person', () => {
 
     await recencySwitch.click();
 
-    // Asserting the expected order, not merely a changed one: recency order can
-    // coincide with alphabetical depending on what the account has tagged
+    // The order assertion alone can hold vacuously when recency already matches
+    // alphabetical, so pin that the toggle itself actually flipped
+    await expect(recencySwitch).not.toBeChecked();
     await expect(options).toHaveText(
       byRecency.toSorted((left, right) => left.localeCompare(right))
     );

--- a/apps/extension/tests/utils/bookmarks-panel.ts
+++ b/apps/extension/tests/utils/bookmarks-panel.ts
@@ -141,12 +141,15 @@ export class BookmarksPanel {
     return this.page.getByTitle('Edit Bookmark');
   }
 
-  async addPersonToBookmark(bookmarkTitle: string, personName: string) {
+  async openPersonSelect(bookmarkTitle: string) {
     const dialog = await this.openEditBookmarkDialog(bookmarkTitle);
     await expect(dialog).toBeVisible();
+    await dialog.getByTestId('person-select').click();
+    return dialog;
+  }
 
-    const personSelect = dialog.getByTestId('person-select');
-    await personSelect.click();
+  async addPersonToBookmark(bookmarkTitle: string, personName: string) {
+    const dialog = await this.openPersonSelect(bookmarkTitle);
 
     const option = this.page.getByRole('option', { name: personName });
     await option.click();
@@ -164,11 +167,7 @@ export class BookmarksPanel {
   }
 
   async removePersonFromBookmark(bookmarkTitle: string, personName: string) {
-    const dialog = await this.openEditBookmarkDialog(bookmarkTitle);
-    await expect(dialog).toBeVisible();
-
-    const personSelect = dialog.getByTestId('person-select');
-    await personSelect.click();
+    const dialog = await this.openPersonSelect(bookmarkTitle);
 
     const option = this.page.getByRole('option', { name: personName });
     await expect(option).toBeVisible();


### PR DESCRIPTION
Stacked on #4168.

## Why

`PersonSelect` sat at **26% lines with 0% of its functions called**. The existing tests only pick an option, so the search filter, the empty state, the sort toggle and the avatar preview had never run.

## Four tests

- Typing narrows the option list to the matching person
- A non-matching query shows the "No persons found" branch
- Turning off recency sorting reorders the list alphabetically
- Hovering an option's avatar opens the preview, and hovering that opens the nested tooltip with the person's name

## Two things worth reviewing

**The sort test pins the expected order, not merely a changed one.** `sortByRecency` only reorders persons tagged in the *default folder* and leaves the rest in Firebase insertion order — so recency order can legitimately coincide with alphabetical, and other specs retag persons in the same shared account while this one runs. Asserting "the order changed" would have been flaky by data with no product bug behind it. It now asserts the alphabetical order explicitly, which is also strictly stronger.

**The switch had no accessible name at all** — it sits beside a plain `<span>Sort by recency</span>`, so it exposed nothing to assistive tech. This adds an `aria-label`, which is a real fix independent of testing.

It still needs a `data-testid` to select, though, and that is worth knowing: **`getByRole('switch')` resolves to zero elements here.** The open combobox popup takes the rest of the dialog out of the accessibility tree, so no role-based selector can reach the switch while the list is open — verified by probing the live DOM, which shows the element present with `role="switch"` and the correct name but absent from the a11y tree. The testid reuses the `recency-switch` name already used by the persons panel switch rather than inventing a second spelling; the two are never co-rendered.

## Refactor

`openPersonSelect(bookmarkTitle)` moves onto `BookmarksPanel`, so the "open dialog → click `person-select`" pair is written once instead of three times (`addPersonToBookmark` and `removePersonFromBookmark` now build on it).

## Verification

27 tests pass — the 4 new ones plus the existing 21-test `bookmarks.spec.ts` and its neighbours — no flake.

<!-- greptile_comment -->

 

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (4): Last reviewed commit: ["test(extension): pin that the sort toggl..."](https://github.com/amitsingh-007/bypass-links/commit/cf7126470e9fecb2ba5724369be25b66f002e7fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53380841)</sub>

**Context used:**

- Knowledge Base — [Extension Popup UI](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/extension-popup.md)

<!-- /greptile_comment -->