### PR TITLE
test(extension): cover logout and the auto sign-out path

### DIFF
--- a/apps/extension/src/entrypoints/popup/panels/HomePopup/components/ToggleExtension.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/HomePopup/components/ToggleExtension.tsx
@@ -29,11 +29,13 @@ function ToggleExtension() {
     <div className="flex items-center gap-2">
       <Switch
         checked={isActive}
-        aria-label="Enable"
+        aria-labelledby="toggle-extension-label"
         data-testid="toggle-extension-switch"
         onCheckedChange={handleToggle}
       />
-      <span className="text-sm">Enable</span>
+      <span id="toggle-extension-label" className="text-sm">
+        Enable
+      </span>
     </div>
   );
 }

--- a/apps/extension/src/entrypoints/popup/panels/HomePopup/components/ToggleExtension.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/HomePopup/components/ToggleExtension.tsx
@@ -27,7 +27,12 @@ function ToggleExtension() {
 
   return (
     <div className="flex items-center gap-2">
-      <Switch checked={isActive} onCheckedChange={handleToggle} />
+      <Switch
+        checked={isActive}
+        aria-label="Enable"
+        data-testid="toggle-extension-switch"
+        onCheckedChange={handleToggle}
+      />
       <span className="text-sm">Enable</span>
     </div>
   );

--- a/apps/extension/tests/fixtures/background-fixture.ts
+++ b/apps/extension/tests/fixtures/background-fixture.ts
@@ -55,7 +55,7 @@ const writeStorageFromWorker = async (
   }, values);
 };
 
-const removeStorageFromWorker = async (
+export const removeStorageFromWorker = async (
   backgroundSW: Worker,
   keys: string | string[]
 ) => {

--- a/apps/extension/tests/specs/auth-lifecycle.spec.ts
+++ b/apps/extension/tests/specs/auth-lifecycle.spec.ts
@@ -63,16 +63,20 @@ const withSignedInProfile = async (
         EExtStorageKey.HAS_PENDING_PERSONS,
       ]);
 
-      await run({
-        context,
-        extensionId,
-        sawAccountWrite: () => sawAccountWrite,
-      });
-
-      expect(
-        sawAccountWrite,
-        'logout tried to write the shared test account'
-      ).toBe(false);
+      try {
+        await run({
+          context,
+          extensionId,
+          sawAccountWrite: () => sawAccountWrite,
+        });
+      } finally {
+        // In a finally so a failing assertion above still surfaces the write by
+        // name, rather than leaving only the symptom it caused
+        expect(
+          sawAccountWrite,
+          'logout tried to write the shared test account'
+        ).toBe(false);
+      }
     }
   );
 

--- a/apps/extension/tests/specs/auth-lifecycle.spec.ts
+++ b/apps/extension/tests/specs/auth-lifecycle.spec.ts
@@ -1,0 +1,124 @@
+import { STORAGE_KEYS } from '@bypass/shared';
+import { TEST_TIMEOUTS } from '@bypass/shared/tests';
+import { expect, test, type BrowserContext } from '@playwright/test';
+
+import { EExtStorageKey } from '@/constants';
+
+import { removeStorageFromWorker } from '../fixtures/background-fixture';
+import {
+  createSharedBackgroundSW,
+  getExtensionId,
+  openExtensionPanelPage,
+  withTempProfileContext,
+} from '../fixtures/base-fixture';
+import { getStorageItem } from '../utils/test-utils';
+
+const GOOGLE_LOGOUT_TABS = [
+  'https://www.google.com/',
+  'https://www.google.com/imghp',
+  'https://myactivity.google.com/activitycontrols/webandapp',
+];
+
+interface SignedInProfile {
+  context: BrowserContext;
+  extensionId: string;
+  /** True if logout ever tried to write the shared account despite the guard. */
+  sawAccountWrite: () => boolean;
+}
+
+/**
+ * Logout is destructive, so each test gets its own copy of the authenticated
+ * profile. The one remote write on the path is aborted rather than faked: a fake
+ * success would let the guard rot unnoticed, and a real one would rewrite the
+ * fixture data every other spec reads.
+ */
+const withSignedInProfile = async (
+  headless: boolean,
+  run: (profile: SignedInProfile) => Promise<void>
+) =>
+  withTempProfileContext(
+    { prefix: 'chrome-auth-lifecycle-', headless, seedFromCachedProfile: true },
+    async (context) => {
+      let sawAccountWrite = false;
+      // A predicate, not a glob: tRPC batches procedures into one path, and a
+      // glob anchored on the last slash misses the write when it is not first
+      await context.route(
+        (url) => url.pathname.includes('bookmarkAndPersonSave'),
+        async (route) => {
+          sawAccountWrite = true;
+          await route.abort();
+        }
+      );
+      for (const url of GOOGLE_LOGOUT_TABS) {
+        await context.route(`${url}**`, async (route) => {
+          await route.fulfill({ contentType: 'text/html', body: '' });
+        });
+      }
+
+      const backgroundSW = await createSharedBackgroundSW(context);
+      const extensionId = await getExtensionId(backgroundSW);
+      // Nothing pending means pre-logout skips the shared account write entirely
+      await removeStorageFromWorker(backgroundSW, [
+        EExtStorageKey.HAS_PENDING_BOOKMARKS,
+        EExtStorageKey.HAS_PENDING_PERSONS,
+      ]);
+
+      await run({
+        context,
+        extensionId,
+        sawAccountWrite: () => sawAccountWrite,
+      });
+
+      expect(
+        sawAccountWrite,
+        'logout tried to write the shared test account'
+      ).toBe(false);
+    }
+  );
+
+test.describe('Auth lifecycle', () => {
+  test('clears synced storage and opens the account tabs on logout', async ({}, testInfo) => {
+    await withSignedInProfile(
+      testInfo.project.use?.headless ?? true,
+      async ({ context, extensionId }) => {
+        const page = await openExtensionPanelPage(context, extensionId, 'home');
+        const tabsBefore = context.pages().length;
+
+        await page.getByTestId('logout-button').click();
+
+        await expect(page.getByTestId('login-button')).toBeVisible({
+          timeout: TEST_TIMEOUTS.AUTH,
+        });
+        expect(
+          await getStorageItem(page, STORAGE_KEYS.bookmarks)
+        ).toBeUndefined();
+        expect(
+          await getStorageItem(page, STORAGE_KEYS.persons)
+        ).toBeUndefined();
+        expect(
+          await getStorageItem(page, STORAGE_KEYS.redirections)
+        ).toBeUndefined();
+        await expect
+          .poll(() => context.pages().length, {
+            timeout: TEST_TIMEOUTS.PAGE_OPEN,
+          })
+          .toBe(tabsBefore + GOOGLE_LOGOUT_TABS.length);
+      }
+    );
+  });
+
+  test('signs out on its own when the extension is switched off', async ({}, testInfo) => {
+    await withSignedInProfile(
+      testInfo.project.use?.headless ?? true,
+      async ({ context, extensionId }) => {
+        const page = await openExtensionPanelPage(context, extensionId, 'home');
+
+        await page.getByTestId('toggle-extension-switch').click();
+
+        await expect(page.getByTestId('login-button')).toBeVisible({
+          timeout: TEST_TIMEOUTS.AUTH,
+        });
+      }
+    );
+  });
+});


### PR DESCRIPTION
Stacked on #4169.

## Why

**No spec had ever clicked logout** — `logout-button` was only ever asserted *visible*. So `processPreLogout` and `processPostLogout` were entirely uncovered and `HomePopup/utils/sync.ts` sat at 56% lines with **28% of its functions** called.

## Protecting the shared account

Logout is destructive: it resets every synced key and pushes local state to Firebase first. So each test copies the authenticated profile rather than touching the worker-shared one, and the single remote write on the path is guarded three ways:

1. **The pending-changes flags are cleared first**, which makes `syncBookmarksAndPersonsFirebaseWithStorage` early-return before it can call Firebase at all. I walked the rest of the logout path to confirm every other step (`resetRedirections`, `resetWebsites`, `resetBookmarks`, `resetPersons`, `clearPersonImageUrls`, `firebaseSignOut`, `deleteAllCache`) is local-only.
2. **The write is matched by a URL predicate, not a glob.** tRPC uses `httpBatchLink`, so procedures share one path — and a glob anchored at the last `/` silently misses the write whenever it is not the *first* procedure in the batch. Today it happens to be first; that is an accident of call ordering, and this guard exists for the day it changes.
3. **It aborts rather than fakes, and a spy asserts it was never attempted.** A faked success would let the guard rot unnoticed; the spy turns a regression into a named failure instead of a confusing 30-second timeout.

## A third test, written and deliberately dropped

I wrote a sign-in-failure test and removed it, because it was **passing green while proving nothing**. `firebaseSignIn` deletes the credentials key the moment it consumes it, and `auth.setup.ts` dumps localStorage *after* clicking Login — so that key is never in the cached storage. The injection was therefore a no-op, the popup fell through to a real interactive `getAuthToken`, and the test was actually asserting "headless Chromium cannot complete OAuth". The `firebaseData.*` abort in it was dead code, and in a headed run it could pop a real OAuth window.

Covering it properly needs `auth.setup.ts` to persist the credential into its dump — a change to shared fixture infrastructure that every spec depends on, which does not belong in this PR.

## Also

The extension toggle gains an `aria-label`; it previously had **no accessible name at all**, sitting beside a plain `<span>Enable</span>`. `ToggleHistory` has the identical gap and is deliberately left alone rather than widening this PR — worth a follow-up.

## Bonus: the persons-CRUD puzzle is closed

The plan flagged `PersonsPanel/utils/index.ts` reading 0% functions despite passing CRUD specs, and asked for it to be explained before crediting any coverage. Phase 0 answered it: that file is now **100% lines / 100% functions**, so it was a coverage-attribution artifact all along, not a swallowed save. No de-flake lever was needed.

## Verification

Both tests pass, and the account-write spy confirms the guard held.

<!-- greptile_comment -->

 

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the revised pathname predicate matches the batched tRPC procedure path and resolves the previously reported interception gap.
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(extension): label the toggle from it..."](https://github.com/amitsingh-007/bypass-links/commit/d67cfab37baaed0de165386f1349d64689d7bef7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53380846)</sub>

**Context used:**

- Knowledge Base — [Extension Popup UI](https://app.greptile.com/amit/-/custom-context/knowledge-base/amitsingh-007/bypass-links/-/docs/extension-popup.md)

<!-- /greptile_comment -->