### PR TITLE
test(extension): cover the search hotkey, including the modal case

### DIFF
--- a/apps/extension/tests/specs/search-hotkey.spec.ts
+++ b/apps/extension/tests/specs/search-hotkey.spec.ts
@@ -1,0 +1,34 @@
+import { TEST_PERSONS } from '@bypass/shared/tests';
+
+import { expect, test } from '../fixtures/persons-fixture';
+import { PersonsPanel } from '../utils/persons-panel';
+
+test.afterEach(async ({ personsPage }) => {
+  await new PersonsPanel(personsPage).ensureAtRoot();
+});
+
+test.describe('Search hotkey', () => {
+  test('focuses the panel search', async ({ personsPage }) => {
+    const panel = new PersonsPanel(personsPage);
+    await panel.ensureAtRoot();
+
+    await personsPage.keyboard.press('ControlOrMeta+f');
+
+    await expect(panel.getSearchInput()).toBeFocused();
+  });
+
+  test('focuses the innermost search when a modal is open', async ({
+    personsPage,
+  }) => {
+    const panel = new PersonsPanel(personsPage);
+    await panel.ensureAtRoot();
+    await panel.openPersonCard(TEST_PERSONS.JOHN_NATHAN);
+    // The dialog moves focus into itself on open, so prove it did not land here
+    await expect(panel.getModalSearchInput()).not.toBeFocused();
+
+    await personsPage.keyboard.press('ControlOrMeta+f');
+
+    // Two search inputs are mounted; the hotkey has to pick the modal's
+    await expect(panel.getModalSearchInput()).toBeFocused();
+  });
+});

--- a/apps/extension/tests/specs/search-hotkey.spec.ts
+++ b/apps/extension/tests/specs/search-hotkey.spec.ts
@@ -3,6 +3,12 @@ import { TEST_PERSONS } from '@bypass/shared/tests';
 import { expect, test } from '../fixtures/persons-fixture';
 import { PersonsPanel } from '../utils/persons-panel';
 
+// Before, so a neighbouring spec cannot hand this one a dirty page; after, so
+// this one cannot hand the next a modal it left open
+test.beforeEach(async ({ personsPage }) => {
+  await new PersonsPanel(personsPage).ensureAtRoot();
+});
+
 test.afterEach(async ({ personsPage }) => {
   await new PersonsPanel(personsPage).ensureAtRoot();
 });
@@ -10,7 +16,6 @@ test.afterEach(async ({ personsPage }) => {
 test.describe('Search hotkey', () => {
   test('focuses the panel search', async ({ personsPage }) => {
     const panel = new PersonsPanel(personsPage);
-    await panel.ensureAtRoot();
 
     await personsPage.keyboard.press('ControlOrMeta+f');
 
@@ -21,7 +26,6 @@ test.describe('Search hotkey', () => {
     personsPage,
   }) => {
     const panel = new PersonsPanel(personsPage);
-    await panel.ensureAtRoot();
     await panel.openPersonCard(TEST_PERSONS.JOHN_NATHAN);
     // The dialog moves focus into itself on open, so prove it did not land here
     await expect(panel.getModalSearchInput()).not.toBeFocused();

--- a/apps/extension/tests/specs/search-hotkey.spec.ts
+++ b/apps/extension/tests/specs/search-hotkey.spec.ts
@@ -27,6 +27,9 @@ test.describe('Search hotkey', () => {
   }) => {
     const panel = new PersonsPanel(personsPage);
     await panel.openPersonCard(TEST_PERSONS.JOHN_NATHAN);
+    // Waited for first: a negative assertion on an unattached locator passes
+    // instantly, which would let the key press land before the modal exists
+    await expect(panel.getModalSearchInput()).toBeVisible();
     // The dialog moves focus into itself on open, so prove it did not land here
     await expect(panel.getModalSearchInput()).not.toBeFocused();
 

--- a/apps/extension/tests/utils/persons-panel.ts
+++ b/apps/extension/tests/utils/persons-panel.ts
@@ -187,7 +187,7 @@ export class PersonsPanel {
     await openPersonCard(this.page, personName);
 
     const dialog = this.getBookmarksDialog();
-    const searchInput = dialog.getByPlaceholder('Search');
+    const searchInput = this.getModalSearchInput();
     await expect(searchInput).toBeVisible();
 
     const bookmarks = dialog.getByTitle('Edit Bookmark');
@@ -270,6 +270,11 @@ export class PersonsPanel {
 
   getSearchInput() {
     return this.page.getByPlaceholder('Search');
+  }
+
+  /** Scoped, because the panel's own search matches the same placeholder. */
+  getModalSearchInput() {
+    return this.getBookmarksDialog().getByPlaceholder('Search');
   }
 
   // ============ Composite Operations ============


### PR DESCRIPTION
Stacked on #4170.

## Why

The `mod+F` handler in the shared `Search` component was **entirely uncovered** — the whole suite contained roughly one keypress. The handler exists specifically to focus the *innermost* search when several are mounted, and the persons panel creates exactly that case once a person's bookmarks modal opens over the panel search.

## Two tests

- `ControlOrMeta+F` on the persons panel focuses the panel's search
- With the bookmarks modal open, the same key focuses the **modal's** search instead — the `visibleSearchInputs.at(-1)` behaviour

The modal test asserts the search is **unfocused before** the keypress. Base UI's dialog moves focus into itself on open, so without that guard the assertion could pass on the dialog's own autofocus rather than on the hotkey doing anything.

`getModalSearchInput()` moves onto the page object, because `getSearchInput()` is page-wide and matches *both* inputs while the modal is open — a strict-mode hazard that already bit this test once. `searchWithinBookmarks` now uses it too.

## Two planned items deliberately left out

**The shortcuts panel Save path.** It writes the `redirections` storage that `background-navigation.spec.ts` asserts on, and mocking the mutation is not enough — the follow-up `syncRedirectionsToStorage` still rewrites that storage from the mocked reply. Not worth the shared-state risk for ~26 lines.

**An authenticated `web-ext` test.** Not reachable with the current fixtures: the web `auth-fixture` restores localStorage and cookies but **not Firebase's own persistence**, so `useUser()` never reports a signed-in state and the page stays on Login. That is precisely why that spec runs unauthenticated today. Reaching the `isLoggedIn` branches needs the fixture to restore Firebase auth — infrastructure work rather than a test.

## Verification

Both tests pass alongside `persons-interactions.spec.ts`.

Note: `persons.spec.ts` fails locally on its image-upload tests. That is the pre-existing Firebase Storage flake, confirmed by running that spec in isolation against an unmodified tree.

<!-- greptile_comment -->

 

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (4): Last reviewed commit: ["test(extension): wait for the modal sear..."](https://github.com/amitsingh-007/bypass-links/commit/c7d6f7b9d9c87e7d11b5454f1074ac91376d9b55) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53380857)</sub>

<!-- /greptile_comment -->