### PR TITLE
test(e2e): address deferred review comments from the coverage stack

### DIFF
--- a/apps/extension/tests/fixtures/background-fixture.ts
+++ b/apps/extension/tests/fixtures/background-fixture.ts
@@ -16,6 +16,7 @@ import {
 } from './base-fixture';
 
 interface BaseBackgroundEnv {
+  context: BrowserContext;
   extensionId: string;
   readStorage: <T = unknown>(key: string) => Promise<T | undefined>;
   writeStorage: (values: Record<string, unknown>) => Promise<void>;
@@ -97,6 +98,7 @@ const createBackgroundEnv = async (
   };
 
   return {
+    context,
     extensionId,
     readStorage: async <T = unknown>(key: string) =>
       runWithBackground(async (backgroundSW) =>

--- a/apps/extension/tests/specs/auth-lifecycle.spec.ts
+++ b/apps/extension/tests/specs/auth-lifecycle.spec.ts
@@ -40,15 +40,19 @@ const withSignedInProfile = async (
     { prefix: 'chrome-auth-lifecycle-', headless, seedFromCachedProfile: true },
     async (context) => {
       let sawAccountWrite = false;
-      // A predicate, not a glob: tRPC batches procedures into one path, and a
-      // glob anchored on the last slash misses the write when it is not first
-      await context.route(
-        (url) => url.pathname.includes('bookmarkAndPersonSave'),
-        async (route) => {
+      // tRPC batches procedures into one request, so the url names only the first
+      await context.route('**/api/trpc**', async (route) => {
+        const request = route.request();
+        if (
+          request.url().includes('bookmarkAndPersonSave') ||
+          (request.postData() ?? '').includes('bookmarkAndPersonSave')
+        ) {
           sawAccountWrite = true;
           await route.abort();
+          return;
         }
-      );
+        await route.fallback();
+      });
       for (const url of GOOGLE_LOGOUT_TABS) {
         await context.route(`${url}**`, async (route) => {
           await route.fulfill({ contentType: 'text/html', body: '' });
@@ -70,12 +74,14 @@ const withSignedInProfile = async (
           sawAccountWrite: () => sawAccountWrite,
         });
       } finally {
-        // In a finally so a failing assertion above still surfaces the write by
-        // name, rather than leaving only the symptom it caused
-        expect(
-          sawAccountWrite,
-          'logout tried to write the shared test account'
-        ).toBe(false);
+        // Soft, because throwing from a finally replaces whatever failure the
+        // body was already reporting
+        expect
+          .soft(
+            sawAccountWrite,
+            'logout tried to write the shared test account'
+          )
+          .toBe(false);
       }
     }
   );

--- a/apps/extension/tests/specs/background-messages.spec.ts
+++ b/apps/extension/tests/specs/background-messages.spec.ts
@@ -1,7 +1,7 @@
 import { TEST_SITES, TEST_TIMEOUTS } from '@bypass/shared/tests';
 import { type Page } from '@playwright/test';
 
-import { EExtStorageKey, POPUP_HOMEPAGE } from '@/constants';
+import { EExtStorageKey } from '@/constants';
 import {
   type RuntimeInput,
   type RuntimeKeys,
@@ -160,6 +160,10 @@ test.describe('Forum button', () => {
   }) => {
     const synced = await sharedBackground.readStorage('websites');
     const { context } = sharedBackground;
+    const forumRoute = `https://${FORUM_HOST}/**`;
+    // Snapshotted, because the click opens a tab we never get a handle on and
+    // this profile is worker scoped -- everything new here is ours to clean up
+    const pagesBefore = new Set(context.pages());
     try {
       await sharedBackground.writeStorage({
         websites: { FORUM_1: FORUM_HOST },
@@ -172,7 +176,7 @@ test.describe('Forum button', () => {
        */
       const popup = await sharedBackground.openPopup();
       // Keep the tab the click opens off the network
-      await context.route(`https://${FORUM_HOST}/**`, async (route) => {
+      await context.route(forumRoute, async (route) => {
         await route.fulfill({ contentType: 'text/html', body: '' });
       });
 
@@ -191,16 +195,11 @@ test.describe('Forum button', () => {
       ).toBeVisible();
     } finally {
       await sharedBackground.writeStorage({ websites: synced ?? {} });
-      // Swept by host because the click opens a tab we never get a handle on,
-      // and this profile is worker scoped and outlives the test
+      await context.unroute(forumRoute);
       await Promise.all(
         context
           .pages()
-          .filter(
-            (page) =>
-              page.url().includes(FORUM_HOST) ||
-              page.url().includes(POPUP_HOMEPAGE)
-          )
+          .filter((page) => !pagesBefore.has(page))
           .map((page) => page.close())
       );
     }

--- a/apps/extension/tests/specs/background-messages.spec.ts
+++ b/apps/extension/tests/specs/background-messages.spec.ts
@@ -1,7 +1,7 @@
 import { TEST_SITES, TEST_TIMEOUTS } from '@bypass/shared/tests';
 import { type Page } from '@playwright/test';
 
-import { EExtStorageKey } from '@/constants';
+import { EExtStorageKey, POPUP_HOMEPAGE } from '@/constants';
 import {
   type RuntimeInput,
   type RuntimeKeys,
@@ -159,6 +159,7 @@ test.describe('Forum button', () => {
     sharedBackground,
   }) => {
     const synced = await sharedBackground.readStorage('websites');
+    const { context } = sharedBackground;
     try {
       await sharedBackground.writeStorage({
         websites: { FORUM_1: FORUM_HOST },
@@ -170,6 +171,11 @@ test.describe('Forum button', () => {
        * the popup itself in front.
        */
       const popup = await sharedBackground.openPopup();
+      // Keep the tab the click opens off the network
+      await context.route(`https://${FORUM_HOST}/**`, async (route) => {
+        await route.fulfill({ contentType: 'text/html', body: '' });
+      });
+
       await sharedBackground.openFixturePage(
         `https://${FORUM_HOST}/`,
         UNREAD_ROWS_HTML
@@ -185,6 +191,18 @@ test.describe('Forum button', () => {
       ).toBeVisible();
     } finally {
       await sharedBackground.writeStorage({ websites: synced ?? {} });
+      // Swept by host because the click opens a tab we never get a handle on,
+      // and this profile is worker scoped and outlives the test
+      await Promise.all(
+        context
+          .pages()
+          .filter(
+            (page) =>
+              page.url().includes(FORUM_HOST) ||
+              page.url().includes(POPUP_HOMEPAGE)
+          )
+          .map((page) => page.close())
+      );
     }
   });
 });

--- a/apps/extension/tests/specs/person-select.spec.ts
+++ b/apps/extension/tests/specs/person-select.spec.ts
@@ -60,15 +60,19 @@ test.describe('Tagging a bookmark with a person', () => {
 
     await expect(options).not.toHaveCount(0);
     const byRecency = await options.allTextContents();
+    const alphabetical = byRecency.toSorted((left, right) =>
+      left.localeCompare(right)
+    );
+
+    expect(
+      byRecency,
+      'the account lists persons alphabetically already, so toggling the sort proves nothing'
+    ).not.toEqual(alphabetical);
 
     await recencySwitch.click();
 
-    // The order assertion alone can hold vacuously when recency already matches
-    // alphabetical, so pin that the toggle itself actually flipped
     await expect(recencySwitch).not.toBeChecked();
-    await expect(options).toHaveText(
-      byRecency.toSorted((left, right) => left.localeCompare(right))
-    );
+    await expect(options).toHaveText(alphabetical);
   });
 
   test('previews a person behind their avatar', async ({ bookmarksPage }) => {

--- a/apps/extension/tests/specs/search-hotkey.spec.ts
+++ b/apps/extension/tests/specs/search-hotkey.spec.ts
@@ -16,6 +16,9 @@ test.afterEach(async ({ personsPage }) => {
 test.describe('Search hotkey', () => {
   test('focuses the panel search', async ({ personsPage }) => {
     const panel = new PersonsPanel(personsPage);
+    // The hotkey proves nothing if the search is already focused
+    await expect(panel.getSearchInput()).toBeVisible();
+    await expect(panel.getSearchInput()).not.toBeFocused();
 
     await personsPage.keyboard.press('ControlOrMeta+f');
 
@@ -30,7 +33,8 @@ test.describe('Search hotkey', () => {
     // Waited for first: a negative assertion on an unattached locator passes
     // instantly, which would let the key press land before the modal exists
     await expect(panel.getModalSearchInput()).toBeVisible();
-    // The dialog moves focus into itself on open, so prove it did not land here
+
+    await expect(panel.getFocusedBookmarksDialog()).toBeAttached();
     await expect(panel.getModalSearchInput()).not.toBeFocused();
 
     await personsPage.keyboard.press('ControlOrMeta+f');

--- a/apps/extension/tests/utils/persons-panel.ts
+++ b/apps/extension/tests/utils/persons-panel.ts
@@ -272,6 +272,11 @@ export class PersonsPanel {
     return this.page.getByPlaceholder('Search');
   }
 
+  /** The dialog autofocuses itself asynchronously; wait for that to land. */
+  getFocusedBookmarksDialog() {
+    return this.getBookmarksDialog().and(this.page.locator(':focus-within'));
+  }
+
   /** Scoped, because the panel's own search matches the same placeholder. */
   getModalSearchInput() {
     return this.getBookmarksDialog().getByPlaceholder('Search');

--- a/apps/web/tests/page-object-models/persons-panel.ts
+++ b/apps/web/tests/page-object-models/persons-panel.ts
@@ -13,8 +13,12 @@ const MODAL_TEST_ID = 'bookmarks-list-modal';
 export class PersonsPanel {
   constructor(readonly page: Page) {}
 
+  getPersonItems(): Locator {
+    return this.page.locator('[data-testid^="person-item-"]');
+  }
+
   async getPersonCount(): Promise<number> {
-    return this.page.locator('[data-testid^="person-item-"]').count();
+    return this.getPersonItems().count();
   }
 
   async getHeaderPersonCount(): Promise<number> {

--- a/apps/web/tests/page-object-models/persons-panel.ts
+++ b/apps/web/tests/page-object-models/persons-panel.ts
@@ -130,8 +130,7 @@ export class PersonsPanel {
   }
 
   async getPersonNames(): Promise<string[]> {
-    const personCards = this.page.locator('[data-testid^="person-item-"]');
-    const names = await personCards.allTextContents();
+    const names = await this.getPersonItems().allTextContents();
     return names.map((name) => name.trim());
   }
 

--- a/apps/web/tests/specs/persons.spec.ts
+++ b/apps/web/tests/specs/persons.spec.ts
@@ -208,33 +208,32 @@ test.describe('Persons Panel', () => {
    * page would stay wide. Resizing the page itself is what crosses the
    * breakpoint, dropping the grid from five columns to three.
    */
-  test('should wrap the grid onto a second row on a narrow viewport', async ({
+  test('should drop grid columns on a narrow viewport', async ({
     authenticatedPage,
   }) => {
-    const countRenderedRows = async () => {
-      const offsets = await authenticatedPage
-        .locator('[data-testid^="person-item-"]')
+    const panel = new PersonsPanel(authenticatedPage);
+    // Columns, not rows: min(persons, 5) against min(persons, 3) always drops,
+    // where row counts tie at exactly six persons
+    const countRenderedColumns = async () => {
+      const offsets = await panel
+        .getPersonItems()
         .evaluateAll((cards) =>
-          cards.map((card) => Math.round(card.getBoundingClientRect().y))
+          cards.map((card) => Math.round(card.getBoundingClientRect().x))
         );
       return new Set(offsets).size;
     };
 
-    // Wrapping is only observable with more persons than the narrow column
-    // count, so say so here rather than failing later on a puzzling row compare
-    const panel = new PersonsPanel(authenticatedPage);
     expect(
       await panel.getPersonCount(),
-      'the grid needs more than three persons to wrap on a narrow viewport'
+      'the grid needs more than three persons to drop a column when narrowed'
     ).toBeGreaterThan(3);
 
-    // Polled, not read once: the grid only lays out after its width is measured
-    await expect.poll(countRenderedRows).toBeGreaterThan(0);
-    const wideRows = await countRenderedRows();
+    // Settles on a full row, not the first card to land
+    await expect.poll(countRenderedColumns).toBeGreaterThan(3);
+    const wideColumns = await countRenderedColumns();
 
     await authenticatedPage.setViewportSize({ width: 700, height: 900 });
 
-    // Relative, so the assertion survives the account gaining or losing a person
-    await expect.poll(countRenderedRows).toBeGreaterThan(wideRows);
+    await expect.poll(countRenderedColumns).toBeLessThan(wideColumns);
   });
 });


### PR DESCRIPTION
Follow-up to the seven-phase E2E coverage stack (#4156–#4162). Those PRs collected review comments from Kody and cubic that were deliberately deferred rather than pushed, because every push re-triggered the AI reviewers across the whole stack. This PR addresses all of them in one place, post-merge.

## What changed

**`apps/extension/tests/specs/auth-lifecycle.spec.ts`**
- The shared-account write guard matched on the request path only. tRPC's `httpBatchLink` batches procedures into one request and the pathname names only the first, so a batched `bookmarkAndPersonSave` slipped past. Now matched on url *or* post body.
- The guard assertion moved to `expect.soft` — it runs in a `finally`, and a hard throw there replaces whatever failure the test body was already reporting.

**`apps/extension/tests/specs/background-messages.spec.ts`**
- The Forum-button click opens a tab we never get a handle on. On a worker-scoped profile that tab outlived the test. Now swept by host in the `finally`, along with the popup.
- `context` exposed on `BaseBackgroundEnv` rather than reached for indirectly.

**`apps/extension/tests/specs/search-hotkey.spec.ts`**
- Asserts the search input is *not* already focused before pressing the hotkey; otherwise the test passes whether or not the hotkey works.
- Waits for the dialog's async autofocus via a `getFocusedBookmarksDialog()` POM helper instead of racing it.

**`apps/extension/tests/specs/person-select.spec.ts`**
- Fails with a clear message if the account's persons happen to already be alphabetical, in which case toggling the sort proves nothing.

**`apps/web/tests/specs/persons.spec.ts`**
- Renamed to match what it asserts — it measures a column drop, not a row wrap.
- The settle poll waited for `> 0` columns, which could catch a partially-populated grid and capture `wideColumns` too low. Now waits for a full row.
- Person-item locator extracted to the POM.

## Verification

```
pnpm lint && pnpm format:check && pnpm typecheck:all   ✅
pnpm e2e search-hotkey person-select auth-lifecycle background-messages   16 passed
pnpm e2e apps/web/tests/specs/persons.spec.ts          10 passed
```

No production code touched — tests and test helpers only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

 

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["test(e2e): unroute the forum stub and re..."](https://github.com/amitsingh-007/bypass-links/commit/7007d145a4a0e698b51fd63443e98e2a2082f7f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53570609)</sub>

<!-- /greptile_comment -->