### PR TITLE
test(e2e): adopt Playwright 1.62 WebStorage, ARIA snapshots and test.step

### DIFF
--- a/.agents/skills/e2e-test-generation/SKILL.md
+++ b/.agents/skills/e2e-test-generation/SKILL.md
@@ -74,7 +74,9 @@ I will ask clarifying questions if:
 
 - **Test constants**: Reuse `@bypass/shared/tests` constants first; keep local constants scoped to a spec when needed
 - **Group tests**: Only use `test.describe` for 2+ tests
-- **Steps**: Use `test.step` when a test has 3+ distinct phases or loops over cases; do not wrap single POM calls, and let the step title replace the phase comment
+- **Steps**: Use `test.step` when a test has 3+ distinct phases or loops over cases; let the step title replace the phase comment
+  - Never wrap POM methods as steps, and never use `box: true` — both hide which inner action failed, which is all a CI log line gives you
+  - A step must not be the thing that produces values for later steps; read them flat beforehand
 - **Test names**: Use clear names that describe behavior under test
 - **Determinism**: Prefer explicit waits on visible UI state over brittle timing assumptions
 - **Clear comments**: Explain "why", not "what"

--- a/.agents/skills/e2e-test-generation/SKILL.md
+++ b/.agents/skills/e2e-test-generation/SKILL.md
@@ -74,6 +74,7 @@ I will ask clarifying questions if:
 
 - **Test constants**: Reuse `@bypass/shared/tests` constants first; keep local constants scoped to a spec when needed
 - **Group tests**: Only use `test.describe` for 2+ tests
+- **Steps**: Use `test.step` when a test has 3+ distinct phases or loops over cases; do not wrap single POM calls, and let the step title replace the phase comment
 - **Test names**: Use clear names that describe behavior under test
 - **Determinism**: Prefer explicit waits on visible UI state over brittle timing assumptions
 - **Clear comments**: Explain "why", not "what"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,13 @@ Playwright tests use setup/teardown projects for both web and extension flows:
 5. **@bypass/extension** (`apps/extension/tests/specs/`) - Parallel extension tests using cached authenticated profile
 6. **extension-teardown** (`apps/extension/tests/global-teardown.ts`) - Cleans up `.playwright/.cache` after extension tests complete
 
+Every run writes an HTML report. Open it to inspect failures, attachments and
+the **Speedboard** tab, which ranks every test by duration:
+
+```bash
+pnpm exec playwright show-report .playwright/playwright-report
+```
+
 ## Key Technologies
 
 - **Frontend**: React, Next.js (web)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ pnpm typecheck:all    # Type check all workspaces
 
 # Testing
 pnpm e2e              # Run Playwright E2E tests
+pnpm e2e:report       # Open the HTML report; its Speedboard tab ranks tests by duration
 ```
 
 ## Architecture
@@ -67,13 +68,6 @@ Playwright tests use setup/teardown projects for both web and extension flows:
 4. **extension-setup** (`apps/extension/tests/auth.setup.ts`) - Runs once per test run to authenticate and cache the Chrome profile
 5. **@bypass/extension** (`apps/extension/tests/specs/`) - Parallel extension tests using cached authenticated profile
 6. **extension-teardown** (`apps/extension/tests/global-teardown.ts`) - Cleans up `.playwright/.cache` after extension tests complete
-
-Every run writes an HTML report. Open it to inspect failures, attachments and
-the **Speedboard** tab, which ranks every test by duration:
-
-```bash
-pnpm exec playwright show-report .playwright/playwright-report
-```
 
 ## Key Technologies
 

--- a/apps/extension/tests/specs/background-navigation.spec.ts
+++ b/apps/extension/tests/specs/background-navigation.spec.ts
@@ -243,12 +243,14 @@ test.describe.serial('Background Service Worker Navigation', () => {
     ];
 
     for (const invalidUrl of invalidUrls) {
-      const page = await sharedBackground.openTab(invalidUrl);
-      try {
-        await expect.poll(() => page.url()).not.toContain('html5test.com');
-      } finally {
-        await page.close();
-      }
+      await test.step(invalidUrl, async () => {
+        const page = await sharedBackground.openTab(invalidUrl);
+        try {
+          await expect.poll(() => page.url()).not.toContain('html5test.com');
+        } finally {
+          await page.close();
+        }
+      });
     }
 
     const historyStartTime = await sharedBackground.readStorage<number>(
@@ -263,12 +265,16 @@ test.describe.serial('Background Service Worker Navigation', () => {
     await sharedBackground.ensureActiveState();
 
     for (let attempt = 0; attempt < 3; attempt++) {
-      const page = await sharedBackground.openTab(TEST_SHORTCUTS.BROWSERTEST);
-      try {
-        await expect.poll(() => page.url()).toContain('https://html5test.com');
-      } finally {
-        await page.close();
-      }
+      await test.step(`attempt ${attempt + 1}`, async () => {
+        const page = await sharedBackground.openTab(TEST_SHORTCUTS.BROWSERTEST);
+        try {
+          await expect
+            .poll(() => page.url())
+            .toContain('https://html5test.com');
+        } finally {
+          await page.close();
+        }
+      });
     }
   });
 });

--- a/apps/extension/tests/specs/bookmark-editing.spec.ts
+++ b/apps/extension/tests/specs/bookmark-editing.spec.ts
@@ -31,7 +31,7 @@ test.describe('Bookmark multi-select', () => {
     await panel.selectBookmark(SECOND, { extend: true });
     await panel.openBookmarkContextMenu(SECOND);
 
-    await expect(bookmarksPage.getByRole('menu')).toMatchAriaSnapshot(`
+    await expect(panel.getContextMenu()).toMatchAriaSnapshot(`
       - menu:
         - /children: equal
         - menuitem "Open all (2) in new tab"

--- a/apps/extension/tests/specs/bookmark-editing.spec.ts
+++ b/apps/extension/tests/specs/bookmark-editing.spec.ts
@@ -31,12 +31,13 @@ test.describe('Bookmark multi-select', () => {
     await panel.selectBookmark(SECOND, { extend: true });
     await panel.openBookmarkContextMenu(SECOND);
 
-    await expect(panel.getContextMenuItem('open')).toHaveText(
-      'Open all (2) in new tab'
-    );
-    await expect(panel.getContextMenuItem('delete-all')).toBeVisible();
-    await expect(panel.getContextMenuItem('edit')).toBeHidden();
-    await expect(panel.getContextMenuItem('delete')).toBeHidden();
+    await expect(bookmarksPage.getByRole('menu')).toMatchAriaSnapshot(`
+      - menu:
+        - /children: equal
+        - menuitem "Open all (2) in new tab"
+        - menuitem "Cut"
+        - menuitem "Delete All"
+    `);
 
     await bookmarksPage.keyboard.press('Escape');
   });

--- a/apps/extension/tests/specs/bookmarks.spec.ts
+++ b/apps/extension/tests/specs/bookmarks.spec.ts
@@ -250,19 +250,13 @@ test.describe('Bookmarks Panel', () => {
       await panel.ensureAtRoot();
       await panel.openFolder(TEST_FOLDERS.MAIN);
 
-      // Get original URL and existing URL from another bookmark
-      const { originalUrl, existingUrl } =
-        await test.step('read the current urls', async () => {
-          await panel.openEditBookmarkDialog(TEST_BOOKMARKS.REACT_DOCS);
-          const original = await panel.getUrlInput().inputValue();
-          await panel.closeDialog();
+      await panel.openEditBookmarkDialog(TEST_BOOKMARKS.REACT_DOCS);
+      const originalUrl = await panel.getUrlInput().inputValue();
+      await panel.closeDialog();
 
-          await panel.openEditBookmarkDialog(TEST_BOOKMARKS.GITHUB);
-          const existing = await panel.getUrlInput().inputValue();
-          await panel.closeDialog();
-
-          return { originalUrl: original, existingUrl: existing };
-        });
+      await panel.openEditBookmarkDialog(TEST_BOOKMARKS.GITHUB);
+      const existingUrl = await panel.getUrlInput().inputValue();
+      await panel.closeDialog();
 
       await test.step('duplicate url is rejected', async () => {
         const duplicateDialog = await panel.editBookmarkUrl(
@@ -290,12 +284,10 @@ test.describe('Bookmarks Panel', () => {
       });
 
       await test.step('original url is restored', async () => {
-        const restoreDialog = await panel.openEditBookmarkDialog(
-          TEST_BOOKMARKS.REACT_DOCS
+        const restoreDialog = await panel.editBookmarkUrl(
+          TEST_BOOKMARKS.REACT_DOCS,
+          originalUrl
         );
-        await panel.getUrlInput().clear();
-        await panel.getUrlInput().fill(originalUrl);
-        await restoreDialog.getByTestId('dialog-save-button').click();
         await expect(restoreDialog).toBeHidden();
 
         await panel.verifyBookmarkExists(TEST_BOOKMARKS.REACT_DOCS);

--- a/apps/extension/tests/specs/bookmarks.spec.ts
+++ b/apps/extension/tests/specs/bookmarks.spec.ts
@@ -119,37 +119,41 @@ test.describe('Bookmarks Panel', () => {
       bookmarksPage,
     }) => {
       const panel = new BookmarksPanel(bookmarksPage);
-      await panel.ensureAtRoot();
-      await panel.openFolder(TEST_FOLDERS.MAIN);
-
-      // Add person tag
-      await panel.addPersonToBookmark(
-        TEST_BOOKMARKS.REACT_DOCS,
-        TEST_PERSONS.JOHN_NATHAN
-      );
-
-      // Verify in persons panel
-      await panel.navigateToPersonsPanel();
       const personsPanel = new PersonsPanel(bookmarksPage);
-      await personsPanel.verifyBookmarkInPersonList(
-        TEST_PERSONS.JOHN_NATHAN,
-        TEST_BOOKMARKS.REACT_DOCS
-      );
 
-      // Remove person tag
-      await panel.ensureAtRoot();
-      await panel.openFolder(TEST_FOLDERS.MAIN);
-      await panel.removePersonFromBookmark(
-        TEST_BOOKMARKS.REACT_DOCS,
-        TEST_PERSONS.JOHN_NATHAN
-      );
+      await test.step('tag the bookmark', async () => {
+        await panel.ensureAtRoot();
+        await panel.openFolder(TEST_FOLDERS.MAIN);
+        await panel.addPersonToBookmark(
+          TEST_BOOKMARKS.REACT_DOCS,
+          TEST_PERSONS.JOHN_NATHAN
+        );
+      });
 
-      // Verify removal in persons panel
-      await panel.navigateToPersonsPanel();
-      await personsPanel.verifyBookmarkNotInPersonList(
-        TEST_PERSONS.JOHN_NATHAN,
-        TEST_BOOKMARKS.REACT_DOCS
-      );
+      await test.step('tag shows in persons panel', async () => {
+        await panel.navigateToPersonsPanel();
+        await personsPanel.verifyBookmarkInPersonList(
+          TEST_PERSONS.JOHN_NATHAN,
+          TEST_BOOKMARKS.REACT_DOCS
+        );
+      });
+
+      await test.step('untag the bookmark', async () => {
+        await panel.ensureAtRoot();
+        await panel.openFolder(TEST_FOLDERS.MAIN);
+        await panel.removePersonFromBookmark(
+          TEST_BOOKMARKS.REACT_DOCS,
+          TEST_PERSONS.JOHN_NATHAN
+        );
+      });
+
+      await test.step('tag is gone from persons panel', async () => {
+        await panel.navigateToPersonsPanel();
+        await personsPanel.verifyBookmarkNotInPersonList(
+          TEST_PERSONS.JOHN_NATHAN,
+          TEST_BOOKMARKS.REACT_DOCS
+        );
+      });
 
       await panel.ensureAtRoot();
     });
@@ -247,46 +251,55 @@ test.describe('Bookmarks Panel', () => {
       await panel.openFolder(TEST_FOLDERS.MAIN);
 
       // Get original URL and existing URL from another bookmark
-      await panel.openEditBookmarkDialog(TEST_BOOKMARKS.REACT_DOCS);
-      const originalUrl = await panel.getUrlInput().inputValue();
-      await panel.closeDialog();
+      const { originalUrl, existingUrl } =
+        await test.step('read the current urls', async () => {
+          await panel.openEditBookmarkDialog(TEST_BOOKMARKS.REACT_DOCS);
+          const original = await panel.getUrlInput().inputValue();
+          await panel.closeDialog();
 
-      await panel.openEditBookmarkDialog(TEST_BOOKMARKS.GITHUB);
-      const existingUrl = await panel.getUrlInput().inputValue();
-      await panel.closeDialog();
+          await panel.openEditBookmarkDialog(TEST_BOOKMARKS.GITHUB);
+          const existing = await panel.getUrlInput().inputValue();
+          await panel.closeDialog();
 
-      // Test 1: Prevent duplicate URL
-      const duplicateDialog = await panel.editBookmarkUrl(
-        TEST_BOOKMARKS.REACT_DOCS,
-        existingUrl
-      );
-      await panel.verifyErrorNotification(
-        'A bookmark with this URL already exists'
-      );
-      await expect(duplicateDialog).toBeVisible();
-      await panel.closeDialog();
+          return { originalUrl: original, existingUrl: existing };
+        });
 
-      // Test 2: Edit URL successfully and verify by opening
-      const newUrl = 'https://www.google.com/';
-      await panel.editBookmarkUrl(TEST_BOOKMARKS.REACT_DOCS, newUrl);
-
-      const newPage = await openNewPageFromAction(context, async () => {
-        await panel.openBookmarkByDoubleClick(TEST_BOOKMARKS.REACT_DOCS);
+      await test.step('duplicate url is rejected', async () => {
+        const duplicateDialog = await panel.editBookmarkUrl(
+          TEST_BOOKMARKS.REACT_DOCS,
+          existingUrl
+        );
+        await panel.verifyErrorNotification(
+          'A bookmark with this URL already exists'
+        );
+        await expect(duplicateDialog).toBeVisible();
+        await panel.closeDialog();
       });
-      expect(newPage.url()).toContain('google.com');
-      await newPage.close();
 
-      // Test 3: Restore original URL
-      const restoreDialog = await panel.openEditBookmarkDialog(
-        TEST_BOOKMARKS.REACT_DOCS
-      );
-      await panel.getUrlInput().clear();
-      await panel.getUrlInput().fill(originalUrl);
-      await restoreDialog.getByTestId('dialog-save-button').click();
-      await expect(restoreDialog).toBeHidden();
+      await test.step('edited url opens the new site', async () => {
+        await panel.editBookmarkUrl(
+          TEST_BOOKMARKS.REACT_DOCS,
+          'https://www.google.com/'
+        );
 
-      // Verify bookmark exists after restoration
-      await panel.verifyBookmarkExists(TEST_BOOKMARKS.REACT_DOCS);
+        const newPage = await openNewPageFromAction(context, async () => {
+          await panel.openBookmarkByDoubleClick(TEST_BOOKMARKS.REACT_DOCS);
+        });
+        expect(newPage.url()).toContain('google.com');
+        await newPage.close();
+      });
+
+      await test.step('original url is restored', async () => {
+        const restoreDialog = await panel.openEditBookmarkDialog(
+          TEST_BOOKMARKS.REACT_DOCS
+        );
+        await panel.getUrlInput().clear();
+        await panel.getUrlInput().fill(originalUrl);
+        await restoreDialog.getByTestId('dialog-save-button').click();
+        await expect(restoreDialog).toBeHidden();
+
+        await panel.verifyBookmarkExists(TEST_BOOKMARKS.REACT_DOCS);
+      });
     });
   });
 
@@ -336,29 +349,30 @@ test.describe('Bookmarks Panel', () => {
     await panel.ensureAtRoot();
     await panel.openFolder(TEST_FOLDERS.MAIN);
 
-    // Test search by title
-    await fillSearchInput(bookmarksPage, 'ButtonGroup');
-    const titleFilteredBookmark = panel.getBookmarkElement(
-      TEST_BOOKMARKS.GITHUB
-    );
-    await expect(titleFilteredBookmark).toBeVisible();
-    await clearSearchInput(bookmarksPage);
+    await test.step('search by title', async () => {
+      await fillSearchInput(bookmarksPage, 'ButtonGroup');
+      await expect(
+        panel.getBookmarkElement(TEST_BOOKMARKS.GITHUB)
+      ).toBeVisible();
+      await clearSearchInput(bookmarksPage);
+    });
 
-    // Test search by URL
-    await fillSearchInput(bookmarksPage, 'material');
-    const urlFilteredBookmark = panel.getBookmarkElement(
-      TEST_BOOKMARKS.REACT_DOCS
-    );
-    await expect(urlFilteredBookmark).toBeVisible();
-    await clearSearchInput(bookmarksPage);
+    await test.step('search by url', async () => {
+      await fillSearchInput(bookmarksPage, 'material');
+      await expect(
+        panel.getBookmarkElement(TEST_BOOKMARKS.REACT_DOCS)
+      ).toBeVisible();
+      await clearSearchInput(bookmarksPage);
+    });
 
-    // Test folders remain visible during search
-    await panel.ensureAtRoot();
-    const folder = panel.getFolderElement(TEST_FOLDERS.MAIN);
-    await expect(folder).toBeVisible();
-    await fillSearchInput(bookmarksPage, 'nonexistentterm');
-    await expect(folder).toBeVisible();
-    await clearSearchInput(bookmarksPage);
+    await test.step('folders survive a non-matching search', async () => {
+      await panel.ensureAtRoot();
+      const folder = panel.getFolderElement(TEST_FOLDERS.MAIN);
+      await expect(folder).toBeVisible();
+      await fillSearchInput(bookmarksPage, 'nonexistentterm');
+      await expect(folder).toBeVisible();
+      await clearSearchInput(bookmarksPage);
+    });
   });
 
   test('should move bookmark using cut from context menu and paste', async ({

--- a/apps/extension/tests/specs/home-popup.spec.ts
+++ b/apps/extension/tests/specs/home-popup.spec.ts
@@ -4,9 +4,9 @@ import { expect, test } from '../fixtures/extension-fixture';
 
 test.describe('Home Popup', () => {
   /**
-   * The signed-out shell is snapshotted rather than asserted button by button:
-   * every action gates its own `disabled` on the auth state, so one tree is what
-   * catches a control that stays enabled for a signed-out user.
+   * One tree instead of eight assertions: every action gates its own `disabled`
+   * on the auth state independently, so this is what catches one of them going
+   * enabled while signed out.
    */
   test('load extension', async ({ page }) => {
     await page.goto(POPUP_HOMEPAGE);
@@ -20,6 +20,8 @@ test.describe('Home Popup', () => {
       - button "Login"
       - button "Defaults" [disabled]
       - button "Shortcuts" [disabled]
+      # Nested button: TooltipTrigger renders its own, and only the inner one is
+      # disabled. A defect, recorded so fixing it shows up here.
       - button "Pin":
         - button "Pin" [disabled]
       - button "Persons" [disabled]

--- a/apps/extension/tests/specs/home-popup.spec.ts
+++ b/apps/extension/tests/specs/home-popup.spec.ts
@@ -3,9 +3,30 @@ import { POPUP_HOMEPAGE } from '@/constants';
 import { expect, test } from '../fixtures/extension-fixture';
 
 test.describe('Home Popup', () => {
+  /**
+   * The signed-out shell is snapshotted rather than asserted button by button:
+   * every action gates its own `disabled` on the auth state, so one tree is what
+   * catches a control that stays enabled for a signed-out user.
+   */
   test('load extension', async ({ page }) => {
     await page.goto(POPUP_HOMEPAGE);
-    // Content script loaded
-    await expect(page.getByTestId('home-popup-heading')).toBeVisible();
+
+    await expect(page.locator('body')).toMatchAriaSnapshot(`
+      - text: Bypass Links
+      - switch "Enable" [checked]
+      - text: Enable
+      - switch
+      - text: History
+      - button "Login"
+      - button "Defaults" [disabled]
+      - button "Shortcuts" [disabled]
+      - button "Pin":
+        - button "Pin" [disabled]
+      - button "Persons" [disabled]
+      - button "Bookmarks" [disabled]
+      - button "Forum" [disabled]
+      - button "Visited":
+        - button "Visited" [disabled]
+    `);
   });
 });

--- a/apps/extension/tests/specs/shortcuts.spec.ts
+++ b/apps/extension/tests/specs/shortcuts.spec.ts
@@ -143,42 +143,37 @@ test.describe('Shortcuts Panel', () => {
 
     await panel.waitForLoading();
 
-    // Get the first alias input
     const firstAliasInput = panel.getAliasInputs().first();
-    const originalValue = await firstAliasInput.inputValue();
-
-    // Edit the alias
-    await firstAliasInput.clear();
-    await firstAliasInput.fill('edited-alias');
-
-    // Click the row save button
-    const firstRuleSaveButton = shortcutsPage.getByTestId('rule-0-save');
-    await firstRuleSaveButton.click();
-
-    // Verify the new value is persisted
-    await expect(firstAliasInput).toHaveValue('edited-alias');
-
-    // Reset for other tests
-    await firstAliasInput.clear();
-    await firstAliasInput.fill(originalValue);
-    await firstRuleSaveButton.click();
-
-    // Verify reset value persisted
-    await expect(firstAliasInput).toHaveValue(originalValue);
-
-    // Edit the website
     const firstWebsiteInput = panel.getWebsiteInputs().first();
+    const firstRuleSaveButton = shortcutsPage.getByTestId('rule-0-save');
+    const originalValue = await firstAliasInput.inputValue();
     const originalWebsite = await firstWebsiteInput.inputValue();
-    await firstWebsiteInput.fill('https://example.com');
-    await firstRuleSaveButton.click();
 
-    // Verify the new value is persisted
-    await expect(firstWebsiteInput).toHaveValue('https://example.com');
+    await test.step('edit alias', async () => {
+      await firstAliasInput.clear();
+      await firstAliasInput.fill('edited-alias');
+      await firstRuleSaveButton.click();
+      await expect(firstAliasInput).toHaveValue('edited-alias');
+    });
 
-    // Reset website for other tests
-    await firstWebsiteInput.fill(originalWebsite);
-    await firstRuleSaveButton.click();
-    await expect(firstWebsiteInput).toHaveValue(originalWebsite);
+    await test.step('restore alias', async () => {
+      await firstAliasInput.clear();
+      await firstAliasInput.fill(originalValue);
+      await firstRuleSaveButton.click();
+      await expect(firstAliasInput).toHaveValue(originalValue);
+    });
+
+    await test.step('edit website', async () => {
+      await firstWebsiteInput.fill('https://example.com');
+      await firstRuleSaveButton.click();
+      await expect(firstWebsiteInput).toHaveValue('https://example.com');
+    });
+
+    await test.step('restore website', async () => {
+      await firstWebsiteInput.fill(originalWebsite);
+      await firstRuleSaveButton.click();
+      await expect(firstWebsiteInput).toHaveValue(originalWebsite);
+    });
   });
 
   test('should reorder rules up and down', async ({ shortcutsPage }) => {

--- a/apps/extension/tests/specs/toggle-history.spec.ts
+++ b/apps/extension/tests/specs/toggle-history.spec.ts
@@ -60,7 +60,10 @@ test.describe('History Tracking Workflow', () => {
         await newPage.close();
       }
 
-      expect(await getHistoryItems(homePage, sites)).not.toHaveLength(0);
+      const visited = await getHistoryItems(homePage, sites);
+      expect(
+        sites.filter((site) => visited.some((item) => item.url?.includes(site)))
+      ).toEqual(sites);
     });
 
     await test.step('disable tracking', async () => {

--- a/apps/extension/tests/specs/toggle-history.spec.ts
+++ b/apps/extension/tests/specs/toggle-history.spec.ts
@@ -53,15 +53,14 @@ test.describe('History Tracking Workflow', () => {
       await expect(homePanel.historyToggle).toBeChecked();
     });
 
-    await test.step('visit the test sites', async () => {
+    await test.step('visits land in history', async () => {
       for (const site of sites) {
         const newPage = await context.newPage();
         await newPage.goto(site, { waitUntil: 'domcontentloaded' });
         await newPage.close();
       }
 
-      const historyBefore = await getHistoryItems(homePage, sites);
-      expect(historyBefore.length).toBeGreaterThan(0);
+      expect(await getHistoryItems(homePage, sites)).not.toHaveLength(0);
     });
 
     await test.step('disable tracking', async () => {

--- a/apps/extension/tests/specs/toggle-history.spec.ts
+++ b/apps/extension/tests/specs/toggle-history.spec.ts
@@ -48,43 +48,42 @@ test.describe('History Tracking Workflow', () => {
       TEST_SITES.EXAMPLE_NET,
     ];
 
-    // Ensure tracking is enabled for this test run.
-    await homePanel.setHistoryEnabled(true);
-    await expect(homePanel.historyToggle).toBeChecked();
+    await test.step('enable tracking', async () => {
+      await homePanel.setHistoryEnabled(true);
+      await expect(homePanel.historyToggle).toBeChecked();
+    });
 
-    // Visit each site in a new tab
-    for (const site of sites) {
-      const newPage = await context.newPage();
-      await newPage.goto(site, { waitUntil: 'domcontentloaded' });
-      await newPage.close();
-    }
+    await test.step('visit the test sites', async () => {
+      for (const site of sites) {
+        const newPage = await context.newPage();
+        await newPage.goto(site, { waitUntil: 'domcontentloaded' });
+        await newPage.close();
+      }
 
-    // Verify the sites are in browser history
-    const historyBefore = await getHistoryItems(homePage, sites);
-    expect(historyBefore.length).toBeGreaterThan(0);
+      const historyBefore = await getHistoryItems(homePage, sites);
+      expect(historyBefore.length).toBeGreaterThan(0);
+    });
 
-    // Turn off history tracking
-    await homePanel.setHistoryEnabled(false);
+    await test.step('disable tracking', async () => {
+      await homePanel.setHistoryEnabled(false);
+      await expect(homePanel.historyToggle).not.toBeChecked();
+      await homePanel.verifyHistoryStartTimeNotExists();
+    });
 
-    // Verify switch is now unchecked
-    await expect(homePanel.historyToggle).not.toBeChecked();
-
-    // Verify historyStartTime is removed from storage
-    await homePanel.verifyHistoryStartTimeNotExists();
-
-    // Verify the test sites are deleted from browser history (with retry)
-    await expect
-      .poll(
-        async () => {
-          const historyAfter = await getHistoryItems(homePage, sites);
-          return historyAfter.length;
-        },
-        {
-          message: 'History items should be deleted',
-          timeout: 15_000,
-        }
-      )
-      .toBe(0);
+    await test.step('tracked history is deleted', async () => {
+      await expect
+        .poll(
+          async () => {
+            const historyAfter = await getHistoryItems(homePage, sites);
+            return historyAfter.length;
+          },
+          {
+            message: 'History items should be deleted',
+            timeout: 15_000,
+          }
+        )
+        .toBe(0);
+    });
   });
 
   test('should turn on history tracking when a bookmark is opened', async ({

--- a/apps/extension/tests/specs/toggle-history.spec.ts
+++ b/apps/extension/tests/specs/toggle-history.spec.ts
@@ -60,10 +60,21 @@ test.describe('History Tracking Workflow', () => {
         await newPage.close();
       }
 
-      const visited = await getHistoryItems(homePage, sites);
-      expect(
-        sites.filter((site) => visited.some((item) => item.url?.includes(site)))
-      ).toEqual(sites);
+      // Chrome commits visits asynchronously, so the same poll the deletion step needs
+      await expect
+        .poll(
+          async () => {
+            const visited = await getHistoryItems(homePage, sites);
+            return sites.filter((site) =>
+              visited.some((item) => item.url?.includes(site))
+            );
+          },
+          {
+            message: 'Every visited site should be tracked',
+            timeout: 15_000,
+          }
+        )
+        .toEqual(sites);
     });
 
     await test.step('disable tracking', async () => {

--- a/apps/extension/tests/utils/bookmarks-panel.ts
+++ b/apps/extension/tests/utils/bookmarks-panel.ts
@@ -243,6 +243,10 @@ export class BookmarksPanel {
     return this.page.locator('[data-testid^="bookmark-item-"]');
   }
 
+  getContextMenu() {
+    return this.page.getByRole('menu');
+  }
+
   getContextMenuItem(itemId: string) {
     return this.page.getByTestId(`context-menu-item-${itemId}`);
   }

--- a/apps/web/tests/auth.setup.ts
+++ b/apps/web/tests/auth.setup.ts
@@ -66,13 +66,11 @@ setup('authenticate and cache web storage', async ({}, testInfo) => {
     timeout: TEST_TIMEOUTS.AUTH,
   });
 
-  await page.waitForFunction(
-    () => {
-      const bookmarks = localStorage.getItem('bookmarks');
-      return bookmarks !== null;
-    },
-    { timeout: TEST_TIMEOUTS.AUTH }
-  );
+  await expect
+    .poll(async () => page.localStorage.getItem('bookmarks'), {
+      timeout: TEST_TIMEOUTS.AUTH,
+    })
+    .not.toBeNull();
 
   const localStorageData = await dumpLocalStorage(page);
 

--- a/apps/web/tests/auth.setup.ts
+++ b/apps/web/tests/auth.setup.ts
@@ -67,7 +67,7 @@ setup('authenticate and cache web storage', async ({}, testInfo) => {
   });
 
   await expect
-    .poll(async () => page.localStorage.getItem('bookmarks'), {
+    .poll(() => page.localStorage.getItem('bookmarks'), {
       timeout: TEST_TIMEOUTS.AUTH,
     })
     .not.toBeNull();

--- a/apps/web/tests/specs/bookmarks.spec.ts
+++ b/apps/web/tests/specs/bookmarks.spec.ts
@@ -76,29 +76,31 @@ test.describe('Bookmarks Panel', () => {
     const countBefore = await panel.getBookmarkCount();
     const rootBadgeCount = await panel.getBadgeCount();
 
-    // Search by title
-    await fillSearchInput(authenticatedPage, 'ButtonGroup');
-    await panel.verifyBookmarkExists(TEST_BOOKMARKS.GITHUB);
+    await test.step('search by title', async () => {
+      await fillSearchInput(authenticatedPage, 'ButtonGroup');
+      await panel.verifyBookmarkExists(TEST_BOOKMARKS.GITHUB);
+    });
 
-    // Clear and search by URL
-    await clearSearchInput(authenticatedPage);
-    await fillSearchInput(authenticatedPage, 'material');
-    await panel.verifyBookmarkExists(TEST_BOOKMARKS.REACT_DOCS);
+    await test.step('search by url', async () => {
+      await clearSearchInput(authenticatedPage);
+      await fillSearchInput(authenticatedPage, 'material');
+      await panel.verifyBookmarkExists(TEST_BOOKMARKS.REACT_DOCS);
+    });
 
-    // Clear and verify count restored
-    await clearSearchInput(authenticatedPage);
-    await expect(async () => {
-      const countAfter = await panel.getBookmarkCount();
-      expect(countAfter).toBe(countBefore);
-    }).toPass();
+    await test.step('clearing restores the full count', async () => {
+      await clearSearchInput(authenticatedPage);
+      await expect(async () => {
+        const countAfter = await panel.getBookmarkCount();
+        expect(countAfter).toBe(countBefore);
+      }).toPass();
+    });
 
-    // Search for React and verify badge count updates
-    await fillSearchInput(authenticatedPage, 'React');
-    const searchBadgeCount = await panel.getBadgeCount();
-    expect(searchBadgeCount).toBeLessThanOrEqual(rootBadgeCount);
-
-    // Clear search
-    await clearSearchInput(authenticatedPage);
+    await test.step('badge count narrows with the search', async () => {
+      await fillSearchInput(authenticatedPage, 'React');
+      const searchBadgeCount = await panel.getBadgeCount();
+      expect(searchBadgeCount).toBeLessThanOrEqual(rootBadgeCount);
+      await clearSearchInput(authenticatedPage);
+    });
   });
 
   test('should keep folders visible when searching and filter results', async ({

--- a/apps/web/tests/specs/bookmarks.spec.ts
+++ b/apps/web/tests/specs/bookmarks.spec.ts
@@ -79,10 +79,10 @@ test.describe('Bookmarks Panel', () => {
     await test.step('search by title', async () => {
       await fillSearchInput(authenticatedPage, 'ButtonGroup');
       await panel.verifyBookmarkExists(TEST_BOOKMARKS.GITHUB);
+      await clearSearchInput(authenticatedPage);
     });
 
     await test.step('search by url', async () => {
-      await clearSearchInput(authenticatedPage);
       await fillSearchInput(authenticatedPage, 'material');
       await panel.verifyBookmarkExists(TEST_BOOKMARKS.REACT_DOCS);
     });

--- a/apps/web/tests/specs/persons.spec.ts
+++ b/apps/web/tests/specs/persons.spec.ts
@@ -103,36 +103,37 @@ test.describe('Persons Panel', () => {
   }) => {
     const panel = new PersonsPanel(authenticatedPage);
 
-    // Open Donald's card and search for non-existent bookmark
-    await panel.openPersonCard(TEST_PERSONS.DONALD);
-    const countBefore = await panel.getBookmarkCountInModalFromList();
-    expect(countBefore).toBeGreaterThan(0);
+    await test.step(`${TEST_PERSONS.DONALD}: unknown query yields no results`, async () => {
+      await panel.openPersonCard(TEST_PERSONS.DONALD);
+      const countBefore = await panel.getBookmarkCountInModalFromList();
+      expect(countBefore).toBeGreaterThan(0);
 
-    await panel.searchWithinBookmarks('nonexistentbookmark123');
-    const noResultsMessage = panel.getNoBookmarksMessage();
-    await expect(noResultsMessage).toBeVisible();
+      await panel.searchWithinBookmarks('nonexistentbookmark123');
+      await expect(panel.getNoBookmarksMessage()).toBeVisible();
 
-    await panel.clearSearchWithinBookmarks();
-    await expect(async () => {
-      const countAfter = await panel.getBookmarkCountInModalFromList();
-      expect(countAfter).toBe(countBefore);
-    }).toPass();
+      await panel.clearSearchWithinBookmarks();
+      await expect(async () => {
+        const countAfter = await panel.getBookmarkCountInModalFromList();
+        expect(countAfter).toBe(countBefore);
+      }).toPass();
 
-    await panel.closeModal();
+      await panel.closeModal();
+    });
 
-    // Open John's card and filter by search
-    await panel.openPersonCard(TEST_PERSONS.JOHN_NATHAN);
-    const countBeforeJohn = await panel.getBookmarkCountInModalFromList();
-    expect(countBeforeJohn).toBeGreaterThan(0);
+    await test.step(`${TEST_PERSONS.JOHN_NATHAN}: query narrows the list`, async () => {
+      await panel.openPersonCard(TEST_PERSONS.JOHN_NATHAN);
+      const countBefore = await panel.getBookmarkCountInModalFromList();
+      expect(countBefore).toBeGreaterThan(0);
 
-    await panel.searchWithinBookmarks('React');
-    await expect(async () => {
-      const countAfter = await panel.getBookmarkCountInModalFromList();
-      expect(countAfter).toBeLessThanOrEqual(countBeforeJohn);
-    }).toPass();
+      await panel.searchWithinBookmarks('React');
+      await expect(async () => {
+        const countAfter = await panel.getBookmarkCountInModalFromList();
+        expect(countAfter).toBeLessThanOrEqual(countBefore);
+      }).toPass();
 
-    await panel.clearSearchWithinBookmarks();
-    await panel.closeModal();
+      await panel.clearSearchWithinBookmarks();
+      await panel.closeModal();
+    });
   });
 
   test('should navigate between multiple persons and back to list', async ({
@@ -140,30 +141,34 @@ test.describe('Persons Panel', () => {
   }) => {
     const panel = new PersonsPanel(authenticatedPage);
 
-    // Open John Nathan, verify, and close
-    await panel.openPersonCard(TEST_PERSONS.JOHN_NATHAN);
-    await panel.verifyModalVisible();
-    await panel.closeModal();
-    await panel.verifyModalClosed();
+    await test.step('open and close a person card', async () => {
+      await panel.openPersonCard(TEST_PERSONS.JOHN_NATHAN);
+      await panel.verifyModalVisible();
+      await panel.closeModal();
+      await panel.verifyModalClosed();
+    });
 
-    // Verify back on persons list
-    await expect(panel.getSearchInput()).toBeVisible();
-    await panel.verifyPersonExists(TEST_PERSONS.JOHN_NATHAN);
+    await test.step('lands back on the persons list', async () => {
+      await expect(panel.getSearchInput()).toBeVisible();
+      await panel.verifyPersonExists(TEST_PERSONS.JOHN_NATHAN);
+    });
 
-    // Open multiple persons sequentially
-    await panel.openPersonCard(TEST_PERSONS.JOHN_NATHAN);
-    await panel.verifyPersonNameInBadge(TEST_PERSONS.JOHN_NATHAN);
-    await panel.closeModal();
-    await panel.verifyModalClosed();
+    await test.step('open each person in turn', async () => {
+      for (const person of [
+        TEST_PERSONS.JOHN_NATHAN,
+        TEST_PERSONS.AKASH_KUMAR_SINGH,
+      ]) {
+        await panel.openPersonCard(person);
+        await panel.verifyPersonNameInBadge(person);
+        await panel.closeModal();
+        await panel.verifyModalClosed();
+      }
+    });
 
-    await panel.openPersonCard(TEST_PERSONS.AKASH_KUMAR_SINGH);
-    await panel.verifyPersonNameInBadge(TEST_PERSONS.AKASH_KUMAR_SINGH);
-    await panel.closeModal();
-    await panel.verifyModalClosed();
-
-    // Verify both persons still exist on list
-    await panel.verifyPersonExists(TEST_PERSONS.JOHN_NATHAN);
-    await panel.verifyPersonExists(TEST_PERSONS.AKASH_KUMAR_SINGH);
+    await test.step('both persons remain listed', async () => {
+      await panel.verifyPersonExists(TEST_PERSONS.JOHN_NATHAN);
+      await panel.verifyPersonExists(TEST_PERSONS.AKASH_KUMAR_SINGH);
+    });
   });
 
   test('should toggle recency switch and verify person order changes', async ({

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "turbo run dev",
     "env": "vercel env pull .env",
     "e2e": "playwright test",
+    "e2e:report": "playwright show-report .playwright/playwright-report",
     "lint": "oxlint --fix",
     "lint:ci": "oxlint",
     "format": "oxfmt",

--- a/packages/shared/src/utils/test-helpers.ts
+++ b/packages/shared/src/utils/test-helpers.ts
@@ -14,16 +14,9 @@ type TestIdScope = Pick<Page, 'getByTestId'>;
 export const dumpLocalStorage = async (
   page: Page
 ): Promise<Record<string, string>> =>
-  page.evaluate(() => {
-    const entries: Record<string, string> = {};
-    for (let i = 0; i < window.localStorage.length; i++) {
-      const key = window.localStorage.key(i);
-      if (key) {
-        entries[key] = window.localStorage.getItem(key) ?? '';
-      }
-    }
-    return entries;
-  });
+  Object.fromEntries(
+    (await page.localStorage.items()).map(({ name, value }) => [name, value])
+  );
 
 /** Seeds localStorage before any page script runs. */
 export const injectLocalStorage = async (


### PR DESCRIPTION
Closes parts of #4160.

Adopts the Playwright 1.62 capabilities the suite had never picked up. Four of
the five checklist items are done; the fifth is deliberately dropped (below).

## `page.localStorage` instead of `page.evaluate`

`dumpLocalStorage` hand-rolled the `window.localStorage` iteration in an in-page
closure. `page.localStorage.items()` runs the identical loop in the utility
world, so this is behaviour-identical — 13 lines become 4 — and it works on
`chrome-extension://` origins too. The `waitForFunction` on `localStorage.bookmarks`
in the web auth setup becomes `expect.poll`, which is typed and shows in the
trace as a named action rather than an opaque wait.

Everything else stays: `injectLocalStorage` and the two auth seeds are
`addInitScript` (no origin yet, and the app reads those keys during boot), and
the remaining `page.evaluate` calls are `chrome.*` APIs or DOM reads. No
`sessionStorage` exists anywhere in the suite.

## ARIA snapshots

Two places, both chosen because they were badly under-asserted:

- **`home-popup.spec.ts`** was one `toBeVisible` on a heading. It now snapshots
  the signed-out shell — all eight buttons and their `[disabled]` state.
  `PanelNavButton`, `Authenticate` and `QuickBookmarkButton` each gate `disabled`
  on the auth state independently, so one of them going enabled for a signed-out
  user was invisible to the suite. (Default `contain` semantics mean this pins
  the controls it lists; a newly added control would not fail it.)
- **`bookmark-editing.spec.ts`** replaces four assertions with one that is
  strictly stronger: `/children: equal` pins the item list, so an item wrongly
  appearing in multi-select mode is now caught.

Inline string snapshots rather than `.aria.yml` files — both trees are ~15 lines,
inline keeps the UI contract visible in the PR diff, and files would need
`expect.toMatchAriaSnapshot.pathTemplate` config to avoid an ugly
project-name-sanitised path.

**This surfaced a real defect**: the popup tree contains
`button "Pin" > button "Pin" [disabled]`, and the same for "Visited". Base UI's
`TooltipTrigger` renders its own `<button>` around ours, so these are nested
buttons — invalid HTML, and the *outer* one is not disabled. Recorded in the
snapshot — marked with a comment so it does not read as intended structure —
rather than papered over, so fixing it surfaces as a deliberate snapshot update.
Not fixed here; it is app source and outside this PR. The fix is one line per
call site (`<TooltipTrigger render={<Button … />}>`, already the idiom in
`packages/ui`) in `QuickBookmarkButton.tsx` and `LastVisitedButton.tsx`.

## `test.step`

31 steps across 10 tests in 6 spec files. Only tests that run 3+ distinct phases
or loop over cases get them; the step titles replace the phase comments rather
than sitting alongside.

POM methods are deliberately **not** wrapped. There are 92 of them, wrapping
re-indents every body for zero new assertions, and `{ box: true }` would
re-point errors at the call site — hiding which of a fat method's eight actions
actually failed, on a `github` reporter with `retries: 2` where that log line is
often all you get.

## Speedboard

No code. Speedboard ships in the 1.62 HTML report as a subnav tab, the config
already writes the report on every run, and CI already uploads it. The
capability was just undocumented, so `AGENTS.md` now points at it.

A pass over a full local run (117 passed / 70s wall clock / 251s summed):

| | Test |
|---|---|
| **42.3s** | `download-page` › chrome extension download |
| 10.4s | ext `persons` › delete the test person created earlier |
| 9.1s | ext `auth-lifecycle` › signs out when the extension is switched off |
| 8.3s / 8.2s | the two `auth.setup` projects |

One test is ~60% of wall clock: `download-page › chrome extension download`
clicks a link whose href is a **GitHub release asset URL**, so it waits on a real
external download, and `waitForEvent('download')` uses the default 10s timeout
rather than the 30s the test sets for itself. It fails locally for that reason —
on `main` as well as here. Worth a follow-up (explicit timeout, or stub the
release URL with `context.route`), but out of scope for this PR.

## Not done

`page.consoleMessages()` / `pageErrors()` / `requests()` was scoped and then
dropped as not worth the machinery for this suite — it needed a new shared
module plus a `test`-base swap across six fixture roots. That checkbox in #4160
is still open.

## Review pass

A four-angle cleanup review (reuse / simplification / efficiency / altitude) ran
over the whole branch; the last commit applies what it found. Highlights: the
url-restore step was hand-rolling `editBookmarkUrl`, one `test.step` existed only
to return values through a closure (now flat reads), the report path was
duplicated out of `playwright.config.ts` into prose (now a `pnpm e2e:report`
script), and the home-popup snapshot's docstring over-claimed given
`toMatchAriaSnapshot`'s default `contain` semantics.

The efficiency angle traced the WebStorage swap into Playwright's source and
confirmed `items()` is the same single round trip running the same in-page loop,
and that `expect.poll` here costs one round trip because the three assertions
before it have already settled.

## Test plan

- `pnpm lint`, `pnpm format:check`, `pnpm typecheck:all` — clean
- Full suite locally: 117 passed, 1 failed (the pre-existing `download-page`
  failure above, reproduced on `main`)
- ARIA strictness verified negatively: deleting `Cut` from the expectation makes
  it fail with a real aria diff, so `/children: equal` is not vacuous
- Steps verified present via the JSON reporter, since the `list` reporter never
  prints them and a green run alone would not show them

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

 

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (3): Last reviewed commit: ["test(e2e): poll the history assertion in..."](https://github.com/amitsingh-007/bypass-links/commit/4584b0b556c20fcf983d0409884f72ea13259af8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54406071)</sub>

<!-- /greptile_comment -->