### PR TITLE
fix(bookmarks): open the right-clicked bookmark from the context menu

### DIFF
--- a/apps/extension/src/entrypoints/popup/components/ContextMenu.tsx
+++ b/apps/extension/src/entrypoints/popup/components/ContextMenu.tsx
@@ -24,8 +24,12 @@ function ContextMenuWrapper({ options, children }: Props) {
   const idRef = useRef('');
 
   const handleContextMenu = (e: React.MouseEvent) => {
-    const dataCtxId = (e.target as HTMLElement).dataset.contextId ?? '';
-    idRef.current = dataCtxId;
+    // Nearest ancestor, not the target: a right-click landing on a row's favicon
+    // or avatars would otherwise resolve to no id at all
+    const target = (e.target as HTMLElement).closest<HTMLElement>(
+      '[data-context-id]'
+    );
+    idRef.current = target?.dataset.contextId ?? '';
   };
 
   return (

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarkContextMenu.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarkContextMenu.tsx
@@ -18,10 +18,10 @@ import { countTruthy } from '../utils';
 import { findBookmarkById } from '../utils/bookmark';
 
 type Props = PropsWithChildren<{
-  handleOpenSelectedBookmarks: VoidFunction;
+  handleOpenBookmarks: (id: string) => void;
 }>;
 
-function BookmarkContextMenu({ children, handleOpenSelectedBookmarks }: Props) {
+function BookmarkContextMenu({ children, handleOpenBookmarks }: Props) {
   const setBookmarkOperation = useBookmarkRouteStore(
     (state) => state.setBookmarkOperation
   );
@@ -80,7 +80,7 @@ function BookmarkContextMenu({ children, handleOpenSelectedBookmarks }: Props) {
   const getMenuOptions = (): IMenuOption[] => {
     const menuOptionsList: IMenuOption[] = [
       {
-        onClick: handleOpenSelectedBookmarks,
+        onClick: handleOpenBookmarks,
         text: `Open ${
           selectedCount > 1 ? `all (${selectedCount}) ` : ''
         }in new tab`,

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksPanel.tsx
@@ -17,6 +17,7 @@ import Panel from '@popup/components/Panel';
 
 import useBookmarkRouteStore from '../store/useBookmarkRouteStore';
 import useBookmarkStore from '../store/useBookmarkStore';
+import { countTruthy } from '../utils';
 import { findBookmarkById } from '../utils/bookmark';
 import BookmarkAddEditDialog from './BookmarkAddEditDialog';
 import BookmarkContextMenu from './BookmarkContextMenu';
@@ -64,23 +65,25 @@ function BookmarksPanel({ folderId, operation, bmUrl }: BMPanelQueryParams) {
   );
 
   /**
-   * The right-clicked bookmark wins unless several are selected: reading the
-   * store selection for a single open made the click a silent no-op whenever
-   * anything cleared the selection first.
+   * The right-clicked bookmark wins over the selection: reading the store
+   * selection for a single open made the click a silent no-op whenever anything
+   * cleared it first. The multi-open branch is gated on the same count the
+   * `Open all (N)` label uses, so the menu can never promise more than it opens,
+   * and it indexes the filtered list the selection positions actually came from.
    */
   const handleOpenBookmarks = (id: string) => {
     const { contextBookmarks: bookmarks, selectedBookmarks: selected } =
       useBookmarkStore.getState();
-    const selectedBookmarksToOpen = bookmarks.filter(
-      (bookmark, index) => selected[index] && !bookmark.isDir
-    );
+    const rightClicked = findBookmarkById(bookmarks, id);
     const bookmarksToOpen =
-      selectedBookmarksToOpen.length > 1
-        ? selectedBookmarksToOpen
-        : [findBookmarkById(bookmarks, id)];
+      countTruthy(selected) > 1 || !rightClicked
+        ? getFilteredContextBookmarks(bookmarks, searchText).filter(
+            (_bookmark, index) => selected[index]
+          )
+        : [rightClicked];
 
     bookmarksToOpen.forEach((bookmark) => {
-      if (bookmark && !bookmark.isDir) {
+      if (!bookmark.isDir) {
         tabs.open(bookmark.url);
       }
     });

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksPanel.tsx
@@ -17,6 +17,7 @@ import Panel from '@popup/components/Panel';
 
 import useBookmarkRouteStore from '../store/useBookmarkRouteStore';
 import useBookmarkStore from '../store/useBookmarkStore';
+import { findBookmarkById } from '../utils/bookmark';
 import BookmarkAddEditDialog from './BookmarkAddEditDialog';
 import BookmarkContextMenu from './BookmarkContextMenu';
 import BookmarksHeader from './BookmarksHeader';
@@ -62,11 +63,24 @@ function BookmarksPanel({ folderId, operation, bmUrl }: BMPanelQueryParams) {
     [virtualizer]
   );
 
-  const handleOpenSelectedBookmarks = () => {
+  /**
+   * The right-clicked bookmark wins unless several are selected: reading the
+   * store selection for a single open made the click a silent no-op whenever
+   * anything cleared the selection first.
+   */
+  const handleOpenBookmarks = (id: string) => {
     const { contextBookmarks: bookmarks, selectedBookmarks: selected } =
       useBookmarkStore.getState();
-    bookmarks.forEach((bookmark, index) => {
-      if (selected[index] && !bookmark.isDir) {
+    const selectedBookmarksToOpen = bookmarks.filter(
+      (bookmark, index) => selected[index] && !bookmark.isDir
+    );
+    const bookmarksToOpen =
+      selectedBookmarksToOpen.length > 1
+        ? selectedBookmarksToOpen
+        : [findBookmarkById(bookmarks, id)];
+
+    bookmarksToOpen.forEach((bookmark) => {
+      if (bookmark && !bookmark.isDir) {
         tabs.open(bookmark.url);
       }
     });
@@ -105,9 +119,7 @@ function BookmarksPanel({ folderId, operation, bmUrl }: BMPanelQueryParams) {
         curFolderId={folderId}
         handleScroll={handleScroll}
       />
-      <BookmarkContextMenu
-        handleOpenSelectedBookmarks={handleOpenSelectedBookmarks}
-      >
+      <BookmarkContextMenu handleOpenBookmarks={handleOpenBookmarks}>
         <ScrollArea
           viewportRef={scrollAreaRef}
           className="w-full"

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksPanel.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarksPanel.tsx
@@ -64,29 +64,25 @@ function BookmarksPanel({ folderId, operation, bmUrl }: BMPanelQueryParams) {
     [virtualizer]
   );
 
-  /**
-   * The right-clicked bookmark wins over the selection: reading the store
-   * selection for a single open made the click a silent no-op whenever anything
-   * cleared it first. The multi-open branch is gated on the same count the
-   * `Open all (N)` label uses, so the menu can never promise more than it opens,
-   * and it indexes the filtered list the selection positions actually came from.
-   */
+  // Right-clicked row wins over the selection, which anything can clear mid-gesture
   const handleOpenBookmarks = (id: string) => {
     const { contextBookmarks: bookmarks, selectedBookmarks: selected } =
       useBookmarkStore.getState();
     const rightClicked = findBookmarkById(bookmarks, id);
-    const bookmarksToOpen =
-      countTruthy(selected) > 1 || !rightClicked
-        ? getFilteredContextBookmarks(bookmarks, searchText).filter(
-            (_bookmark, index) => selected[index]
-          )
-        : [rightClicked];
 
-    bookmarksToOpen.forEach((bookmark) => {
-      if (!bookmark.isDir) {
-        tabs.open(bookmark.url);
+    if (rightClicked && countTruthy(selected) < 2) {
+      tabs.open(rightClicked.url);
+      return;
+    }
+
+    // Selection positions index the filtered rows, not the whole folder
+    getFilteredContextBookmarks(bookmarks, searchText).forEach(
+      (bookmark, index) => {
+        if (selected[index] && !bookmark.isDir) {
+          tabs.open(bookmark.url);
+        }
       }
-    });
+    );
   };
 
   // Reset scroll on folder change

--- a/apps/extension/src/entrypoints/popup/provider/DynamicProvider.tsx
+++ b/apps/extension/src/entrypoints/popup/provider/DynamicProvider.tsx
@@ -1,5 +1,6 @@
 import { DynamicContext } from '@bypass/shared';
 import { type PropsWithChildren, useMemo } from 'react';
+import { toast } from 'sonner';
 import { useLocation } from 'wouter';
 
 import { getFaviconUrl } from '@/constants/favicon';
@@ -28,7 +29,10 @@ function DynamicProvider({ children }: PropsWithChildren) {
         // Idempotent, so loop callers can call this per url
         open: (url: string) => {
           startHistoryMonitor();
-          browser.tabs.create({ url, active: false });
+          browser.tabs.create({ url, active: false }).catch((error) => {
+            console.error(error);
+            toast.error('Could not open the link in a new tab');
+          });
         },
       },
       favicon: { getUrl: getFaviconUrl },

--- a/apps/extension/tests/specs/bookmarks.spec.ts
+++ b/apps/extension/tests/specs/bookmarks.spec.ts
@@ -177,26 +177,8 @@ test.describe('Bookmarks Panel', () => {
       const panel = new BookmarksPanel(bookmarksPage);
       await panel.ensureAtRoot();
 
-      /**
-       * Selecting stays inside the action: Open reads the store selection, and a
-       * bookmark reload wipes it, so a retry has to re-select before reopening.
-       */
-      const openFromContextMenu = async () => {
-        await bookmarksPage.keyboard.press('Escape');
-        await panel.selectBookmark(TEST_BOOKMARKS.REACT_DOCS);
-        await panel.openBookmarkContextMenu(TEST_BOOKMARKS.REACT_DOCS);
-        await expect(panel.getContextMenuItem('open')).toBeEnabled();
-        // Re-checked with the menu up: a reload landing here empties the
-        // selection, which turns Open into a no-op with nothing to observe
-        await expect(
-          panel.getBookmarkRow(TEST_BOOKMARKS.REACT_DOCS)
-        ).toHaveAttribute('data-is-selected', 'true');
-        await panel.clickContextMenuItem('open');
-      };
-
-      const contextMenuPage = await openNewPageFromAction(
-        context,
-        openFromContextMenu
+      const contextMenuPage = await openNewPageFromAction(context, () =>
+        panel.openBookmarkContextMenuItem(TEST_BOOKMARKS.REACT_DOCS, 'open')
       );
       await contextMenuPage.close();
     });

--- a/apps/extension/tests/utils/bookmarks-panel.ts
+++ b/apps/extension/tests/utils/bookmarks-panel.ts
@@ -247,10 +247,6 @@ export class BookmarksPanel {
     return this.page.getByRole('menu');
   }
 
-  getContextMenuItem(itemId: string) {
-    return this.page.getByTestId(`context-menu-item-${itemId}`);
-  }
-
   // ============ Composite Operations ============
 
   async closeDialog() {

--- a/apps/web/src/app/utils/index.ts
+++ b/apps/web/src/app/utils/index.ts
@@ -1,4 +1,8 @@
 export const openNewTab = (url: string) => {
   const newWindow = window.open(url, '_blank', 'noopener,noreferrer');
-  newWindow?.focus();
+  if (!newWindow) {
+    console.error(`Could not open a new tab for ${url}`);
+    return;
+  }
+  newWindow.focus();
 };

--- a/apps/web/src/app/utils/index.ts
+++ b/apps/web/src/app/utils/index.ts
@@ -1,8 +1,4 @@
 export const openNewTab = (url: string) => {
-  const newWindow = window.open(url, '_blank', 'noopener,noreferrer');
-  if (!newWindow) {
-    console.error(`Could not open a new tab for ${url}`);
-    return;
-  }
-  newWindow.focus();
+  // `noopener` makes window.open return null by spec, so there is no handle to focus
+  window.open(url, '_blank', 'noopener,noreferrer');
 };

--- a/packages/shared/src/utils/test-helpers.ts
+++ b/packages/shared/src/utils/test-helpers.ts
@@ -3,8 +3,10 @@ import fs from 'node:fs';
 import {
   expect,
   type BrowserContext,
+  type ConsoleMessage,
   type Locator,
   type Page,
+  type WebError,
 } from '@playwright/test';
 
 import { TEST_TIMEOUTS } from '../constants/e2e-tests';
@@ -186,6 +188,20 @@ export const openNewPageFromAction = async (
   const openedPages: Page[] = [];
   const collectPage = (page: Page) => openedPages.push(page);
   context.on('page', collectPage);
+  /**
+   * A refused open leaves no trace but what the page logged, and without it a
+   * flake here is indistinguishable from a gesture that never landed.
+   */
+  const pageLogs: string[] = [];
+  const collectConsole = (message: ConsoleMessage) => {
+    if (message.type() === 'error') {
+      pageLogs.push(`console.error: ${message.text()}`);
+    }
+  };
+  const collectError = (error: WebError) =>
+    pageLogs.push(`pageerror: ${error.error().message}`);
+  context.on('console', collectConsole);
+  context.on('weberror', collectError);
   let handedOver: Page | undefined;
 
   try {
@@ -194,7 +210,7 @@ export const openNewPageFromAction = async (
       await expect
         .poll(() => openedPages.length, {
           timeout: TEST_TIMEOUTS.PAGE_OPEN_ATTEMPT,
-          message: 'Expected action to open a new page',
+          message: `Expected action to open a new page${pageLogs.length ? `\n${pageLogs.join('\n')}` : ''}`,
         })
         .toBeGreaterThan(0);
     }).toPass({ timeout, intervals: [100] });
@@ -206,6 +222,8 @@ export const openNewPageFromAction = async (
     return newPage;
   } finally {
     context.off('page', collectPage);
+    context.off('console', collectConsole);
+    context.off('weberror', collectError);
     /**
      * Everything the action opened is closed unless it is being handed to the
      * caller: a retry duplicates the tab, and a failing attempt would otherwise

--- a/packages/shared/src/utils/test-helpers.ts
+++ b/packages/shared/src/utils/test-helpers.ts
@@ -205,15 +205,29 @@ export const openNewPageFromAction = async (
   let handedOver: Page | undefined;
 
   try {
-    await expect(async () => {
-      await action();
-      await expect
-        .poll(() => openedPages.length, {
-          timeout: TEST_TIMEOUTS.PAGE_OPEN_ATTEMPT,
-          message: `Expected action to open a new page${pageLogs.length ? `\n${pageLogs.join('\n')}` : ''}`,
-        })
-        .toBeGreaterThan(0);
-    }).toPass({ timeout, intervals: [100] });
+    try {
+      await expect(async () => {
+        await action();
+        await expect
+          .poll(() => openedPages.length, {
+            timeout: TEST_TIMEOUTS.PAGE_OPEN_ATTEMPT,
+            message: 'Expected action to open a new page',
+          })
+          .toBeGreaterThan(0);
+      }).toPass({ timeout, intervals: [100] });
+    } catch (error) {
+      /**
+       * Appended here rather than in the poll's message, which is templated
+       * before the poll runs and so misses everything logged while it waited.
+       */
+      if (pageLogs.length) {
+        throw new Error(
+          `${(error as Error).message}\n\nPage logs:\n${pageLogs.join('\n')}`,
+          { cause: error }
+        );
+      }
+      throw error;
+    }
 
     const [newPage] = openedPages;
     await expect.poll(() => newPage.url(), { timeout }).not.toBe('about:blank');


### PR DESCRIPTION
> **Status: does NOT fix the flake.** A dispatched Playwright run on this branch ([32272608456](https://github.com/amitsingh-007/bypass-links/actions/runs/32272608456)) reproduced `should open bookmark via context menu` exactly as before. What this PR does contain is three real bugs found along the way, plus the diagnostics that narrowed the flake considerably. Retitled and rescoped accordingly — see [Where the flake stands](#where-the-flake-stands).

## Bugs fixed

- **`BookmarksPanel.tsx`** — a single *Open in new tab* now resolves the right-clicked bookmark via `findBookmarkById` instead of the store selection, so the action no longer depends on selection state surviving the gesture. *Open all (N)* keeps the selection path, gated on the same `countTruthy(selectedBookmarks)` the label uses, so the menu can no longer promise two and open none (a folder + one link previously did exactly that).
- **`BookmarksPanel.tsx`** — the multi-open path indexes `getFilteredContextBookmarks(…)`, the list selection positions actually come from. Previously a search plus two selections opened whichever bookmarks sat at those positions in the *unfiltered* folder.
- **`ContextMenu.tsx`** — `handleContextMenu` resolves `closest('[data-context-id]')` rather than reading the event target directly. A right-click on a row's favicon or person avatars resolved to an empty id; Open survived it via the selection fallback, but `edit`/`delete` go through `getBookmark(id)` and **throw** `Bookmark not found for id:` on the empty string.
- **`apps/web/.../utils/index.ts`** — drops a null check and a dead `?.focus()`. `noopener` makes `window.open` return null *by specification*, so both were meaningless.

## Diagnostics

`openNewPageFromAction` now captures context `console`/`weberror` output and appends it to the failure when the retry loop gives up. It earned itself back immediately by catching the bogus `window.open` null check logging on a *passing* web test.

## Where the flake stands

Ruled out by the dispatched run, on top of the original trace analysis:

| Hypothesis | Status |
| --- | --- |
| Store selection empty at click time | **Eliminated** — the single-open path no longer reads the selection at all, and it still failed identically |
| `browser.tabs.create` rejecting | **Eliminated** — zero console errors and zero page errors captured |
| Gesture not landing | **Eliminated** — trace shows the click on the item, hit-target verified, menu closing afterwards |
| Base UI's 1px "opening gesture" guard in `useMenuItemCommonProps` | **Eliminated** — right-click at (640, 164.5), item click at (480, 186) |

What remains is that the menu item's React `onClick` does not run, on the first item only, in CI only, ~1 run in 5 — while `edit`/`cut`/`delete` on the same menu never flake. Pinning it needs a `console.error` breadcrumb at the handler entry and before `tabs.create`, then dispatched runs until it reproduces; the helper above will surface them in the failure message.

## Verification

`pnpm lint`, `pnpm format:check`, `pnpm typecheck:all` clean. Every context-menu-touching spec (`bookmarks`, `bookmark-editing`, `persons`, `persons-interactions`, web `bookmarks`) passes: 56 passed, 2 flaky (the known persons image-upload timeouts), 0 failed. The dispatched CI run is 117 passed with the one flaky annotation this PR does not fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)