### PR TITLE
fix: folder dropdown in the add/edit bookmark dialog opens on top of its trigger

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-save-exact=true

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bypass/extension",
-  "version": "25.12.0",
+  "version": "25.13.0",
   "private": true,
   "description": "Bypass links from various sites to required links, with added functionality of Bookmarks Manager, Tagging Panel.",
   "type": "module",

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarkAddEditDialog.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarkAddEditDialog.tsx
@@ -281,11 +281,7 @@ function BookmarkAddEditDialog({ curFolderId, handleScroll }: Props) {
                         {selectedFolder?.label ?? 'Select folder'}
                       </SelectValue>
                     </SelectTrigger>
-                    <SelectContent
-                      alignItemWithTrigger={false}
-                      align="start"
-                      data-testid="bookmark-folder-options"
-                    >
+                    <SelectContent alignItemWithTrigger={false}>
                       {folderOptions.map((option) => (
                         <SelectItem key={option.value} value={option.value}>
                           {option.label}

--- a/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarkAddEditDialog.tsx
+++ b/apps/extension/src/entrypoints/popup/panels/BookmarksPanel/components/BookmarkAddEditDialog.tsx
@@ -273,12 +273,19 @@ function BookmarkAddEditDialog({ curFolderId, handleScroll }: Props) {
                     value={field.state.value}
                     onValueChange={(value) => field.handleChange(value ?? '')}
                   >
-                    <SelectTrigger className="w-full">
+                    <SelectTrigger
+                      className="w-full"
+                      data-testid="bookmark-folder-select"
+                    >
                       <SelectValue placeholder="Select folder">
                         {selectedFolder?.label ?? 'Select folder'}
                       </SelectValue>
                     </SelectTrigger>
-                    <SelectContent>
+                    <SelectContent
+                      alignItemWithTrigger={false}
+                      align="start"
+                      data-testid="bookmark-folder-options"
+                    >
                       {folderOptions.map((option) => (
                         <SelectItem key={option.value} value={option.value}>
                           {option.label}

--- a/apps/extension/tests/specs/bookmark-editing.spec.ts
+++ b/apps/extension/tests/specs/bookmark-editing.spec.ts
@@ -1,4 +1,4 @@
-import { TEST_BOOKMARKS } from '@bypass/shared/tests';
+import { TEST_BOOKMARKS, TEST_FOLDERS } from '@bypass/shared/tests';
 
 import { expect, bookmarkTest as test } from '../fixtures/panel-fixture';
 import { BookmarksPanel } from '../utils/bookmarks-panel';
@@ -83,6 +83,47 @@ test.describe('Bookmark reordering', () => {
     await panel.moveBookmarkOnto(FIRST, SECOND);
 
     await expect.poll(() => panel.getBookmarkTitles()).toEqual([SECOND, FIRST]);
+  });
+});
+
+test.describe('Folder select', () => {
+  /**
+   * Base UI's `alignItemWithTrigger` overlays the popup on the trigger so the
+   * selected row lands exactly where the trigger was. The popup shares the
+   * dialog's `bg-popover`, so that reads as "the dropdown never opened" and it
+   * buries the fields above. The popup has to sit clear of the trigger.
+   */
+  test('opens the folder dropdown clear of the trigger', async ({
+    bookmarksPage,
+  }) => {
+    const panel = new BookmarksPanel(bookmarksPage);
+    await openRootListing(panel);
+
+    const dialog = await panel.openFolderSelect(FIRST);
+
+    // Options are portaled out of the dialog, so they are queried page-level
+    await expect(
+      bookmarksPage.getByRole('option', { name: TEST_FOLDERS.MAIN })
+    ).toBeVisible();
+
+    const trigger = await dialog
+      .getByTestId('bookmark-folder-select')
+      .boundingBox();
+    const popup = await bookmarksPage
+      .getByTestId('bookmark-folder-options')
+      .boundingBox();
+    if (!trigger || !popup) {
+      throw new Error('folder select trigger or dropdown is missing');
+    }
+
+    const overlaps =
+      popup.y < trigger.y + trigger.height &&
+      trigger.y < popup.y + popup.height;
+    expect(overlaps, 'the dropdown covers the trigger it opened from').toBe(
+      false
+    );
+
+    await bookmarksPage.keyboard.press('Escape');
   });
 });
 

--- a/apps/extension/tests/specs/bookmark-editing.spec.ts
+++ b/apps/extension/tests/specs/bookmark-editing.spec.ts
@@ -86,45 +86,40 @@ test.describe('Bookmark reordering', () => {
   });
 });
 
-test.describe('Folder select', () => {
-  /**
-   * Base UI's `alignItemWithTrigger` overlays the popup on the trigger so the
-   * selected row lands exactly where the trigger was. The popup shares the
-   * dialog's `bg-popover`, so that reads as "the dropdown never opened" and it
-   * buries the fields above. The popup has to sit clear of the trigger.
-   */
-  test('opens the folder dropdown clear of the trigger', async ({
-    bookmarksPage,
-  }) => {
-    const panel = new BookmarksPanel(bookmarksPage);
-    await openRootListing(panel);
+/** Overlaying the trigger reads as "the dropdown never opened": same bg-popover. */
+test('opens the folder dropdown clear of the trigger', async ({
+  bookmarksPage,
+}) => {
+  const panel = new BookmarksPanel(bookmarksPage);
+  await openRootListing(panel);
 
-    const dialog = await panel.openFolderSelect(FIRST);
+  const dialog = await panel.openEditBookmarkDialog(FIRST);
+  const trigger = dialog.getByTestId('bookmark-folder-select');
+  await trigger.click();
 
-    // Options are portaled out of the dialog, so they are queried page-level
-    await expect(
-      bookmarksPage.getByRole('option', { name: TEST_FOLDERS.MAIN })
-    ).toBeVisible();
+  const dropdown = bookmarksPage.getByRole('listbox');
+  await expect(
+    dropdown.getByRole('option', { name: TEST_FOLDERS.MAIN })
+  ).toBeVisible();
 
-    const trigger = await dialog
-      .getByTestId('bookmark-folder-select')
-      .boundingBox();
-    const popup = await bookmarksPage
-      .getByTestId('bookmark-folder-options')
-      .boundingBox();
-    if (!trigger || !popup) {
-      throw new Error('folder select trigger or dropdown is missing');
-    }
-
-    const overlaps =
-      popup.y < trigger.y + trigger.height &&
-      trigger.y < popup.y + popup.height;
-    expect(overlaps, 'the dropdown covers the trigger it opened from').toBe(
-      false
-    );
-
-    await bookmarksPage.keyboard.press('Escape');
-  });
+  // Polled, not read once: the entry animation slides the popup 8px past its
+  // settled position, which is more than its clearance over the trigger
+  await expect
+    .poll(
+      async () => {
+        const triggerBox = await trigger.boundingBox();
+        const dropdownBox = await dropdown.boundingBox();
+        if (!triggerBox || !dropdownBox) {
+          return null;
+        }
+        return (
+          dropdownBox.y < triggerBox.y + triggerBox.height &&
+          triggerBox.y < dropdownBox.y + dropdownBox.height
+        );
+      },
+      { message: 'the dropdown covers the trigger it opened from' }
+    )
+    .toBe(false);
 });
 
 test.describe('Bookmark form validation', () => {

--- a/apps/extension/tests/utils/bookmarks-panel.ts
+++ b/apps/extension/tests/utils/bookmarks-panel.ts
@@ -154,6 +154,13 @@ export class BookmarksPanel {
     return this.page.getByTitle('Edit Bookmark');
   }
 
+  async openFolderSelect(bookmarkTitle: string) {
+    const dialog = await this.openEditBookmarkDialog(bookmarkTitle);
+    await expect(dialog).toBeVisible();
+    await dialog.getByTestId('bookmark-folder-select').click();
+    return dialog;
+  }
+
   async openPersonSelect(bookmarkTitle: string) {
     const dialog = await this.openEditBookmarkDialog(bookmarkTitle);
     await expect(dialog).toBeVisible();

--- a/apps/extension/tests/utils/bookmarks-panel.ts
+++ b/apps/extension/tests/utils/bookmarks-panel.ts
@@ -154,13 +154,6 @@ export class BookmarksPanel {
     return this.page.getByTitle('Edit Bookmark');
   }
 
-  async openFolderSelect(bookmarkTitle: string) {
-    const dialog = await this.openEditBookmarkDialog(bookmarkTitle);
-    await expect(dialog).toBeVisible();
-    await dialog.getByTestId('bookmark-folder-select').click();
-    return dialog;
-  }
-
   async openPersonSelect(bookmarkTitle: string) {
     const dialog = await this.openEditBookmarkDialog(bookmarkTitle);
     await expect(dialog).toBeVisible();

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -86,3 +86,5 @@ catalogMode: strict
 cleanupUnusedCatalogs: true
 
 failIfNoMatch: true
+
+saveExact: true


### PR DESCRIPTION
## The bug

Clicking the **Folder** select in the add/edit bookmark dialog looked like it did nothing.

It was actually opening every time. Base UI's `Select` defaults to `alignItemWithTrigger`, which overlays the popup on the trigger and scrolls it so the *selected* row sits exactly where the trigger was. Combined with the popup and the dialog both using `bg-popover` and only a `ring-1 ring-foreground/10` edge, the click produced no visible change at the trigger — while the option list quietly rendered over the Title and URL fields above it.

## The fix

One prop:

```diff
-<SelectContent>
+<SelectContent alignItemWithTrigger={false}>
```

`packages/ui` is untouched — the default stays as shadcn ships it, and this dialog is its only `SelectContent` caller in the repo.

## Test

`bookmark-editing.spec.ts` gains a case asserting the dropdown's bounding box does not overlap the trigger's. It fails on the old positioning (`the dropdown covers the trigger it opened from`) and passes with the fix. One `data-testid` was added to the trigger, since `getByRole('combobox')` is ambiguous with the person combobox in the same dialog; the dropdown itself is reached by `getByRole('listbox')`.

The check polls rather than reading `boundingBox()` once. `SelectContent` animates in *only* when `alignItemWithTrigger` is off (`data-[align-trigger=true]:animate-none`), so the fix is what introduced the window: `slide-in-from-top-2` lifts the popup 8px while its settled clearance over the trigger is ~4px, and a single mid-animation read reports an overlap that isn't there. Thanks @cubic-dev-ai for catching that.

Verified both directions after the cuts: dropping the prop fails, restoring it passes 8/8 under `--repeat-each`.

Checks: `pnpm lint`, `pnpm format:check`, `pnpm typecheck:all` clean. E2E: `bookmark-editing`, `bookmarks`, `person-select`, `quick-bookmark-button` — 37 passed.

## Also in here

The first commit is unrelated local work that was sitting in the tree: `save-exact` moves from the single-setting `.npmrc` into `pnpm-workspace.yaml`, and the extension version bumps to 25.13.0. @pullfrog is right that a release-style bump riding along with a bug fix makes cherry-picking noisier — flagging it rather than silently splitting, since the bump was already staged locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

 

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: cut the folder select fix down..."](https://github.com/amitsingh-007/bypass-links/commit/faea1c1e3874466434270dae5c4d734beac55dd7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56015819)</sub>

<!-- /greptile_comment -->