### PR TITLE
ci: deploy Vercel with vercel-action API mode

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,12 +31,12 @@ jobs:
         if: ${{ !inputs.vercel_url }}
         uses: amondnet/vercel-action@v42
         id: vercel-action
+        env:
+          NPM_CONFIG_FORCE: 'true'
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID}}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID}}
-          experimental-api: true
-          root-directory: apps/web
           github-comment: false
 
       - name: Set preview URL

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -35,6 +35,8 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID}}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID}}
+          experimental-api: true
+          root-directory: apps/web
           github-comment: false
 
       - name: Set preview URL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID}}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID}}
+          experimental-api: true
+          root-directory: apps/web
           github-comment: false
 
       - name: Building Extension
@@ -142,7 +144,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID}}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID}}
-          vercel-args: '--prod'
+          experimental-api: true
+          target: production
+          root-directory: apps/web
 
       - name: Finish deployment
         uses: bobheadxi/deployments@v1.5.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,12 @@ jobs:
       - name: Deploy Preview (Vercel)
         uses: amondnet/vercel-action@v42
         id: vercel-action
+        env:
+          NPM_CONFIG_FORCE: 'true'
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID}}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID}}
-          experimental-api: true
-          root-directory: apps/web
           github-comment: false
 
       - name: Building Extension
@@ -139,14 +139,14 @@ jobs:
 
       - name: Deploy (Vercel)
         uses: amondnet/vercel-action@v42
+        env:
+          NPM_CONFIG_FORCE: 'true'
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID}}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID}}
-          experimental-api: true
-          target: production
-          root-directory: apps/web
+          vercel-args: '--prod'
 
       - name: Finish deployment
         uses: bobheadxi/deployments@v1.5.0

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -3,7 +3,7 @@
   "cleanUrls": true,
   "trailingSlash": false,
   "regions": ["bom1"],
-  "installCommand": "cd ../.. && pnpm install --prod=false",
+  "installCommand": "cd ../.. && pnpm install",
   "buildCommand": "cd ../.. && pnpm build --filter=@bypass/web",
   "ignoreCommand": "npx turbo-ignore"
 }

--- a/package.json
+++ b/package.json
@@ -44,5 +44,6 @@
       "version": "^24",
       "onFail": "error"
     }
-  }
+  },
+  "packageManager": "pnpm@12.1.0"
 }


### PR DESCRIPTION
Fixes the pnpm 12 release failure where `amondnet/vercel-action` deployed through `npx`, which npm rejects with `EBADDEVENGINES` because `devEngines.packageManager` requires pnpm.

- Switch preview and production deployment steps to the action’s API mode (`experimental-api: true`)
- Point API deployments at the `apps/web` project root
- Replace `vercel-args: --prod` with `target: production`

Keeps the existing preview, Playwright, production, release, and cache-purge sequence. No workflow shell deployment commands are added.







<!-- greptile_comment -->

 

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up scope.

No blocking failure remains.
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(build): update Vercel install for pn..."](https://github.com/amitsingh-007/bypass-links/commit/2631d98cfe19535cb16494bd55279e40c9b82295) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59473252)</sub>

<!-- /greptile_comment -->